### PR TITLE
Fix LoggingContext to not put null value into MDC

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/LoggingContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/LoggingContext.java
@@ -41,7 +41,7 @@ public class LoggingContext implements AutoCloseable {
 
     public LoggingContext(String subscriptionId, TaskRequest request, TaskMetadata metadata) {
         MDC.put(METADATA_KEY, metadata.toString());
-        MDC.put(TASK_KEY, request.key());
+        MDC.put(TASK_KEY, String.valueOf(request.key()));
         MDC.put(SUBSCRIPTION_ID_KEY, subscriptionId);
         MDC.put(OFFSET_KEY, String.valueOf(request.recordOffset()));
         MDC.put(TOPIC_KEY, request.topicPartition().topic());


### PR DESCRIPTION
Despite the slf4j's document states null value is allowed, it also says that it depends on underlying implementation.
<img width="666" alt="image" src="https://user-images.githubusercontent.com/2255161/77754804-62d49080-706f-11ea-9f16-988763947215.png">

In fact I found that log4j, one of major implementation doesn't supports it (logback does).
It should be better to avoid passing null values in any cases without expectation for the logger to be used.