### PR TITLE
(in progress) Fix duplication on shutdown fixes #23

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import java.util.stream.IntStream;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.decaton.protocol.Sample.HelloTask;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite.DecatonProducerRecord;
+
+public class CoreFunctionalityTest {
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+
+    @Test(timeout = 30000)
+    public void testProcessConcurrently() {
+        int numTasks = 10000;
+        ProcessorTestSuite<HelloTask> suite =
+                ProcessorTestSuite.builder(rule, HelloTask.parser())
+                                  .produce(numTasks, IntStream.range(0, numTasks).mapToObj(i -> {
+                                      String key = String.valueOf(i % 100);
+                                      return new DecatonProducerRecord<>(key, HelloTask.newBuilder().setAge(i).build());
+                                  }).iterator())
+                                  .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
+                                      // adding some delay to generate out-of-order completion
+                                      Thread.sleep(task.getAge() % 5);
+                                  }))
+                                  .propertySupplier(StaticPropertySupplier.of(
+                                          Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16),
+                                          Property.ofStatic(ProcessorProperties.CONFIG_GROUP_REBALANCE_TIMEOUT_MS, Long.MAX_VALUE)
+                                  ))
+                                  .build();
+        suite.run();
+    }
+}

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -84,8 +84,7 @@ public class RetryQueueingTest {
                 rule.bootstrapServers(),
                 ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
                                  .thenProcess(processor),
-                RetryConfig.withBackoff(Duration.ofMillis(10)),
-                null);
+                RetryConfig.withBackoff(Duration.ofMillis(10)));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 
             keys.forEach(key -> client.put(key, HelloTask.getDefaultInstance()));

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
@@ -42,7 +42,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
     private final ExecutionScheduler scheduler;
     private final TaskMetrics taskMetrics;
     private final ProcessMetrics processMetrics;
-    private volatile boolean terminated;
 
     public ProcessPipeline(ThreadScope scope,
                            List<DecatonProcessor<T>> processors,
@@ -75,10 +74,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
         }
 
         scheduler.schedule(extracted.metadata());
