### PR TITLE
Isolate exceptions threw from decaton's internal with those from user-supplied code

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
@@ -18,7 +18,6 @@ package com.linecorp.decaton.processor;
 
 import static org.junit.Assert.assertEquals;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,7 +30,6 @@ import org.junit.Test;
 
 import com.linecorp.decaton.client.DecatonClient;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
-import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 import com.linecorp.decaton.protocol.Sample.HelloTask;
 import com.linecorp.decaton.testing.KafkaClusterRule;
@@ -42,18 +40,15 @@ public class RateLimiterTest {
     public static KafkaClusterRule rule = new KafkaClusterRule();
 
     private String topicName;
-    private String retryTopicName;
 
     @Before
     public void setUp() {
         topicName = rule.admin().createRandomTopic(3, 3);
-        retryTopicName = topicName + "-retry";
-        rule.admin().createTopic(retryTopicName, 3, 3);
     }
 
     @After
     public void tearDown() {
-        rule.admin().deleteTopics(topicName, retryTopicName);
+        rule.admin().deleteTopics(topicName);
     }
 
     @Test(timeout = 30000)
@@ -76,7 +71,7 @@ public class RateLimiterTest {
                 rule.bootstrapServers(),
                 ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
                                  .thenProcess(processor),
-                RetryConfig.withBackoff(Duration.ofMillis(10)),
+                null,
                 StaticPropertySupplier.of(rateProp));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 

--- a/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
@@ -37,7 +37,7 @@ import com.linecorp.decaton.protocol.Sample.HelloTask;
 import com.linecorp.decaton.testing.KafkaClusterRule;
 import com.linecorp.decaton.testing.TestUtils;
 
-public class RetryQueueingTest {
+public class RateLimiterTest {
     @ClassRule
     public static KafkaClusterRule rule = new KafkaClusterRule();
 
@@ -57,12 +57,9 @@ public class RetryQueueingTest {
     }
 
     @Test(timeout = 30000)
-    public void testRetryQueuing() throws Exception {
+    public void testPropertyDynamicSwitch() throws Exception {
         Set<String> keys = new HashSet<>();
 
-        // scenario:
-        //   * produce 10000 tasks.
-        //   * all tasks will be retried once, and processed after retried
         for (int i = 0; i < 10000; i++) {
             keys.add("key" + i);
         }
@@ -70,25 +67,26 @@ public class RetryQueueingTest {
         CountDownLatch processLatch = new CountDownLatch(keys.size());
 
         DecatonProcessor<HelloTask> processor = (context, task) -> {
-            String key = context.key();
-
-            if (context.metadata().retryCount() == 0) {
-                context.retry();
-            } else {
-                processedKeys.add(key);
-                processLatch.countDown();
-            }
+            processedKeys.add(context.key());
+            processLatch.countDown();
         };
 
+        DynamicProperty<Long> rateProp = new DynamicProperty<>(ProcessorProperties.CONFIG_PROCESSING_RATE);
         try (ProcessorSubscription subscription = TestUtils.subscription(
                 rule.bootstrapServers(),
                 ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
                                  .thenProcess(processor),
                 RetryConfig.withBackoff(Duration.ofMillis(10)),
-                null);
+                StaticPropertySupplier.of(rateProp));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 
-            keys.forEach(key -> client.put(key, HelloTask.getDefaultInstance()));
+            int count = 0;
+            for (String key : keys) {
+                if (++count % 1000 == 0) {
+                    rateProp.set((long) count / 10);
+                }
+                client.put(key, HelloTask.getDefaultInstance());
+            }
             processLatch.await();
         }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/AveragingRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/AveragingRateLimiter.java
@@ -55,13 +55,12 @@ class AveragingRateLimiter implements RateLimiter {
 
     @Override
     public long acquire(int permits) throws InterruptedException {
-        if (latch.getCount() == 0) {
-            throw new IllegalStateException("This limiter is already closed");
-        }
-
         long microsToWait = reserve(permits);
         if (microsToWait > 0L) {
             latch.await(microsToWait, MICROSECONDS);
+        }
+        if (terminated()) {
+            return 0;
         }
         return microsToWait;
     }
@@ -100,6 +99,10 @@ class AveragingRateLimiter implements RateLimiter {
 
     private long nowMicros() {
         return NANOSECONDS.toMicros(currentTimeNanos.getAsLong() - startNanos);
+    }
+
+    private boolean terminated() {
+        return latch.getCount() == 0;
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
@@ -87,7 +87,7 @@ public class ExecutionScheduler implements AutoCloseable {
         if (terminated()) {
             return;
         }
-        metrics.tasksSchedulingDelay.record(Math.max(timeWaitedMs, 0), TimeUnit.MILLISECONDS);
+        metrics.tasksSchedulingDelay.record(Math.max(0, timeWaitedMs), TimeUnit.MILLISECONDS);
 
         long throttledMicros = rateLimiter.acquire();
         if (terminated()) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
@@ -66,7 +66,7 @@ public class ExecutionScheduler implements AutoCloseable {
                       timeToWaitMs, scope, metadata);
             sleep(timeToWaitMs);
         }
-        return timeToWaitMs;
+        return Math.max(0, timeToWaitMs);
     }
 
     /**
@@ -87,13 +87,13 @@ public class ExecutionScheduler implements AutoCloseable {
         if (terminated()) {
             return;
         }
-        metrics.tasksSchedulingDelay.record(Math.max(0, timeWaitedMs), TimeUnit.MILLISECONDS);
+        metrics.tasksSchedulingDelay.record(timeWaitedMs, TimeUnit.MILLISECONDS);
 
         long throttledMicros = rateLimiter.acquire();
         if (terminated()) {
             return;
         }
-        metrics.partitionThrottledTime.record(Math.max(0, throttledMicros), TimeUnit.MICROSECONDS);
+        metrics.partitionThrottledTime.record(throttledMicros, TimeUnit.MICROSECONDS);
     }
 
     private boolean terminated() {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/InfiniteBlocker.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/InfiniteBlocker.java
@@ -31,7 +31,14 @@ class InfiniteBlocker implements RateLimiter {
     public long acquire(int permits) throws InterruptedException {
         Timer timer = Utils.timer();
         latch.await();
+        if (terminated()) {
+            return 0;
+        }
         return timer.elapsedMicros();
+    }
+
+    private boolean terminated() {
+        return latch.getCount() == 0;
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
@@ -80,17 +80,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
         DeferredCompletion completion = request.completion();
         result.whenComplete((r, e) -> {
             if (e != null) {
-                if (e instanceof InterruptedException && true /* terminated */) {
-                    log.info("Processing task interrupted during shutdown");
-                    // Usually an InterruptedException is considered as just one case of failure,
-                    // but if it occurred while shutting down it's highly likely indicating processing
-                    // had been interrupted regardless to it's logic failure.
-                    // In case we must don't want to mark a processing offset as completed as it can be
-                    // expected to be processed successfully after an instance restarts.
-                    return;
-                } else {
-                    taskMetrics.tasksError.increment();
-                }
+                taskMetrics.tasksError.increment();
             }
             completion.complete();
         });

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
@@ -24,15 +24,39 @@ public interface RateLimiter extends AutoCloseable {
     long PAUSED = 0L;
     long MAX_RATE = SECONDS.toMicros(1L);
 
+    /**
+     * Acquire single execution from this limiter.
+     * Blocks until next execution is permitted and returns duration in microseconds that it has blocked.
+     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately
+     * with return value zero.
+     *
+     * @return duration in microseconds that the caller should wait before start execution.
+     * @throws InterruptedException when interrupted.
+     */
     default long acquire() throws InterruptedException {
         return acquire(1);
     }
 
+    /**
+     * Acquire given number of executions from this limiter for execution.
+     * Blocks until next execution is permitted and returns duration in microseconds that it has blocked.
+     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately
+     * with return value zero.
+     *
+     * @param permits number of executions.
+     * @return duration in microseconds that the caller should wait before start execution.
+     * @throws InterruptedException when interrupted.
+     */
     long acquire(int permits) throws InterruptedException;
 
     @Override
     default void close() throws Exception {}
 
+    /**
+     * Create a new {@link RateLimiter} with appropriate implementation based on given parameter.
+     * @param permitsPerSecond the number of executions to permit for every second.
+     * @return a {@link RateLimiter}.
+     */
     static RateLimiter create(long permitsPerSecond) {
         if (permitsPerSecond == PAUSED) {
             return new InfiniteBlocker();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
@@ -30,7 +30,7 @@ public interface RateLimiter extends AutoCloseable {
      * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately
      * with return value zero.
      *
-     * @return duration in microseconds that the caller should wait before start execution.
+     * @return duration in microseconds that it has blocked.
      * @throws InterruptedException when interrupted.
      */
     default long acquire() throws InterruptedException {
@@ -44,7 +44,7 @@ public interface RateLimiter extends AutoCloseable {
      * with return value zero.
      *
      * @param permits number of executions.
-     * @return duration in microseconds that the caller should wait before start execution.
+     * @return duration in microseconds that it has blocked.
      * @throws InterruptedException when interrupted.
      */
     long acquire(int permits) throws InterruptedException;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
@@ -33,9 +33,10 @@ class TaskRequest {
     private final DeferredCompletion completion;
     private final String key;
     private final String id;
+    @ToString.Exclude
     private byte[] rawRequestBytes;
 
-    public TaskRequest(TopicPartition topicPartition,
+    TaskRequest(TopicPartition topicPartition,
                        long recordOffset,
                        DeferredCompletion completion,
                        String key,

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
@@ -37,10 +37,10 @@ class TaskRequest {
     private byte[] rawRequestBytes;
 
     TaskRequest(TopicPartition topicPartition,
-                       long recordOffset,
-                       DeferredCompletion completion,
-                       String key,
-                       byte[] rawRequestBytes) {
+                long recordOffset,
+                DeferredCompletion completion,
+                String key,
+                byte[] rawRequestBytes) {
         this.topicPartition = topicPartition;
         this.recordOffset = recordOffset;
         this.completion = completion;

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionProcessorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -60,11 +61,10 @@ public class PartitionProcessorTest {
             if (count.incrementAndGet() == 3) {
                 throw new RuntimeException("exception");
             }
-            return null;
+            return mock(ProcessPipeline.class);
         }).when(processors).newPipeline(any(), any(), any());
 
         List<ProcessorUnit> units = new ArrayList<>();
-
         try {
             new PartitionProcessor(scope, processors) {
                 @Override
@@ -79,7 +79,9 @@ public class PartitionProcessorTest {
         }
 
         assertEquals(2, units.size());
-        verify(units.get(0), times(1)).close();
-        verify(units.get(1), times(1)).close();
+        verify(units.get(0), times(1)).initiateShutdown();
+        verify(units.get(1), times(1)).initiateShutdown();
+        verify(units.get(0), times(1)).awaitShutdown();
+        verify(units.get(1), times(1)).awaitShutdown();
     }
 }

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
@@ -210,10 +210,11 @@ public class ProcessPipelineTest {
             return null;
         }).when(schedulerMock).schedule(any());
 
+        TaskRequest request = taskRequest();
         ExecutorService executor = Executors.newFixedThreadPool(1);
         executor.execute(() -> {
             try {
-                pipeline.scheduleThenProcess(taskRequest());
+                pipeline.scheduleThenProcess(request);
             } catch (InterruptedException e) {
                 fail("Fail by exception: " + e);
             }
@@ -226,6 +227,7 @@ public class ProcessPipelineTest {
         // Checking it actually returns
         executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
         verify(pipeline, never()).process(any(), any());
+        verify(request.completion(), never()).complete();
     }
 }
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
@@ -153,20 +153,24 @@ public class ProcessPipelineTest {
         when(extractorMock.extract(any()))
                 .thenReturn(new DecatonTask<>(null, TASK, TASK.toByteArray()));
 
+        TaskRequest request = taskRequest();
         // Checking exception doesn't bubble up
-        pipeline.scheduleThenProcess(taskRequest());
+        pipeline.scheduleThenProcess(request);
         verify(schedulerMock, never()).schedule(any());
         verify(processorMock, never()).process(any(), any());
+        verify(request.completion(), times(1)).complete();
     }
 
     @Test
     public void testScheduleThenProcess_ExtractThrows() throws InterruptedException {
         when(extractorMock.extract(any())).thenThrow(new RuntimeException());
 
+        TaskRequest request = taskRequest();
         // Checking exception doesn't bubble up
-        pipeline.scheduleThenProcess(taskRequest());
+        pipeline.scheduleThenProcess(request);
         verify(schedulerMock, never()).schedule(any());
         verify(processorMock, never()).process(any(), any());
+        verify(request.completion(), times(1)).complete();
     }
 
     @Test

--- a/testing/src/main/resources/log4j.properties
+++ b/testing/src/main/resources/log4j.properties
@@ -21,4 +21,4 @@ log4j.appender.console.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.com.linecorp.decaton=INFO
+log4j.logger.com.linecorp.decaton=DEBUG


### PR DESCRIPTION
This patch changes responsibility of `ProcessorUnit` and `ProcessPipeline`.
As-is:
* `ProcessorUnit` => manage per-thread queue, manage offset completes(especially, when processor returns w/o deferring completion) and some duration/error metrics 
* `ProcessPipeline` => task extraction, execution scheduling and some duration/error measurements

To-be:
* `ProcessorUnit` will focus on manage per-thread queue
* `ProcessPipeline` takes all the others and property distinguish failures at task extraction, scheduling and processing


All locations that pauses/sleeps upon task to become ready for processing are now checking termination flag so that once the termination starts they stops and returns immediately.

Now exceptions from user-supplied `DecatonProcessor` and unexpected exceptions from decaton's code are strictly distinguished and the latter causes consumption to stop by not comiting offset (should we terminate subscription in such case?)

All RateLimiters are made to not throw exception for access after close but returns immediately instead (and decaton skips the task accordingly to the termination flag).

PartitionProcessor's dependency termination order has fixed to regard child components inter-dependencies.

After this patch the existing special treatment against `InterruptedException` during shutdown is dropped because we found that it is pointless in typical implementation o processors which wraps entire `process()` logic with wide try-catch and handling in user's code. The reason it was only for `InterruptedException` is that it is one of the most typically thrown exception during shutdown but it lacks strong rationale since any other exceptions may be thrown instead of it (especially or libraries that prefer unchecked exceptions).