### PR TITLE
Add profiling capability to benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,11 +13,11 @@ Build a shadowJar:
 
 Run with arbitrary parameters:
 ```sh
-java -cp build/libs/benchmark-VERSION-shadow.jar com.linecorp.decaton.benchmark.Main \
+./debm.sh
  --title "Decaton" \
  --runner com.linecorp.decaton.benchmark.DecatonRunner \
  --tasks 10000 \
  --warmup 100 \
- --max-latency=10 \
+ --simulate-latency=10 \
  --param=decaton.partition.concurrency=20 
 ```

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -3,7 +3,7 @@ ext {
     shadeAllDependencies = true
 
     picoVersion = "4.2.0"
-    jacksonVersion = "2.9.2"
+    jacksonVersion = "2.10.3"
 }
 
 dependencies {
@@ -15,6 +15,8 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    // To serialize java.time.Duration
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/benchmark/debm.sh
+++ b/benchmark/debm.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+ASYNC_PROFILER_VERSION=1.7
+ASYNC_PROFILER_URL_BASE="https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNC_PROFILER_VERSION}"
+extra_opts=""
+classpath="$CLASSPATH:$(ls $(dirname $0)/build/libs/benchmark-*-shadow.jar | sort -nr | head -1)"
+
+if [[ "$*" == *--profile* ]] && [[ "$*" != *--profiler-bin* ]] && ! which profiler.sh >/dev/null 2>&1; then
+    dir="/tmp/async-profiler-${ASYNC_PROFILER_VERSION}"
+    if ! [ -e "$dir/profiler.sh" ]; then
+        case "$(uname -s)" in
+            Linux*)     platform=linux;;
+            Darwin*)    platform=macos;;
+            *)          echo "Cannot determine platform to download async-profiler" >&2; exit 1;;
+        esac
+        url="$ASYNC_PROFILER_URL_BASE/async-profiler-${ASYNC_PROFILER_VERSION}-${platform}-x64.tar.gz"
+        echo "Downloading async-profiler from $url into $dir" >&2
+        mkdir -p $dir
+        curl -L "$url" | tar zx -C $dir
+    fi
+    extra_opts="$extra_opts --profiler-bin=$dir/profiler.sh"
+fi
+
+exec java -XX:+UseG1GC -cp "$classpath" com.linecorp.decaton.benchmark.Main $extra_opts "$@"

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
@@ -95,7 +95,11 @@ public class AsyncProfilerProfiling implements Profiling {
     private Optional<Path> findOutputPath() {
         for (int i = 0; i < asyncProfilerOpts.size() - 1; i++) {
             if ("-f".equals(asyncProfilerOpts.get(i))) {
-                return Optional.of(Paths.get(asyncProfilerOpts.get(i + 1)));
+                // Avoid printing absolute path expecting the result to be copy & pasted in public
+                // place by security concerns.
+                Path path = Paths.get("").toAbsolutePath().relativize(
+                        Paths.get("", asyncProfilerOpts.get(i + 1)));
+                return Optional.of(path);
             }
         }
         return Optional.empty();

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.io.File;
+import java.lang.ProcessBuilder.Redirect;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Profiler for execution.
+ * Internally uses async-profiler https://github.com/jvm-profiling-tools/async-profiler to get
+ * stack samples.
+ */
+@Slf4j
+public class AsyncProfilerProfiling implements Profiling {
+    private static final int PROFILER_CMD_TIMEOUT_SECS = 30;
+
+    private final Path asyncProfilerBin;
+    private final List<String> asyncProfilerOpts;
+
+    public AsyncProfilerProfiling(Path asyncProfilerBin, Collection<String> asyncProfilerOpts) {
+        this.asyncProfilerBin = asyncProfilerBin;
+        if (asyncProfilerOpts == null) {
+            this.asyncProfilerOpts = new ArrayList<>();
+        } else {
+            this.asyncProfilerOpts = new ArrayList<>(asyncProfilerOpts);
+        }
+        if (!this.asyncProfilerOpts.contains("-f")) {
+            this.asyncProfilerOpts.add("-f");
+            this.asyncProfilerOpts.add(outputFileName());
+        }
+    }
+
+    private static long currentPid() {
+        String[] names = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
+        return Long.parseLong(names[0]);
+    }
+
+    private static String outputFileName() {
+        return "profile-" + currentPid() + ".svg";
+    }
+
+    private void exec(String subCommand) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(asyncProfilerBin.toString());
+        cmd.addAll(asyncProfilerOpts);
+        cmd.add(subCommand);
+        cmd.add(String.valueOf(currentPid()));
+        try {
+            Process process = new ProcessBuilder(cmd)
+                    .redirectOutput(new File("/dev/stderr"))
+                    .redirectError(Redirect.INHERIT)
+                    .start();
+            if (!process.waitFor(PROFILER_CMD_TIMEOUT_SECS, TimeUnit.SECONDS)) {
+                throw new RuntimeException("timed out waiting async-profiler command");
+            }
+            if (process.exitValue() != 0) {
+                throw new RuntimeException("async-profiler exits with error: " + process.exitValue());
+            }
+        } catch (Exception e) {
+            log.error("Failed to run profiler command: {}", cmd, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void start() {
+        log.info("Start profiling execution");
+        exec("start");
+    }
+
+    private Optional<Path> findOutputPath() {
+        for (int i = 0; i < asyncProfilerOpts.size() - 1; i++) {
+            if ("-f".equals(asyncProfilerOpts.get(i))) {
+                return Optional.of(Paths.get(asyncProfilerOpts.get(i + 1)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Path> stop() {
+        log.info("Finish profiling execution");
+        exec("stop");
+        return findOutputPath();
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
@@ -95,10 +95,7 @@ public class AsyncProfilerProfiling implements Profiling {
     private Optional<Path> findOutputPath() {
         for (int i = 0; i < asyncProfilerOpts.size() - 1; i++) {
             if ("-f".equals(asyncProfilerOpts.get(i))) {
-                // Avoid printing absolute path expecting the result to be copy & pasted in public
-                // place by security concerns.
-                Path path = Paths.get("").toAbsolutePath().relativize(
-                        Paths.get("", asyncProfilerOpts.get(i + 1)));
+                Path path = Paths.get(asyncProfilerOpts.get(i + 1));
                 return Optional.of(path);
             }
         }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
@@ -16,15 +16,9 @@
 
 package com.linecorp.decaton.benchmark;
 
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
-import com.linecorp.decaton.benchmark.BenchmarkResult.Performance;
-import com.linecorp.decaton.benchmark.BenchmarkResult.ResourceUsage;
-import com.linecorp.decaton.benchmark.ResourceTracker.TrackingValues;
-import com.linecorp.decaton.benchmark.Runner.Config;
-import com.linecorp.decaton.benchmark.Task.KafkaDeserializer;
+import com.linecorp.decaton.benchmark.Execution.Stage;
 import com.linecorp.decaton.testing.EmbeddedKafkaCluster;
 import com.linecorp.decaton.testing.EmbeddedZooKeeper;
 
@@ -44,56 +38,29 @@ public class Benchmark {
         return TemporaryTopic.create(bootstrapServers, topic);
     }
 
-    private void generateWorkload(String bootstrapServers, String topic) throws InterruptedException {
-        RecordsGenerator generator = new RecordsGenerator(config.simulateLatencyMs());
-        log.info("Generate {} tasks and {} for warmup", config.tasks(), config.warmupTasks());
-        generator.generate(bootstrapServers, topic, config.tasks(), config.warmupTasks());
+    private static void generateWorkload(String bootstrapServers, String topic, int numTasks, int latencyMs) {
+        RecordsGenerator generator = new RecordsGenerator();
+        log.info("Generate {} tasks with latency {} ms", numTasks, latencyMs);
+        try {
+            generator.generate(bootstrapServers, topic, numTasks, latencyMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     private BenchmarkResult runRecording(String bootstrapServers, String topic) throws InterruptedException {
-        log.info("Loading runner {}", config.runner());
-        Runner runner = Runner.fromClassName(config.runner());
-        Config config = new Config(bootstrapServers,
-                                   topic,
-                                   new KafkaDeserializer(),
-                                   this.config.params());
-
-        Recording recording = new Recording(this.config.tasks(), this.config.warmupTasks());
-        ResourceTracker resourceTracker = new ResourceTracker();
-        log.info("Initializing runner {}", this.config.runner());
-        runner.init(config, recording, resourceTracker);
-        final Map<Long, TrackingValues> resourceUsageReport;
-        try {
-            generateWorkload(bootstrapServers, topic);
-            if (!recording.await(3, TimeUnit.MINUTES)) {
-                throw new RuntimeException("timeout on awaiting benchmark to complete");
+        Execution.Config config = new Execution.Config(bootstrapServers, topic, this.config);
+        Execution execution = new ForkingExecution();
+        return execution.execute(config, stage -> {
+            if (stage == Stage.READY_WARMUP) {
+                log.info("Start warmup with {} tasks", this.config.warmupTasks());
+                generateWorkload(bootstrapServers, topic, this.config.warmupTasks(), 0);
+            } else if (stage == Stage.READY) {
+                log.info("Start real run with {} tasks", this.config.tasks());
+                generateWorkload(bootstrapServers, topic, this.config.tasks(), this.config.simulateLatencyMs());
             }
-            resourceUsageReport = resourceTracker.report();
-        } finally {
-            try {
-                runner.close();
-            } catch (Exception e) {
-                log.warn("Failed to close runner - {}", runner.getClass(), e);
-            }
-        }
-
-        return assembleResult(recording, resourceUsageReport);
-    }
-
-    private static BenchmarkResult assembleResult(Recording recording,
-                                                  Map<Long, TrackingValues> resourceUsageReport) {
-        Performance performance = recording.computeResult();
-        int threads = resourceUsageReport.size();
-        TrackingValues resourceValues =
-                resourceUsageReport.values().stream()
-                                   .reduce(new TrackingValues(0, 0),
-                                           (a, b) -> new TrackingValues(
-                                                   a.cpuTime() + b.cpuTime(),
-                                                   a.allocatedBytes() + b.allocatedBytes()));
-        ResourceUsage resource = new ResourceUsage(threads,
-                                                   resourceValues.cpuTime(),
-                                                   resourceValues.allocatedBytes());
-        return new BenchmarkResult(performance, resource);
+        });
     }
 
     public BenchmarkResult run() throws InterruptedException {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
@@ -55,7 +55,7 @@ public class Benchmark {
         if (this.config.forking()) {
             execution = new ForkingExecution();
         } else {
-            execution = new InProcessExecution(false);
+            execution = new InProcessExecution();
         }
         return execution.execute(config, stage -> {
             if (stage == Stage.READY_WARMUP) {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Benchmark.java
@@ -51,7 +51,12 @@ public class Benchmark {
 
     private BenchmarkResult runRecording(String bootstrapServers, String topic) throws InterruptedException {
         Execution.Config config = new Execution.Config(bootstrapServers, topic, this.config);
-        Execution execution = new ForkingExecution();
+        final Execution execution;
+        if (this.config.forking()) {
+            execution = new ForkingExecution();
+        } else {
+            execution = new InProcessExecution(false);
+        }
         return execution.execute(config, stage -> {
             if (stage == Stage.READY_WARMUP) {
                 log.info("Start warmup with {} tasks", this.config.warmupTasks());

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -16,13 +16,17 @@
 
 package com.linecorp.decaton.benchmark;
 
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
+import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
 @Value
 @Accessors(fluent = true)
+@Builder
 public class BenchmarkConfig {
     /**
      * Title of this benchmark.
@@ -54,4 +58,14 @@ public class BenchmarkConfig {
      * Implementation specific key-value parameters that are supported by {@link Runner} implementation.
      */
     Map<String, String> params;
+    /**
+     * Profiling config that is optional and might be null.
+     */
+    ProfilingConfig profiling;
+
+    @Value
+    public static class ProfilingConfig {
+        Path profilerBin;
+        List<String> profilerOpts;
+    }
 }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -59,6 +59,10 @@ public class BenchmarkConfig {
      */
     Map<String, String> params;
     /**
+     * Disable await on JIT stabilization before the actual run.
+     */
+    boolean skipWaitingJIT;
+    /**
      * Profiling config that is optional and might be null.
      */
     ProfilingConfig profiling;

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -62,6 +62,10 @@ public class BenchmarkConfig {
      * Profiling config that is optional and might be null.
      */
     ProfilingConfig profiling;
+    /**
+     * Whether to run benchmark in forked JVM or within the same JVM.
+     */
+    boolean forking;
 
     @Value
     public static class ProfilingConfig {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toMap;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -120,7 +119,7 @@ public class BenchmarkResult {
     @Value
     public static class ExtraInfo {
         public static final ExtraInfo EMPTY = new ExtraInfo(null);
-        Path profilerOutput;
+        String profilerOutput;
     }
 
     Performance performance;

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
@@ -18,7 +18,6 @@ package com.linecorp.decaton.benchmark;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.beans.ConstructorProperties;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -89,7 +88,7 @@ public class BenchmarkResult {
         }
     }
 
-    // TODO: WTF? using @Value here causes compilation error
+    @Value
     public static class JvmStats {
         @Value
         public static class GcStats {
@@ -98,15 +97,6 @@ public class BenchmarkResult {
         }
 
         Map<String, GcStats> gcStats;
-
-        @ConstructorProperties("gcStats")
-        public JvmStats(Map<String, GcStats> gcStats) {
-            this.gcStats = gcStats;
-        }
-
-        public Map<String, GcStats> gcStats() {
-            return gcStats;
-        }
 
         public JvmStats plus(JvmStats other) {
             Map<String, GcStats> merged = new HashMap<>(gcStats);

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Execution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Execution.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.util.function.Consumer;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * Execute benchmark given a configuration.
+ */
+public interface Execution {
+    @Value
+    @Accessors(fluent = true)
+    class Config {
+        String bootstrapServers;
+        String topic;
+        BenchmarkConfig benchmarkConfig;
+    }
+
+    /**
+     * A list of commands used to communicate between this execution and the benchmark controller
+     * to synchronize at some points where cooperative progress is required.
+     */
+    enum Stage {
+        /**
+         * The execution is ready to receive workload for warmup.
+         */
+        READY_WARMUP,
+        /**
+         * The execution has done dealing with warmup workloads and ready to receive real workload.
+         */
+        READY,
+        /**
+         * The execution has completed measuring real workload and now ready to return the result.
+         */
+        FINISH,
+    }
+
+    /**
+     * Execute the benchmark.
+     * The implementation should instantiate {@link Runner}, invoke {@code stageCallback} on every
+     * points to indicate progress and aggregate the result as {@link BenchmarkResult}.
+     *
+     * @param config the benchmark configuration.
+     * @param stageCallback the callback to tell progress.
+     * @return the benchmark result.
+     * @throws InterruptedException when interrupted.
+     */
+    BenchmarkResult execute(Config config, Consumer<Stage> stageCallback) throws InterruptedException;
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
@@ -50,7 +50,7 @@ public class ForkingExecution implements Execution {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         Config config = mapper.readValue(args[0], Config.class);
-        InProcessExecution execution = new InProcessExecution();
+        InProcessExecution execution = new InProcessExecution(true);
         BenchmarkResult result = execution.execute(config, System.out::println);
         mapper.writeValue(System.out, result);
     }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
@@ -50,7 +50,7 @@ public class ForkingExecution implements Execution {
 
     public static void main(String[] args) throws IOException, InterruptedException {
         Config config = mapper.readValue(args[0], Config.class);
-        InProcessExecution execution = new InProcessExecution(true);
+        InProcessExecution execution = new InProcessExecution();
         BenchmarkResult result = execution.execute(config, System.out::println);
         mapper.writeValue(System.out, result);
     }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.ProcessBuilder.Redirect;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An {@link Execution} that executes the benchmark in a separate JVM process.
+ */
+@Slf4j
+public class ForkingExecution implements Execution {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    static {
+        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+              .registerModule(new JavaTimeModule());
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        Config config = mapper.readValue(args[0], Config.class);
+        InProcessExecution execution = new InProcessExecution();
+        BenchmarkResult result = execution.execute(config, System.out::println);
+        mapper.writeValue(System.out, result);
+    }
+
+    @Override
+    public BenchmarkResult execute(Config config, Consumer<Stage> stageCallback) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(javaBin().toString());
+        cmd.add("-server");
+        cmd.addAll(jvmFlags());
+        cmd.add("-cp"); cmd.add(currentClasspath());
+        cmd.add(ForkingExecution.class.getName());
+        cmd.add(serializeConfig(config));
+
+        final Process process;
+        try {
+            log.debug("Forking child process for run with: {}", cmd);
+            process = new ProcessBuilder()
+                    .command(cmd)
+                    .redirectError(Redirect.INHERIT)
+                    .start();
+        } catch (IOException e) {
+            log.error("Failed to spawn child process: {}", cmd, e);
+            throw new RuntimeException("failed to spawn child process", e);
+        }
+
+        final BenchmarkResult result;
+        try {
+             result = communicate(process.getInputStream(), stageCallback);
+        } catch (IOException e) {
+            throw new RuntimeException("error while communicating with child", e);
+        } finally {
+            try {
+                process.waitFor();
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while waiting child", e);
+            }
+        }
+        if (process.exitValue() != 0) {
+            throw new RuntimeException("child exit with error: " + process.exitValue());
+        }
+        return result;
+    }
+
+    private static BenchmarkResult communicate(InputStream in, Consumer<Stage> stageCallback)
+            throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        String line;
+        while ((line = br.readLine()) != null) {
+            log.debug("Received line from child: {}", line);
+            Stage stage = Stage.valueOf(line);
+            stageCallback.accept(stage);
+            if (stage == Stage.FINISH) {
+                break;
+            }
+        }
+        line = br.readLine();
+        return mapper.readValue(line, BenchmarkResult.class);
+    }
+
+    private static Path javaBin() {
+        return Paths.get(System.getProperty("java.home"), "bin", "java");
+    }
+
+    private static String currentClasspath() {
+        return ManagementFactory.getRuntimeMXBean().getClassPath();
+    }
+
+    private static List<String> jvmFlags() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments();
+    }
+
+    private static String serializeConfig(Config config) {
+        try {
+            return mapper.writeValueAsString(config);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("failed to serialize config", e);
+        }
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -91,7 +91,7 @@ public class InProcessExecution implements Execution {
         }
 
         stageCallback.accept(Stage.FINISH);
-        return assembleResult(recording, resourceUsageReport, jvmReport, profilerOutput.orElse(null));
+        return assembleResult(recording, resourceUsageReport, jvmReport, profilerOutput);
     }
 
     private static Profiling profiling(BenchmarkConfig bmConfig) {
@@ -121,7 +121,7 @@ public class InProcessExecution implements Execution {
     private static BenchmarkResult assembleResult(Recording recording,
                                                   Map<Long, TrackingValues> resourceUsageReport,
                                                   Map<String, GcStats> jvmReport,
-                                                  Path profilerOutput) {
+                                                  Optional<Path> profilerOutput) {
         Performance performance = recording.computeResult();
         int threads = resourceUsageReport.size();
         TrackingValues resourceValues =
@@ -137,6 +137,6 @@ public class InProcessExecution implements Execution {
                 Entry::getKey,
                 e -> new JvmStats.GcStats(e.getValue().count(), e.getValue().time())));
         JvmStats jvmStats = new JvmStats(gcStats);
-        return new BenchmarkResult(performance, resource, jvmStats, new ExtraInfo(profilerOutput));
+        return new BenchmarkResult(performance, resource, jvmStats, new ExtraInfo(profilerOutput.map(String::valueOf).orElse(null)));
     }
 }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -42,6 +42,12 @@ import lombok.extern.slf4j.Slf4j;
 public class InProcessExecution implements Execution {
     private static final int COMPILE_TIME_CHECK_INTERVAL_MS = 5000;
 
+    private final boolean awaitJITStable;
+
+    public InProcessExecution(boolean awaitJITStable) {
+        this.awaitJITStable = awaitJITStable;
+    }
+
     @Override
     public BenchmarkResult execute(Config config, Consumer<Stage> stageCallback) throws InterruptedException {
         BenchmarkConfig bmConfig = config.benchmarkConfig();
@@ -65,7 +71,9 @@ public class InProcessExecution implements Execution {
             if (!recording.awaitWarmupComplete(3, TimeUnit.MINUTES)) {
                 throw new RuntimeException("timeout on awaiting benchmark to complete");
             }
-            awaitJITGetsSettled();
+            if (awaitJITStable) {
+                awaitJITGetsSettled();
+            }
 
             profiling.start();
             JvmTracker jvmTracker = JvmTracker.create();

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -42,12 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 public class InProcessExecution implements Execution {
     private static final int COMPILE_TIME_CHECK_INTERVAL_MS = 5000;
 
-    private final boolean awaitJITStable;
-
-    public InProcessExecution(boolean awaitJITStable) {
-        this.awaitJITStable = awaitJITStable;
-    }
-
     @Override
     public BenchmarkResult execute(Config config, Consumer<Stage> stageCallback) throws InterruptedException {
         BenchmarkConfig bmConfig = config.benchmarkConfig();
@@ -71,7 +65,7 @@ public class InProcessExecution implements Execution {
             if (!recording.awaitWarmupComplete(3, TimeUnit.MINUTES)) {
                 throw new RuntimeException("timeout on awaiting benchmark to complete");
             }
-            if (awaitJITStable) {
+            if (!bmConfig.skipWaitingJIT()) {
                 awaitJITGetsSettled();
             }
 

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.lang.management.CompilationMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import com.linecorp.decaton.benchmark.BenchmarkConfig.ProfilingConfig;
+import com.linecorp.decaton.benchmark.BenchmarkResult.JvmStats;
+import com.linecorp.decaton.benchmark.BenchmarkResult.Performance;
+import com.linecorp.decaton.benchmark.BenchmarkResult.ResourceUsage;
+import com.linecorp.decaton.benchmark.JvmTracker.GcStats;
+import com.linecorp.decaton.benchmark.ResourceTracker.TrackingValues;
+import com.linecorp.decaton.benchmark.Task.KafkaDeserializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An {@link Execution} that executes benchmark within the instantiated JVM.
+ */
+@Slf4j
+public class InProcessExecution implements Execution {
+    private static final int COMPILE_TIME_CHECK_INTERVAL_MS = 5000;
+
+    @Override
+    public BenchmarkResult execute(Config config, Consumer<Stage> stageCallback) throws InterruptedException {
+        BenchmarkConfig bmConfig = config.benchmarkConfig();
+
+        log.info("Loading runner {}", bmConfig.runner());
+        Runner runner = Runner.fromClassName(bmConfig.runner());
+        Recording recording = new Recording(bmConfig.tasks(), bmConfig.warmupTasks());
+        ResourceTracker resourceTracker = new ResourceTracker();
+        log.info("Initializing runner {}", bmConfig.runner());
+
+        Runner.Config runnerConfig = new Runner.Config(config.bootstrapServers(),
+                                                       config.topic(),
+                                                       new KafkaDeserializer(),
+                                                       bmConfig.params());
+        Profiling profiling = profiling(bmConfig);
+        runner.init(runnerConfig, recording, resourceTracker);
+        final Map<Long, TrackingValues> resourceUsageReport;
+        final Map<String, GcStats> jvmReport;
+        try {
+            stageCallback.accept(Stage.READY_WARMUP);
+            if (!recording.awaitWarmupComplete(3, TimeUnit.MINUTES)) {
+                throw new RuntimeException("timeout on awaiting benchmark to complete");
+            }
+            awaitJITGetsSettled();
+
+            profiling.start();
+            JvmTracker jvmTracker = JvmTracker.create();
+            stageCallback.accept(Stage.READY);
+            if (!recording.await(3, TimeUnit.MINUTES)) {
+                throw new RuntimeException("timeout on awaiting benchmark to complete");
+            }
+            profiling.stop().ifPresent(
+                    outputPath -> log.info("Profiling output is available at {}", outputPath));
+            jvmReport = jvmTracker.report();
+            resourceUsageReport = resourceTracker.report();
+        } finally {
+            try {
+                runner.close();
+            } catch (Exception e) {
+                log.warn("Failed to close runner - {}", runner.getClass(), e);
+            }
+        }
+
+        stageCallback.accept(Stage.FINISH);
+        return assembleResult(recording, resourceUsageReport, jvmReport);
+    }
+
+    private static Profiling profiling(BenchmarkConfig bmConfig) {
+        ProfilingConfig config = bmConfig.profiling();
+        if (config == null) {
+            return Profiling.NOOP;
+        } else {
+            return new AsyncProfilerProfiling(config.profilerBin(), config.profilerOpts());
+        }
+    }
+
+    private static void awaitJITGetsSettled() throws InterruptedException {
+        CompilationMXBean compileMxBean = ManagementFactory.getCompilationMXBean();
+        long time = compileMxBean.getTotalCompilationTime();
+        log.info("Waiting for JIT compilation to get stable");
+        while (true) {
+            log.debug("Still waiting JIT compilation to get stable, time={}", time);
+            Thread.sleep(COMPILE_TIME_CHECK_INTERVAL_MS);
+            long newTime = compileMxBean.getTotalCompilationTime();
+            if (time == newTime) {
+                break;
+            }
+            time = newTime;
+        }
+    }
+
+    private static BenchmarkResult assembleResult(Recording recording,
+                                                  Map<Long, TrackingValues> resourceUsageReport,
+                                                  Map<String, GcStats> jvmReport) {
+        Performance performance = recording.computeResult();
+        int threads = resourceUsageReport.size();
+        TrackingValues resourceValues =
+                resourceUsageReport.values().stream()
+                                   .reduce(new TrackingValues(0, 0),
+                                           (a, b) -> new TrackingValues(
+                                                   a.cpuTime() + b.cpuTime(),
+                                                   a.allocatedBytes() + b.allocatedBytes()));
+        ResourceUsage resource = new ResourceUsage(threads,
+                                                   resourceValues.cpuTime(),
+                                                   resourceValues.allocatedBytes());
+        Map<String, JvmStats.GcStats> gcStats = jvmReport.entrySet().stream().collect(toMap(
+                Entry::getKey,
+                e -> new JvmStats.GcStats(e.getValue().count(), e.getValue().time())));
+        JvmStats jvmStats = new JvmStats(gcStats);
+        return new BenchmarkResult(performance, resource, jvmStats);
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/JvmTracker.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/JvmTracker.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Track JVM related performance metrics.
+ */
+@Slf4j
+public class JvmTracker {
+    @Value
+    @Accessors(fluent = true)
+    public static class GcStats {
+        long count;
+        long time;
+    }
+
+    private final List<GarbageCollectorMXBean> gcMxBeans;
+    private final Map<String, GcStats> targets;
+
+    /**
+     * Create a {@link JvmTracker} with origin values at the time it gets called.
+     * @return a {@link JvmTracker}.
+     */
+    public static JvmTracker create() {
+        List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();
+        Map<String, GcStats> targets = new HashMap<>();
+        for (GarbageCollectorMXBean gcMxBean : gcMxBeans) {
+            targets.put(gcMxBean.getName(),
+                        new GcStats(gcMxBean.getCollectionCount(), gcMxBean.getCollectionTime()));
+        }
+        return new JvmTracker(gcMxBeans, targets);
+    }
+
+    JvmTracker(List<GarbageCollectorMXBean> gcMxBeans, Map<String, GcStats> targets) {
+        this.gcMxBeans = gcMxBeans;
+        this.targets = targets;
+    }
+
+    public Map<String, GcStats> report() {
+        Map<String, GcStats> report = new HashMap<>();
+        for (GarbageCollectorMXBean gcMxBean : gcMxBeans) {
+            GcStats initValues = targets.get(gcMxBean.getName());
+            if (initValues == null) {
+                log.warn("Could not collect GC stats for {}", gcMxBean.getName());
+                continue;
+            }
+            GcStats values =
+                    new GcStats(gcMxBean.getCollectionCount() - initValues.count,
+                                gcMxBean.getCollectionTime() - initValues.time);
+            report.put(gcMxBean.getName(), values);
+        }
+        return report;
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -92,9 +92,18 @@ public final class Main implements Callable<Integer> {
         if (enableProfiling) {
             profiling = new ProfilingConfig(profilerBin, parseOptions(profilerOpts));
         }
-        BenchmarkConfig config = new BenchmarkConfig(
-                title, runner, tasks, warmupTasks, simulateLatencyMs, bootstrapServers, params, profiling);
-
+        BenchmarkConfig config =
+                BenchmarkConfig.builder()
+                               .title(title)
+                               .runner(runner)
+                               .tasks(tasks)
+                               .warmupTasks(warmupTasks)
+                               .simulateLatencyMs(simulateLatencyMs)
+                               .bootstrapServers(bootstrapServers)
+                               .params(params)
+                               .profiling(profiling)
+                               .forking(true)
+                               .build();
         Benchmark benchmark = new Benchmark(config);
         BenchmarkResult result = benchmark.run();
         result.print(config, System.out);

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -16,10 +16,18 @@
 
 package com.linecorp.decaton.benchmark;
 
+import static java.util.Collections.emptyList;
+
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
+
+import com.linecorp.decaton.benchmark.BenchmarkConfig.ProfilingConfig;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -30,28 +38,63 @@ public final class Main implements Callable<Integer> {
     @Option(names = "--title", description = "Title of the case to test", required = true)
     private String title;
 
-    @Option(names = "--runner", description = "Fully-qualified runner class name that implements Runner", required = true)
+    @Option(names = "--runner", description = "Fully-qualified runner class name that implements Runner",
+            required = true,
+            defaultValue = "com.linecorp.decaton.benchmark.DecatonRunner")
     private String runner;
 
     @Option(names = "--tasks", description = "Number of tasks to generate for testing", required = true)
     private int tasks;
 
-    @Option(names = "--warmup", description = "Number of tasks to apply for warm up execution (class loading, JIT compile...) before start measurement", defaultValue = "10")
+    @Option(names = "--warmup",
+            description = "Number of tasks to apply for warm up execution (class loading, JIT compile...) before start measurement",
+            defaultValue = "10")
     private int warmupTasks;
 
-    @Option(names = "--simulate-latency", description = "Latency in milliseconds to inject for simulating processing time for each tasks", defaultValue = "0")
+    @Option(names = "--simulate-latency",
+            description = "Latency in milliseconds to inject for simulating processing time for each tasks",
+            defaultValue = "0")
     private int simulateLatencyMs;
 
-    @Option(names = "--bootstrap-servers", description = "Optional bootstrap.servers property. if supplied, the specified kafka cluster is used for benchmarking instead of local embedded clusters")
+    @Option(names = "--bootstrap-servers",
+            description = "Optional bootstrap.servers property. if supplied, the specified kafka cluster is used for benchmarking instead of local embedded clusters")
     private String bootstrapServers;
 
     @Option(names = "--param", description = "Key-value parameters to supply for runner")
     private Map<String, String> params = new HashMap<>();
 
+    @Option(names = "--profile", description = "Enable profiling of execution with async-profiler")
+    private boolean enableProfiling;
+
+    @Option(names = "--profiler-bin", description = "Path to async-profiler's profiler.sh",
+            defaultValue = "profiler.sh")
+    private Path profilerBin;
+
+    @Option(names = "--profiler-opts", description = "Options to pass for async-profiler's profiler.sh")
+    private String profilerOpts;
+
+    private static List<String> parseOptions(String opts) {
+        if (opts == null) {
+            return emptyList();
+        }
+
+        StringTokenizer tok = new StringTokenizer(opts);
+        List<String> items = new ArrayList<>();
+        while (tok.hasMoreElements()) {
+            items.add(tok.nextToken());
+        }
+        return items;
+    }
+
     @Override
     public Integer call() throws Exception {
+        BenchmarkConfig.ProfilingConfig profiling = null;
+        if (enableProfiling) {
+            profiling = new ProfilingConfig(profilerBin, parseOptions(profilerOpts));
+        }
         BenchmarkConfig config = new BenchmarkConfig(
-                title, runner, tasks, warmupTasks, simulateLatencyMs, bootstrapServers, params);
+                title, runner, tasks, warmupTasks, simulateLatencyMs, bootstrapServers, params, profiling);
+
         Benchmark benchmark = new Benchmark(config);
         BenchmarkResult result = benchmark.run();
         result.print(config, System.out);

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -63,6 +63,9 @@ public final class Main implements Callable<Integer> {
     @Option(names = "--param", description = "Key-value parameters to supply for runner")
     private Map<String, String> params = new HashMap<>();
 
+    @Option(names = "--no-wait-jit", description = "Do not await JIT compilation to get stable before moving onto actual run")
+    private boolean skipWaitingJIT;
+
     @Option(names = "--profile", description = "Enable profiling of execution with async-profiler")
     private boolean enableProfiling;
 
@@ -101,6 +104,7 @@ public final class Main implements Callable<Integer> {
                                .simulateLatencyMs(simulateLatencyMs)
                                .bootstrapServers(bootstrapServers)
                                .params(params)
+                               .skipWaitingJIT(skipWaitingJIT)
                                .profiling(profiling)
                                .forking(true)
                                .build();

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Profiling.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Profiling.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Profile the running JVM while executing benchmark.
+ */
+public interface Profiling {
+    Profiling NOOP = new Profiling() {
+        @Override
+        public void start() {
+            // noop
+        }
+
+        @Override
+        public Optional<Path> stop() {
+            return Optional.empty();
+        }
+    };
+
+    /**
+     * Start profiling.
+     */
+    void start();
+
+    /**
+     * Stop profiling.
+     * @return the path storing profiling output.
+     */
+    Optional<Path> stop();
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/RecordsGenerator.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/RecordsGenerator.java
@@ -33,12 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RecordsGenerator {
-    private final int simulateLatencyMs;
-
-    public RecordsGenerator(int simulateLatencyMs) {
-        this.simulateLatencyMs = Math.max(0, simulateLatencyMs);
-    }
-
     private static void consumeResults(Deque<Future<RecordMetadata>> results, boolean await)
             throws InterruptedException {
         Future<RecordMetadata> future;
@@ -62,7 +56,7 @@ public class RecordsGenerator {
         return producer.send(record);
     }
 
-    public void generate(String bootstrapServers, String topic, int numTasks, int numWarmupTasks)
+    public void generate(String bootstrapServers, String topic, int numTasks, int simulateLatencyMs)
             throws InterruptedException {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "decaton-benchmark");
@@ -75,11 +69,6 @@ public class RecordsGenerator {
         Deque<Future<RecordMetadata>> results = new ArrayDeque<>();
         try (Producer<byte[], Task> producer =
                      new KafkaProducer<>(props, new ByteArraySerializer(), new Task.KafkaSerializer())) {
-            for (int i = 0; i < numWarmupTasks; i++) {
-                results.addLast(produce(producer, topic, 0));
-                consumeResults(results, false);
-            }
-
             for (int i = 0; i < numTasks; i++) {
                 results.addLast(produce(producer, topic, simulateLatencyMs));
                 consumeResults(results, false);

--- a/benchmark/src/main/resources/logback.xml
+++ b/benchmark/src/main/resources/logback.xml
@@ -15,13 +15,14 @@
   -->
 
 <configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
   <root level="WARN">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDERR" />
   </root>
   <logger name="com.linecorp.decaton.benchmark" level="DEBUG" />
   <logger name="kafka" level="OFF" />

--- a/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
@@ -41,7 +41,7 @@ public class PerformanceBoundTest {
         Assume.assumeTrue(System.getProperty("it.test-perf") != null);
     }
 
-    @Test
+    @Test(timeout = 300000)
     public void testPerformanceBoundBusy() throws InterruptedException {
         Map<String, String> params = new HashMap<>();
         params.put(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY.name(), "8");
@@ -52,6 +52,7 @@ public class PerformanceBoundTest {
                                                 .warmupTasks(10_000)
                                                 .simulateLatencyMs(0)
                                                 .params(params)
+                                                .forking(false)
                                                 .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);
@@ -64,7 +65,7 @@ public class PerformanceBoundTest {
         assertThat((int) result.performance().throughput(), greaterThanOrEqualTo(10000));
     }
 
-    @Test
+    @Test(timeout = 300000)
     public void testPerformanceBoundWithLatency() throws InterruptedException {
         Map<String, String> params = new HashMap<>();
         params.put(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY.name(), "10");
@@ -75,6 +76,7 @@ public class PerformanceBoundTest {
                                                 .warmupTasks(10_000)
                                                 .simulateLatencyMs(10)
                                                 .params(params)
+                                                .forking(false)
                                                 .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);

--- a/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
@@ -53,6 +53,7 @@ public class PerformanceBoundTest {
                                                 .simulateLatencyMs(0)
                                                 .params(params)
                                                 .forking(false)
+                                                .skipWaitingJIT(true)
                                                 .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);
@@ -77,6 +78,7 @@ public class PerformanceBoundTest {
                                                 .simulateLatencyMs(10)
                                                 .params(params)
                                                 .forking(false)
+                                                .skipWaitingJIT(true)
                                                 .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);

--- a/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PerformanceBoundTest.java
@@ -45,9 +45,14 @@ public class PerformanceBoundTest {
     public void testPerformanceBoundBusy() throws InterruptedException {
         Map<String, String> params = new HashMap<>();
         params.put(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY.name(), "8");
-        BenchmarkConfig config = new BenchmarkConfig(
-                "PerformanceBoundBusy", DecatonRunner.class.getName(),
-                10_000, 10_000, 0, null, params);
+        BenchmarkConfig config = BenchmarkConfig.builder()
+                                                .title("PerformanceBoundBusy")
+                                                .runner(DecatonRunner.class.getName())
+                                                .tasks(10_000)
+                                                .warmupTasks(10_000)
+                                                .simulateLatencyMs(0)
+                                                .params(params)
+                                                .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);
         for (int i = 0; i < ITERATIONS; i++) {
@@ -63,9 +68,14 @@ public class PerformanceBoundTest {
     public void testPerformanceBoundWithLatency() throws InterruptedException {
         Map<String, String> params = new HashMap<>();
         params.put(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY.name(), "10");
-        BenchmarkConfig config = new BenchmarkConfig(
-                "PerformanceBoundWithLatency", DecatonRunner.class.getName(),
-                10_000, 10_000, 10, null, params);
+        BenchmarkConfig config = BenchmarkConfig.builder()
+                                                .title("PerformanceBoundWithLatency")
+                                                .runner(DecatonRunner.class.getName())
+                                                .tasks(10_000)
+                                                .warmupTasks(10_000)
+                                                .simulateLatencyMs(10)
+                                                .params(params)
+                                                .build();
         Benchmark benchmark = new Benchmark(config);
         List<BenchmarkResult> results = new ArrayList<>(ITERATIONS);
         for (int i = 0; i < ITERATIONS; i++) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -46,11 +46,11 @@ public class Metrics {
     }
 
     public class SubscriptionMetrics {
-        private Timer processDuration(String scope) {
+        private Timer processDuration(String section) {
             return Timer.builder("subscription.process.durations")
                         .description(String.format(
-                                "Time spent for processing %s in consuming loop", scope))
-                        .tags(availableTags.subscriptionScope().and("scope", scope))
+                                "Time spent for processing %s in consuming loop", section))
+                        .tags(availableTags.subscriptionScope().and("section", section))
                         .distributionStatisticExpiry(Duration.ofSeconds(60))
                         .publishPercentiles(0.5, 0.9, 0.99, 0.999)
                         .register(registry);
@@ -126,11 +126,11 @@ public class Metrics {
                           .tags(availableTags.partitionScope())
                           .register(registry);
 
-        public final Counter queueStarvedTime =
-                Counter.builder("partition.queue.starved.time")
-                       .description("Total duration of time the partition's queue was starving")
-                       .tags(availableTags.partitionScope())
-                       .register(registry);
+        public final Timer queueStarvedTime =
+                Timer.builder("partition.queue.starved.time")
+                     .description("Total duration of time the partition's queue was starving")
+                     .tags(availableTags.partitionScope())
+                     .register(registry);
 
         public final Timer partitionPausedTime =
                 Timer.builder("partition.paused.time")

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -29,6 +29,7 @@ public class Metrics {
     public static final String NAMESPACE = "decaton";
 
     private static final CompositeMeterRegistry registry = new CompositeMeterRegistry();
+
     static {
         registry.config().meterFilter(new MeterFilter() {
             @Override
@@ -42,6 +43,28 @@ public class Metrics {
 
     private Metrics(AvailableTags availableTags) {
         this.availableTags = availableTags;
+    }
+
+    public class SubscriptionMetrics {
+        private Timer processDuration(String scope) {
+            return Timer.builder("subscription.process.durations")
+                        .description(String.format(
+                                "Time spent for processing %s in consuming loop", scope))
+                        .tags(availableTags.subscriptionScope().and("scope", scope))
+                        .distributionStatisticExpiry(Duration.ofSeconds(60))
+                        .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                        .register(registry);
+        }
+
+        public final Timer consumerPollTime = processDuration("poll");
+
+        public final Timer handleRecordsTime = processDuration("records");
+
+        public final Timer reloadContextsTime = processDuration("reload");
+
+        public final Timer handlePausesTime = processDuration("pause");
+
+        public final Timer commitOffsetTime = processDuration("commit");
     }
 
     public class TaskMetrics {
@@ -102,6 +125,12 @@ public class Metrics {
                           .description("The number of pending tasks")
                           .tags(availableTags.partitionScope())
                           .register(registry);
+
+        public final Counter queueStarvedTime =
+                Counter.builder("partition.queue.starved.time")
+                       .description("Total duration of time the partition's queue was starving")
+                       .tags(availableTags.partitionScope())
+                       .register(registry);
 
         public final Timer partitionPausedTime =
                 Timer.builder("partition.paused.time")

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
@@ -113,7 +113,7 @@ public class PartitionContext {
     public void addRequest(TaskRequest request) {
         partitionProcessor.addTask(request);
         if (lastQueueStarvedTime > 0) {
-            metrics.queueStarvedTime.increment(System.nanoTime() - lastQueueStarvedTime);
+            metrics.queueStarvedTime.record(System.nanoTime() - lastQueueStarvedTime, TimeUnit.NANOSECONDS);
             lastQueueStarvedTime = -1;
         }
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
@@ -38,6 +38,7 @@ public class PartitionContext {
     // The offset committed successfully at last commit
     private long lastCommittedOffset;
     private long pausedTimeNanos;
+    private long lastQueueStarvedTime;
 
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
@@ -55,6 +56,7 @@ public class PartitionContext {
 
         lastCommittedOffset = -1;
         pausedTimeNanos = -1;
+        lastQueueStarvedTime = -1;
     }
 
     /**
@@ -88,7 +90,11 @@ public class PartitionContext {
 
     public void updateHighWatermark() {
         commitControl.updateHighWatermark();
-        metrics.tasksPending.set(commitControl.pendingOffsetsCount());
+        int pendingCount = commitControl.pendingOffsetsCount();
+        metrics.tasksPending.set(pendingCount);
+        if (pendingCount == 0 && lastQueueStarvedTime < 0) {
+            lastQueueStarvedTime = System.nanoTime();
+        }
     }
 
     public int pendingTasksCount() {
@@ -106,6 +112,10 @@ public class PartitionContext {
 
     public void addRequest(TaskRequest request) {
         partitionProcessor.addTask(request);
+        if (lastQueueStarvedTime > 0) {
+            metrics.queueStarvedTime.increment(System.nanoTime() - lastQueueStarvedTime);
+            lastQueueStarvedTime = -1;
+        }
     }
 
     public DeferredCompletion registerOffset(long offset) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -44,6 +44,8 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.Property;
 import com.linecorp.decaton.processor.SubscriptionStateListener;
+import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.metrics.Metrics.SubscriptionMetrics;
 import com.linecorp.decaton.processor.runtime.Utils.Timer;
 
 public class ProcessorSubscription extends Thread implements AsyncShutdownable {
@@ -60,6 +62,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
     private final Property<Long> commitIntervalMillis;
     private final Property<Long> rebalanceTimeoutMillis;
     private final SubscriptionStateListener stateListener;
+    private final SubscriptionMetrics metrics;
 
     public ProcessorSubscription(SubscriptionScope scope,
                                  Supplier<Consumer<String, byte[]>> consumerSupplier,
@@ -72,6 +75,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
         this.stateListener = stateListener;
         terminated = new AtomicBoolean();
         contexts = new PartitionContexts(scope, processors);
+        metrics = Metrics.withTags("subscription", scope.subscriptionId()).new SubscriptionMetrics();
 
         blacklistedKeysFilter = new BlacklistedKeysFilter(props);
         commitIntervalMillis = props.get(ProcessorProperties.CONFIG_COMMIT_INTERVAL_MS);
@@ -229,7 +233,9 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
                 pollOnce(consumer);
                 if (System.currentTimeMillis() - lastCommittedMillis >= commitIntervalMillis.value()) {
                     try {
+                        Timer timer = Utils.timer();
                         commitCompletedOffsets(consumer);
+                        metrics.commitOffsetTime.record(timer.duration());
                     } catch (CommitFailedException | TimeoutException e) {
                         logger.warn("Offset commit failed, but continuing to consume", e);
                         // Continue processing, assuming commit will be handled successfully in next attempt.
@@ -261,8 +267,11 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
     }
 
     private void pollOnce(Consumer<String, byte[]> consumer) {
+        Timer timer = Utils.timer();
         ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT_MILLIS);
+        metrics.consumerPollTime.record(timer.duration());
 
+        timer = Utils.timer();
         records.forEach(record -> {
             TopicPartition tp = new TopicPartition(record.topic(), record.partition());
             PartitionContext context = contexts.get(tp);
@@ -276,10 +285,18 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
                 completion.complete();
             }
         });
-        contexts.updateHighWatermarks();
+        metrics.handleRecordsTime.record(timer.duration());
+
+        timer = Utils.timer();
         contexts.maybeHandlePropertyReload();
+        metrics.reloadContextsTime.record(timer.duration());
+
+        contexts.updateHighWatermarks();
+
+        timer = Utils.timer();
         pausePartitions(consumer);
         resumePartitions(consumer);
+        metrics.handlePausesTime.record(timer.duration());
     }
 
     private void pausePartitions(Consumer<?, ?> consumer) {


### PR DESCRIPTION
## Motivation

The benchmark module is useful not only for tracking performance regression between decaton versions but also for persuading even further performance optimizations and/or to figure out why the performance regression has happened.
To get more insights from benchmark we need more information from it most significantly profiling.
Of course we can run profilers like async-profiler externally with synchronizing timing with benchmark execution, but it's highly useful to integrate the profiling into benchmark itself so that:
* We can easily perform profiling just by single extra command line switch
* Benchmark code knows more about when it should start profiling. e.g, should not profile until warmup completes.

## Major Changes

* Made benchmark runner to fork a separate JVM to run consumer instance. This has several reasons like 1. to avoid GC/allocation workload from unrelated thing like embedded kafka cluster, producers, 2. to remove noises from profiling result: Related classes: `Execution`, `InProcessExecution`, `ForkingExecution`
* Add async-profiler support. Related classes: `Profiling`, `AsyncProfilerProfiling`
* Add JVM (GC) stats in output. Related classes: `JvmTracker`
* Add some metrics to observe partition processors' queue starving status. Related classes: `Metrics`
* Wait until JIT compilation to get settled after warmup before proceeding to real run. Related classes: `Benchmark`

Example output:
```
=== Decaton (100000 tasks) ===
# Runner: com.linecorp.decaton.benchmark.DecatonRunner
# Tasks: 100000 (warmup: 100000)
# Simulated Latency(ms): 0
# Param: decaton.partition.concurrency=20
--- Performance ---
Execution Time(ms): 4569.00
Throughput: 21886.63 tasks/sec
Delivery Latency(ms): mean=954 max=3049
--- Resource Usage (61 threads observed) ---
Cpu Time(ms): 9071.49
Allocated Heap(KiB): 831205.57
--- JVM ---
GC (G1 Old Generation) Count: 0
GC (G1 Old Generation) Time(ms): 0
GC (G1 Young Generation) Count: 5
GC (G1 Young Generation) Time(ms): 45
```