### PR TITLE
 Deprecate use of KafkaConsumer#committed by locally cached committed offset

### DIFF
--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -1,6 +1,6 @@
 Dynamic Property Configuration
 =============================
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: centraldogma,processor
 
 == Property Supplier

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,6 +1,6 @@
 Getting Started Decaton
 =======================
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: common,client,processor,protobuf
 
 Let's start from the most basic usage of Decaton client/processor.

--- a/docs/key-blocking.adoc
+++ b/docs/key-blocking.adoc
@@ -1,5 +1,5 @@
 = Key Blocking
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -1,6 +1,6 @@
 Monitoring Decaton
 ==================
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 This document guides you how to monitor your Decaton processor applications.

--- a/docs/rate-limiting.adoc
+++ b/docs/rate-limiting.adoc
@@ -1,5 +1,5 @@
 = Rate Limiting
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/retry-queueing.adoc
+++ b/docs/retry-queueing.adoc
@@ -1,5 +1,5 @@
 = Retry Queuing
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/src/main/java/com/linecorp/decaton/DocumentChecker.java
+++ b/docs/src/main/java/com/linecorp/decaton/DocumentChecker.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import java.util.regex.Pattern;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.ast.DocumentHeader;
+import org.asciidoctor.jruby.internal.IOUtils;
 
 import lombok.Value;
 import lombok.experimental.Accessors;
@@ -154,8 +156,8 @@ public final class DocumentChecker {
     }
 
     private static Set<String> findUpdatedModules(Version baseVersion, String[] modules) throws IOException {
-        Process proc = Runtime.getRuntime().exec(
-                new String[] { "git", "diff", "--name-only", "tags/v" + baseVersion, "HEAD" });
+        String[] cmd = { "git", "diff", "--name-only", "tags/v" + baseVersion, "HEAD" };
+        Process proc = Runtime.getRuntime().exec(cmd);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
             Set<String> updatedMods = new HashSet<>();
             reader.lines().forEach(line -> {
@@ -176,6 +178,8 @@ public final class DocumentChecker {
             }
 
             if (proc.exitValue() != 0) {
+                System.err.printf("git command %s failed with output: %s\n",
+                                  Arrays.toString(cmd), IOUtils.readFull(proc.getErrorStream()));
                 throw new RuntimeException("git command failed");
             }
         }

--- a/docs/task-compaction.adoc
+++ b/docs/task-compaction.adoc
@@ -1,5 +1,5 @@
 = Task Compaction
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/why-decaton.adoc
+++ b/docs/why-decaton.adoc
@@ -1,6 +1,6 @@
 Why Decaton
 ===========
-:base_version: 0.0.33
+:base_version: 0.0.35-SNAPSHOT
 :modules: processor
 
 This document explains why we have decided to create a new consumer framework.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControl.java
@@ -71,7 +71,8 @@ public class OutOfOrderCommitControl {
         this.topicPartition = topicPartition;
         states = new ArrayDeque<>(capacity);
         this.capacity = capacity;
-        earliest = latest = highWatermark = 0;
+        earliest = latest = 0;
+        highWatermark = -1;
     }
 
     public TopicPartition topicPartition() {

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControlTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControlTest.java
@@ -63,12 +63,12 @@ public class OutOfOrderCommitControlTest {
         comp3.complete();
         partitionState.updateHighWatermark();
         assertEquals(4, partitionState.pendingOffsetsCount());
-        assertEquals(0, partitionState.commitReadyOffset());
+        assertEquals(-1, partitionState.commitReadyOffset());
 
         comp2.complete();
         partitionState.updateHighWatermark();
         assertEquals(4, partitionState.pendingOffsetsCount());
-        assertEquals(0, partitionState.commitReadyOffset());
+        assertEquals(-1, partitionState.commitReadyOffset());
 
         comp1.complete();
         partitionState.updateHighWatermark();
@@ -86,7 +86,7 @@ public class OutOfOrderCommitControlTest {
         DeferredCompletion comp1 = partitionState.reportFetchedOffset(1);
 
         comp1.complete();
-        assertEquals(0, partitionState.commitReadyOffset());
+        assertEquals(-1, partitionState.commitReadyOffset());
         comp1.complete(); // nothing happens
         partitionState.updateHighWatermark();
         assertEquals(1, partitionState.commitReadyOffset());
@@ -114,10 +114,10 @@ public class OutOfOrderCommitControlTest {
 
         comp2.complete(); // now committedOffsets contains 2
         partitionState.updateHighWatermark();
-        assertEquals(0, partitionState.commitReadyOffset());
+        assertEquals(-1, partitionState.commitReadyOffset());
         comp2.complete(); // commit again
         partitionState.updateHighWatermark();
-        assertEquals(0, partitionState.commitReadyOffset());
+        assertEquals(-1, partitionState.commitReadyOffset());
     }
 
     @Test

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionContextTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionContextTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.DeferredCompletion;
+import com.linecorp.decaton.processor.ProcessorProperties;
+
+public class PartitionContextTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private final PartitionScope scope = new PartitionScope(
+            new SubscriptionScope("subscription", "topic",
+                                  Optional.empty(), ProcessorProperties.builder().build()),
+            new TopicPartition("topic", 0));
+
+    @Mock
+    private Processors<?> processors;
+
+    private static final int MAX_PENDING_RECORDS = 100;
+
+    private PartitionContext context;
+
+    @Before
+    public void setUp() {
+        context = new PartitionContext(scope, processors, MAX_PENDING_RECORDS);
+    }
+
+    @Test
+    public void testOffsetWaitingCommit() {
+        assertFalse(context.offsetWaitingCommit().isPresent());
+
+        DeferredCompletion comp = context.registerOffset(100);
+        assertFalse(context.offsetWaitingCommit().isPresent());
+
+        comp.complete();
+        context.updateHighWatermark();
+        assertEquals(OptionalLong.of(100), context.offsetWaitingCommit());
+
+        context.updateCommittedOffset(100);
+        assertFalse(context.offsetWaitingCommit().isPresent());
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/SubPartitionerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/SubPartitionerTest.java
@@ -19,13 +19,13 @@ package com.linecorp.decaton.processor.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.kafka.common.utils.Utils;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.apache.kafka.common.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SubPartitionerTest {
     static final int DIST_KEYS_COUNT = 10000;
@@ -43,7 +43,7 @@ public class SubPartitionerTest {
     }
 
     private static double stddev(int[] counts) {
-        double avg = Arrays.stream(counts).sum() / counts.length;
+        double avg = (double) Arrays.stream(counts).sum() / counts.length;
         double variance = Arrays.stream(counts).asDoubleStream()
                                 .map(v -> Math.pow(avg - v, 2)).sum() / counts.length;
         return Math.sqrt(variance);


### PR DESCRIPTION
fixed #16 

By deprecating use of `KafkaConsumer#committed`, the issue is likely fixed but I guarded `offsetCommit` aginst `TimeoutException` as well to avoid future repeat of the same situation.

3rd commit contains completely unrelated change that I found when looking at some code.