### PR TITLE
 Fix DynamicRateLimiter to conservatively check and retry on unexpected limiter return

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/AveragingRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/AveragingRateLimiter.java
@@ -69,7 +69,8 @@ class AveragingRateLimiter implements RateLimiter {
         return timer.elapsedMicros();
     }
 
-    private synchronized long reserve(int permits) {
+    // visible for testing
+    synchronized long reserve(int permits) {
         if (permits <= 0) {
             throw new IllegalArgumentException("Requested permits (%s) must be positive");
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiter.java
@@ -46,11 +46,11 @@ class DynamicRateLimiter implements RateLimiter {
         RateLimiter limiter;
         long waitedTimeUs = 0;
         do {
-            // We conservatively check if acquire has returned because of it closed by switch
-            // rather than complete waiting for the expected time.
-            // This might apply extra waiting time for callers but still better than taking risk
-            // of making it like a starting pistol that effectively synchronizes all threads and resume them
-            // exactly at the same time.
+            // We conservatively check if acquire has returned because of it closed by switch rather than
+            // complete waiting for the expected time.
+            // This might apply extra waiting time for callers but still better than taking risk of making it
+            // to work like a starting pistol that synchronizes all threads and resume them exactly at the same
+            // time which might produces extreme bursting.
             limiter = current;
             waitedTimeUs += limiter.acquire(permits);
         } while (limiter != current);

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/InfiniteBlocker.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/InfiniteBlocker.java
@@ -29,11 +29,11 @@ class InfiniteBlocker implements RateLimiter {
 
     @Override
     public long acquire(int permits) throws InterruptedException {
-        Timer timer = Utils.timer();
-        latch.await();
         if (terminated()) {
             return 0;
         }
+        Timer timer = Utils.timer();
+        latch.await();
         return timer.elapsedMicros();
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/RateLimiter.java
@@ -27,8 +27,7 @@ public interface RateLimiter extends AutoCloseable {
     /**
      * Acquire single execution from this limiter.
      * Blocks until next execution is permitted and returns duration in microseconds that it has blocked.
-     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately
-     * with return value zero.
+     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately.
      *
      * @return duration in microseconds that it has blocked.
      * @throws InterruptedException when interrupted.
@@ -40,8 +39,7 @@ public interface RateLimiter extends AutoCloseable {
     /**
      * Acquire given number of executions from this limiter for execution.
      * Blocks until next execution is permitted and returns duration in microseconds that it has blocked.
-     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately
-     * with return value zero.
+     * For any access that is simultaneous or later of {@link #close()} call, this method returns immediately.
      *
      * @param permits number of executions.
      * @return duration in microseconds that it has blocked.

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiterTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/DynamicRateLimiterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.Property;
+
+public class DynamicRateLimiterTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    BiConsumer<Long, Long> listener;
+
+    @Mock
+    Property<Long> prop;
+
+    DynamicRateLimiter limiter;
+
+    @Before
+    public void setUp() {
+        doAnswer(invocation -> {
+            listener = invocation.getArgument(0);
+            return null;
+        }).when(prop).listen(any());
+        limiter = new DynamicRateLimiter(prop);
+    }
+
+    @Test(timeout = 10000)
+    public void testAcquireOnSwitch() throws InterruptedException {
+        // First setup limiter to pause all execution
+        listener.accept(null, RateLimiter.PAUSED);
+
+        final int THREADS = 10;
+        final long LIMIT = 4;
+
+        // All threads enters limiter for acquisition
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch atAcquire = new CountDownLatch(THREADS);
+        long[] execTimes = new long[THREADS];
+        for (int i = 0; i < THREADS; i++) {
+            int id = i;
+            executor.execute(() -> {
+                try {
+                    atAcquire.countDown();
+                    limiter.acquire();
+                    execTimes[id] = System.nanoTime();
+                } catch (InterruptedException e) {
+                    fail("got exception");
+                }
+            });
+        }
+        atAcquire.await();
+
+        // Dynamically update limit and unblock from pause
+        listener.accept(RateLimiter.PAUSED, LIMIT);
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+
+        // Sum up all intervals between executions to get approximate time needed in total to finish all N
+        // executions. It should be fine to take diff of all executions even for those in the same group (e.g,
+        // the first LIMIT threads) because their diff must be nearly equal to zero which is negligible.
+        Arrays.sort(execTimes);
+        long sum = 0;
+        for (int i = 1; i < execTimes.length; i++) {
+            sum += execTimes[i] - execTimes[i - 1];
+        }
+        // Say we have N threads, L limit of executions per second, only L threads are permitted to execute
+        // so in total at least N / L seconds will be needed to complete executing all threads.
+        long expectedTime = THREADS / LIMIT;
+        long sumSeconds = TimeUnit.NANOSECONDS.toSeconds(sum);
+        assertTrue(String.format("%d >= %d", sumSeconds, expectedTime), sumSeconds >= expectedTime);
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/RateLimiterTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/RateLimiterTest.java
@@ -95,37 +95,35 @@ public class RateLimiterTest {
         final long rate = 10L;
         final long permitIntervalNanos = SECONDS.toNanos(1L) / rate;
 
-        RateLimiter limiter = spy(new AveragingRateLimiter(rate, 1.0d, timeSupplier));
+        AveragingRateLimiter limiter = new AveragingRateLimiter(rate, 1.0d, timeSupplier);
 
         AtomicInteger callCount = new AtomicInteger();
-        LongUnaryOperator expectedThrottlingMicros = currentNanos -> {
-            return NANOSECONDS.toMicros(
-                    Math.max(permitIntervalNanos * callCount.getAndIncrement() - currentNanos, 0L));
-        };
+        LongUnaryOperator expectedThrottlingMicros = currentNanos -> NANOSECONDS.toMicros(
+                Math.max(permitIntervalNanos * callCount.getAndIncrement() - currentNanos, 0L));
 
         // 1st call
         doReturn(0L).when(timeSupplier).getAsLong();
-        assertEquals(expectedThrottlingMicros.applyAsLong(0L), limiter.acquire());
+        assertEquals(expectedThrottlingMicros.applyAsLong(0L), limiter.reserve(1));
 
         // 2nd call, 9ms after started
         long currentNanos = MILLISECONDS.toNanos(9L);
         doReturn(currentNanos).when(timeSupplier).getAsLong();
-        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.acquire());
+        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.reserve(1));
 
         // 3rd call, 140ms after started
         currentNanos = MILLISECONDS.toNanos(140L);
         doReturn(currentNanos).when(timeSupplier).getAsLong();
-        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.acquire());
+        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.reserve(1));
 
         // 4th call, 150ms after started
         currentNanos = MILLISECONDS.toNanos(150L);
         doReturn(currentNanos).when(timeSupplier).getAsLong();
-        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.acquire());
+        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.reserve(1));
 
         // 5th call, 500ms after started
         currentNanos = MILLISECONDS.toNanos(500L);
         doReturn(currentNanos).when(timeSupplier).getAsLong();
-        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.acquire());
+        assertEquals(expectedThrottlingMicros.applyAsLong(currentNanos), limiter.reserve(1));
     }
 
     @Test(timeout = 2000)


### PR DESCRIPTION
Follow-up for #32 

* Make `DynamicRateLimiter` to conservatively check if limiter has returned because of termination or switch
* Revert limiters to return even partially awaited time to record metrics correctly especially when it resumed from PAUSE state