### PR TITLE
Fix use-after-close bug in DynamicRateLimiter

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/DynamicProperty.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/DynamicProperty.java
@@ -74,7 +74,7 @@ public class DynamicProperty<T> extends AbstractProperty<T> {
         validate(value);
 
         this.value = value;
-        logger.debug("Property {} has been updated ({} => {})", name(), currentValue, value);
+        logger.info("Property {} has been updated ({} => {})", name(), currentValue, value);
 
         notifyListeners(currentValue, value);
         return currentValue;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
@@ -130,9 +130,9 @@ class DynamicRateLimiter implements RateLimiter {
         try {
             // In contrast to prop listener, it is okay to close limiter here w/o write lock because that means
             // subscription is being shutdown so no new/on-going acquire() needs to success.
-            terminated = true;
             current.limiter.close();
         } finally {
+            terminated = true;
             current.lock.readLock().unlock();
         }
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
@@ -27,11 +27,11 @@ class DynamicRateLimiter implements RateLimiter {
     private volatile RateLimiter current;
 
     DynamicRateLimiter(Property<Long> rateProperty) {
-        current = RateLimiter.create(RateLimiter.UNLIMITED);
+        current = createLimiter(RateLimiter.UNLIMITED);
 
         rateProperty.listen((oldValue, newValue) -> {
             RateLimiter oldLimiter = current;
-            current = RateLimiter.create(newValue);
+            current = createLimiter(newValue);
 
             try {
                 oldLimiter.close();
@@ -39,6 +39,11 @@ class DynamicRateLimiter implements RateLimiter {
                 logger.warn("Failed to close rate limiter: {}", oldLimiter, e);
             }
         });
+    }
+
+    // visible for testing
+    RateLimiter createLimiter(long permitsPerSecond) {
+        return RateLimiter.create(permitsPerSecond);
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
@@ -101,6 +101,7 @@ class DynamicRateLimiter implements RateLimiter {
                 // In case of 1, we can use a grabbed `latest` limiter but it is preferred to retry to grab
                 // a new one so the prop listener thread doesn't have to wait extra long until this thread
                 // release the lock.
+                latest.lock.readLock().unlock();
                 continue;
             }
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiterTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.Property;
+
+public class DynamicRateLimiterTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private Property<Long> prop;
+
+    private BiConsumer<Long, Long> listener;
+
+    @Before
+    public void setUp() {
+        doAnswer(invocation -> listener = invocation.getArgument(0)).when(prop).listen(any());
+    }
+
+    @Test(timeout = 5000)
+    public void testDynamicSwitchLimiter() throws InterruptedException {
+        RateLimiter oldLimiter = spy(RateLimiter.create(10));
+
+        AtomicBoolean firstCall = new AtomicBoolean(true);
+        CountDownLatch readOld = new CountDownLatch(1);
+        CountDownLatch recreate = new CountDownLatch(1);
+        DynamicRateLimiter dyn = new DynamicRateLimiter(prop) {
+            @Override
+            RateLimiter createLimiter(long permitsPerSecond) {
+                if (firstCall.getAndSet(false)) {
+                    return oldLimiter;
+                } else {
+                    recreate.countDown();
+                    try {
+                        readOld.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return super.createLimiter(permitsPerSecond);
+                }
+            }
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+
+        CountDownLatch limiterClosed = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            readOld.countDown();
+            limiterClosed.await();
+            return invocation.callRealMethod();
+        }).when(oldLimiter).acquire(anyInt()); // Don't switch to acquire() which is defined as default interface method
+
+        // 1. Call prop listener so it reads the current limiter and stops there
+        executor.execute(() -> {
+            listener.accept(null, 100L);
+            limiterClosed.countDown();
+        });
+        recreate.await();
+
+        // 2. Attempt to acquire so it also reads the current limiter and stops at entry
+        // of acquire().
+        // 3. By below completing readOld latch, the listener becomes runnable again, close old limiter
+        // 4. At the end of listener it completes limiterClosed latch so the below finally reaches the actual
+        // limiter's acquire() and returns.
+        long got = dyn.acquire();
+
+        // We're actually checking that it returns w/o an exception
+        assertEquals(0, got);
+    }
+}


### PR DESCRIPTION
## Explanation of bug

`DynamicRateLimiter` was using volatile variable to hold the currently active `RateLimiter` and replacing it with new one with new limit when it gets notified for the property update.
This was supposed to work well because users (calls `#acquire()`) might keep using old value read from `volatile current` which might have already rewritten by property listener.
However since property listener not just replaces reference but closes the limiter, this can cause race between property listener and hence user access already closed limiter consequently.

This could be reproduced by the unit test I added at c712cd6.

## Solution

The resulting solution became bit complex than I initially thought.
The patched version of `DynamicRateLimiter` makes use of both `volatile` var and RW lock to protect limiters against close while its being used.
In this solution, 
* readers throughput won't be affected because all they require is read lock which isn't exclusive with others. even when prop listener is updating the `current` limiter, it won't be block and can grab an active limiter just after 1 retry.
* writer can replace active limiter w/o lock. It has to wait on old limiter until all its users disappears to close the old limiter, but the time should be less and definite because all new entry of acquire() are routed to the new limiter.
See source comment for the detail.

Besides that, I have considered below (probably simpler) solutions but rejected them by individual reasons.

###  Depecate `RateLimiter#close`  with `RateLimiter#shutdown` and make it call optional
The idea of this solution is, by making RateLimiter's shutdown function call to be optional, when it got switched by property listener the user threads which grabbed the old value from `current` can just keep using the old one. This should be fine because currently all `RateLimiter` implementations implements `#close` just for immediately terminating all waiters on it.
However I turned out that by leaving (forgetting) the old `RateLimiter` in prop listener, it would causes extra long shutdown time of subscription by following scenario:
1.  thread 1..N grabs old limiter
2. prop listener replaces `current` with new one
3. subscription.close()
4. only the current limiter closed (so its waiters abort immediately)

### RW lock at DynamicRateLimiter
We might introduce RW lock at DynamicRateLimiter and acquire read for `#acquire()` calls while holding write for replacing `current` and close it.
This guarantees all users to grab a RateLimiter that is not already/going to be closed by prop listener.
However, the biggest concern is unexpected long lock either at users or at prop listener.

* If we make the lock's fair-policy "unfair", then while prop listener is awaiting on write lock, continuous calls of `acquire()` from users threads keeps interrupting and prevents prop listener to hold write lock indefinitely.
* If we make the lock's fair-policy "fair", then the above problem disappears, but instead some user threads will wait certainly and unnecessarily long while the write lock is waiting for other readers to release. In this case throughput might drops temporarily.