-        if (terminated) {
-            log.debug("Returning after schedule due to termination");
-            return;
-        }
 
         CompletableFuture<Void> result = process(request, extracted);
         result.whenComplete((r, e) -> {
@@ -149,7 +144,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
 
     @Override
     public void close() {
-        terminated = true;
         scheduler.close();
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -250,7 +250,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             Timer timer = Utils.timer();
             contexts.destroyAllProcessors();
             try {
-                contexts.updateHighWatermarks();
+                waitForRemainingTasksCompletion(rebalanceTimeoutMillis.value());
                 commitCompletedOffsets(consumer);
             } catch (RuntimeException e) {
                 logger.error("Offset commit failed before closing consumer", e);

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
@@ -35,8 +35,6 @@ public class ProcessorUnit implements AsyncShutdownable {
 
     private final ResourceUtilizationMetrics metrics;
 
-    private volatile boolean terminated;
-
     public ProcessorUnit(ThreadScope scope, ProcessPipeline<?> pipeline) {
         this.pipeline = pipeline;
 
@@ -56,13 +54,6 @@ public class ProcessorUnit implements AsyncShutdownable {
     }
 
     private void processTask(TaskRequest request) {
-        if (terminated) {
-            // There's a chance that some tasks leftover in executor's queue are still attempted to be processed
-            // even after this unit enters shutdown sequences.
-            // In such case we should ignore all following tasks to quickly complete shutdown sequence.
-            return;
-        }
-
         Timer timer = Utils.timer();
         try {
             pipeline.scheduleThenProcess(request);
@@ -81,7 +72,6 @@ public class ProcessorUnit implements AsyncShutdownable {
 
     @Override
     public void initiateShutdown() {
-        terminated = true;
         pipeline.close();
         executor.shutdown();
     }

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
@@ -224,10 +224,10 @@ public class ProcessPipelineTest {
         closeLatch.countDown();
 
         executor.shutdown();
-        // Checking it actually returns
+        // Checking scheduled task is passed to processor when shutdown
         executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
-        verify(pipeline, never()).process(any(), any());
-        verify(request.completion(), never()).complete();
+        verify(pipeline, times(1)).process(any(), any());
+        verify(request.completion(), times(1)).complete();
     }
 }
 

--- a/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
@@ -60,7 +60,7 @@ public class TestUtils {
     public static <T> ProcessorSubscription subscription(String bootstrapServers,
                                                          ProcessorsBuilder<T> processorsBuilder,
                                                          RetryConfig retryConfig,
-                                                         PropertySupplier propertySupplier) {
+                                                         PropertySupplier... propertySuppliers) {
         Properties props = new Properties();
         props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "test-processor" + sequence());
@@ -78,9 +78,7 @@ public class TestUtils {
         if (retryConfig != null) {
             builder.enableRetry(retryConfig);
         }
-        if (propertySupplier != null) {
-            builder.properties(propertySupplier);
-        }
+        builder.properties(propertySuppliers);
         ProcessorSubscription subscription = builder.buildAndStart();
 
         try {

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -1,0 +1,225 @@
+package com.linecorp.decaton.testing.processor;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
+
+import com.linecorp.decaton.client.DecatonClient;
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.ProcessorsBuilder;
+import com.linecorp.decaton.processor.PropertySupplier;
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.RetryConfig;
+import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.TestUtils;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Checks basic functionality which Decaton processor should satisfy in whatever type of processing.
+ *
+ * Basic functionality here includes:
+ * - All produced tasks are processed without leaking nor duplication
+ *     * Decaton adopts at-least-once processing semantics which allows duplication in principle, but
+ *       in ordinary situation (i.e. consumers and brokers are working fine and tasks are completed
+ *       within {@link ProcessorProperties#CONFIG_GROUP_REBALANCE_TIMEOUT_MS} during rebalance),
+ *       it's expected duplication not to occur
+ * - Preserve key based ordering
+ * - Rebalance doesn't break above functionalities
+ *
+ * Note that this class holds entire produced tasks and consumed tasks during test.
+ * Supplying huge amount of tasks may pressure JVM heap quite a lot.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ProcessorTestSuite<T extends MessageLite> {
+    private final KafkaClusterRule rule;
+    private final Parser<T> parser;
+    private final int numSubscriptionInstance;
+    private final int numTasks;
+    private final Iterator<DecatonProducerRecord<T>> tasks;
+    private final Function<ProcessorsBuilder<T>, ProcessorsBuilder<T>> configureProcessorsBuilder;
+    private final RetryConfig retryConfig;
+    private final PropertySupplier propertySupplier;
+
+    private static final int NUM_PARTITIONS = 8;
+
+    @Value
+    @Accessors(fluent = true)
+    public static class DecatonProducerRecord<T> {
+        String key;
+        T task;
+    }
+
+    @Setter
+    @Accessors(fluent = true)
+    public static class Builder<T extends MessageLite> {
+        private final KafkaClusterRule rule;
+        private final Parser<T> parser;
+
+        /**
+         * Number of subscription instances which consumes tasks
+         */
+        private int numSubscriptionInstances = 3;
+        /**
+         * Configure test-specific processing logic
+         */
+        private Function<ProcessorsBuilder<T>, ProcessorsBuilder<T>> configureProcessorsBuilder;
+        private RetryConfig retryConfig;
+        private PropertySupplier propertySupplier;
+
+        @Setter(AccessLevel.NONE)
+        private int numTasks;
+        @Setter(AccessLevel.NONE)
+        private Iterator<DecatonProducerRecord<T>> taskIterator;
+
+        private Builder(KafkaClusterRule rule, Parser<T> parser) {
+            this.rule = rule;
+            this.parser = parser;
+        }
+
+        public Builder<T> produce(int numTasks,
+                                  Iterator<DecatonProducerRecord<T>> taskIterator) {
+            this.numTasks = numTasks;
+            this.taskIterator = taskIterator;
+            return this;
+        }
+
+        public ProcessorTestSuite<T> build() {
+            return new ProcessorTestSuite<>(rule,
+                                            parser,
+                                            numSubscriptionInstances,
+                                            numTasks,
+                                            taskIterator,
+                                            configureProcessorsBuilder,
+                                            retryConfig,
+                                            propertySupplier);
+        }
+    }
+
+    public static <T extends MessageLite> Builder<T> builder(KafkaClusterRule rule,
+                                                             Parser<T> parser) {
+        return new Builder<>(rule, parser);
+    }
+
+    /**
+     * Checks processor's basic functionality.
+     * scenario:
+     *   1. Start multiple subscription instances
+     *   2. Produce tasks
+     *   3. When half of tasks are processed, restart subscriptions one by one
+     *   4. Await all tasks be processed
+     *   5. Compare processed tasks to produced tasks
+     */
+    public void run() {
+        String topicName = rule.admin().createRandomTopic(NUM_PARTITIONS, 3);
+
+        CountDownLatch processLatch = new CountDownLatch(numTasks);
+        CountDownLatch rollingRestartLatch = new CountDownLatch(numTasks / 2);
+
+        List<DecatonProducerRecord<T>> processedTasks = Collections.synchronizedList(new ArrayList<>());
+        DecatonProcessor<T> globalProcessor = (context, task) -> {
+            // If a task is retried, ordering is no longer preserved
+            if (context.metadata().retryCount() == 0) {
+                processedTasks.add(new DecatonProducerRecord<>(context.key(), task));
+                processLatch.countDown();
+                rollingRestartLatch.countDown();
+            }
+            context.deferCompletion().completeWith(context.push(task));
+        };
+
+        Supplier<ProcessorSubscription> subscriptionSupplier = () -> {
+            ProcessorsBuilder<T> processorsBuilder =
+                    ProcessorsBuilder.consuming(topicName,
+                                                new ProtocolBuffersDeserializer<>(parser))
+                                     .thenProcess(globalProcessor);
+
+            return TestUtils.subscription(rule.bootstrapServers(),
+                                          configureProcessorsBuilder.apply(processorsBuilder),
+                                          retryConfig,
+                                          propertySupplier);
+        };
+
+        DecatonClient<T> client = null;
+        ProcessorSubscription[] subscriptions = new ProcessorSubscription[numSubscriptionInstance];
+        try {
+            client = TestUtils.client(topicName, rule.bootstrapServers());
+            for (int i = 0; i < numSubscriptionInstance; i++) {
+                subscriptions[i] = subscriptionSupplier.get();
+            }
+
+            Map<String, List<T>> producedTasks = new HashMap<>();
+            while(tasks.hasNext()) {
+                DecatonProducerRecord<T> record = tasks.next();
+                client.put(record.key(), record.task());
+                List<T> tasks = producedTasks.computeIfAbsent(record.key(), key -> new ArrayList<>());
+                tasks.add(record.task());
+            }
+
+            rollingRestartLatch.await();
+            for (int i = 0; i < numSubscriptionInstance; i++) {
+                subscriptions[i].close();
+                subscriptions[i] = subscriptionSupplier.get();
+            }
+
+            processLatch.await();
+            for (int i = 0; i < numSubscriptionInstance; i++) {
+                subscriptions[i].close();
+            }
+
+            Map<String, List<T>> processedTasksPerKey = new HashMap<>();
+            for (DecatonProducerRecord<T> record : processedTasks) {
+                processedTasksPerKey.computeIfAbsent(record.key(),
+                                                     key -> new ArrayList<>()).add(record.task());
+            }
+
+            // Using assertTrue over assertEquals not to explode log when test fails
+            assertTrue("all produced keys must be processed",
+                       producedTasks.keySet().equals(processedTasksPerKey.keySet()));
+
+            for (String key : producedTasks.keySet()) {
+                List<T> produced = producedTasks.get(key);
+                List<T> processed = processedTasksPerKey.get(key);
+
+                assertTrue("all produced tasks must be processed in order per key without duplication",
+                           produced.equals(processed));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            safeClose(client);
+            for (ProcessorSubscription subscription : subscriptions) {
+                safeClose(subscription);
+            }
+            rule.admin().deleteTopics(topicName);
+        }
+    }
+
+    private static void safeClose(AutoCloseable resource) {
+        try {
+            if (resource != null) {
+                resource.close();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to close the resource", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Decaton allows process duplication by design.
However, it's expected duplication not to occur in ordinary processing situation. ordinary situation here means:

- All consumer and brokers works properly
- All tasks is completed within CONFIG_GROUP_REBALANCE_TIMEOUT_MS on partition revocation

Currently, process can be duplicated even in ordinary situation above due to 3 issues.

This PR fixes them.

###  Issue 1: ProcessPipeline returns immediately without doing process after terminated
- This causes duplication by following sequence:

(tasks are denoted by [offset: key])
Say partition contains `[1:a], [2:b], [3:b], [4:a]`, and partition concurrency is set to 2 (threadX,Y).
And `key a` will be routed to threadX, `key b` will be routed to threadY.

1. threadX's queue will be like this: `[1:a], [4:a]`
2. threadY's queue will be like this: `[2:b], [3:b]`
3. OOOCC will be like this: `[1(n), 2(n), 3(n), 4(n)] hw=0`
    * `(n)` means not completed. `(c)` means completed.
4. threadX completes `[1:a]` and `[4:a]`
5. threadY completes only `[2:b]`
6. OOOCC will be like this: `[1(c), 2(c), 3(n), 4(c)] hw=2`
7. Initiate shutdown
8. ProcessorPipeline returns without completing `[3:b]`, hence `[4:a]` will be processed again after rebalance

#### Solution
Revert to process all queued tasks.

### Issue 2: Kafka 2.4 has changed to call `onPartitionsRevoked` on shutdown

Kafka clients changed the behavior to call `onPartitionRevoked` on KafkaConsumer#close. (https://github.com/apache/kafka/pull/6884)

This can cause duplication as below:

Say OOOCC is like this `[1(c), 2(c), 3(n), 4(c)] hw=2`.

1. initiate shutdown
2. All processors are destroyed (https://github.com/line/decaton/blob/85a426ee8754349f82b6442cc9cab95226acb051/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java#L254)
3. consumer#close (https://github.com/line/decaton/blob/85a426ee8754349f82b6442cc9cab95226acb051/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java#L255)
4. revocation handler waits all pending tasks to complete, but since all processors are destroyed, `3(n)` will not be completed by anyone (https://github.com/line/decaton/blob/85a426ee8754349f82b6442cc9cab95226acb051/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java#L180)
5. exceeds CONFIG_GROUP_REBALANCE_TIMEOUT_MS, `4(c)` will be processed again after rebalance

#### Solution
onPartitionRevoked immediately returns if ProcessorSubscription already terminated.

### Issue 3: ProcessorSubscription doesn't wait pending tasks on shutdown
#### Solution
wait all pending tasks on shutdown