### PR TITLE
Cleanup all metrics at corresponding shutdown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
         protobufVersion = "3.3.0"
         kafkaVersion = "2.4.0"
         prometheusVersion = "0.6.0"
-        micrometerVersion = "1.3.1"
+        micrometerVersion = "1.5.1"
         lombokVersion = "1.18.4"
         junitVersion = "4.12"
 

--- a/processor/src/it/java/com/linecorp/decaton/processor/MetricsCleanupTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/MetricsCleanupTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.decaton.client.DecatonClient;
+import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
+import com.linecorp.decaton.protocol.Sample.HelloTask;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.TestUtils;
+
+import io.micrometer.core.instrument.Meter;
+
+public class MetricsCleanupTest {
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+
+    private String topicName;
+
+    @Before
+    public void setUp() {
+        topicName = rule.admin().createRandomTopic(3, 3);
+    }
+
+    @After
+    public void tearDown() {
+        rule.admin().deleteTopics(topicName);
+    }
+
+    @Test(timeout = 30000)
+    public void testMetricsCleanup() throws Exception {
+        CountDownLatch processLatch = new CountDownLatch(1);
+        try (ProcessorSubscription subscription = TestUtils.subscription(
+                rule.bootstrapServers(),
+                ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
+                                 .thenProcess((context, task) -> processLatch.countDown()),
+                null,
+                StaticPropertySupplier.of());
+             DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
+            client.put(null, HelloTask.getDefaultInstance());
+            processLatch.await();
+        }
+
+        List<Meter> meters = Metrics.registry().getMeters();
+        assertEquals(emptyList(), meters);
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -66,20 +66,19 @@ public class Metrics {
         }
 
         <T extends Meter> T meter(Supplier<T> ctor) {
-            final T meter;
             synchronized (meterRefCounts) {
-                meter = ctor.get();
+                T meter = ctor.get();
                 meterRefCounts.computeIfAbsent(meter.getId(), key -> new AtomicInteger())
                               .incrementAndGet();
+                meters.add(meter);
+                return meter;
             }
-            meters.add(meter);
-            return meter;
         }
 
         @Override
         public void close() {
-            for (Meter meter : meters) {
-                synchronized (meterRefCounts) {
+            synchronized (meterRefCounts) {
+                for (Meter meter : meters) {
                     Meter.Id id = meter.getId();
                     int count = meterRefCounts.get(id).decrementAndGet();
                     if (count == 0) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -18,7 +18,11 @@ package com.linecorp.decaton.processor.metrics;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
@@ -49,17 +53,25 @@ public class Metrics {
     }
 
     /**
-     * Superclass of all *Metrics classes just to implement {@link #close()} to cleanup
-     * metrics instances altogether.
+     * Superclass of all *Metrics classes managing lifecycle of meter instances.
+     * This class implements refcounting for meters identified by {@link Meter.Id} and make sure to remove
+     * the instance from {@link MeterRegistry} when the last reference to the meter closed and disappeared.
      */
     abstract static class AbstractMetrics implements AutoCloseable {
+        private static final Map<Meter.Id, AtomicInteger> meterRefCounts = new HashMap<>();
         private final List<Meter> meters;
 
         protected AbstractMetrics() {
             meters = new ArrayList<>();
         }
 
-        <T extends Meter> T meter(T meter) {
+        <T extends Meter> T meter(Supplier<T> ctor) {
+            final T meter;
+            synchronized (meterRefCounts) {
+                meter = ctor.get();
+                meterRefCounts.computeIfAbsent(meter.getId(), key -> new AtomicInteger())
+                              .incrementAndGet();
+            }
             meters.add(meter);
             return meter;
         }
@@ -67,21 +79,28 @@ public class Metrics {
         @Override
         public void close() {
             for (Meter meter : meters) {
-                registry.remove(meter);
                 meter.close();
+                synchronized (meterRefCounts) {
+                    Meter.Id id = meter.getId();
+                    int count = meterRefCounts.get(id).decrementAndGet();
+                    if (count == 0) {
+                        meterRefCounts.remove(id);
+                        registry.remove(meter);
+                    }
+                }
             }
         }
     }
 
     public class SubscriptionMetrics extends AbstractMetrics {
         private Timer processDuration(String section) {
-            return meter(Timer.builder("subscription.process.durations")
-                              .description(String.format(
-                                      "Time spent for processing %s in consuming loop", section))
-                              .tags(availableTags.subscriptionScope().and("section", section))
-                              .distributionStatisticExpiry(Duration.ofSeconds(60))
-                              .publishPercentiles(0.5, 0.9, 0.99, 0.999)
-                              .register(registry));
+            return meter(() -> Timer.builder("subscription.process.durations")
+                                    .description(String.format(
+                                            "Time spent for processing %s in consuming loop", section))
+                                    .tags(availableTags.subscriptionScope().and("section", section))
+                                    .distributionStatisticExpiry(Duration.ofSeconds(60))
+                                    .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                                    .register(registry));
         }
 
         public final Timer consumerPollTime = processDuration("poll");
@@ -97,111 +116,112 @@ public class Metrics {
 
     public class TaskMetrics extends AbstractMetrics {
         public final Counter tasksProcessed =
-                meter(Counter.builder("tasks.processed")
-                             .description("The number of tasks processed")
-                             .tags(availableTags.partitionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("tasks.processed")
+                                   .description("The number of tasks processed")
+                                   .tags(availableTags.partitionScope())
+                                   .register(registry));
 
         public final Counter tasksDiscarded =
-                meter(Counter.builder("tasks.discarded")
-                             .description("The number of tasks discarded")
-                             .tags(availableTags.partitionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("tasks.discarded")
+                                   .description("The number of tasks discarded")
+                                   .tags(availableTags.partitionScope())
+                                   .register(registry));
 
         public final Counter tasksError =
-                meter(Counter.builder("tasks.error")
-                             .description("The number of tasks thrown exception by process")
-                             .tags(availableTags.partitionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("tasks.error")
+                                   .description("The number of tasks thrown exception by process")
+                                   .tags(availableTags.partitionScope())
+                                   .register(registry));
     }
 
     public class ProcessMetrics extends AbstractMetrics {
         public final Timer tasksCompleteDuration =
-                meter(Timer.builder("tasks.complete.duration")
-                           .description("Time of a task taken to be completed")
-                           .tags(availableTags.partitionScope())
-                           .distributionStatisticExpiry(Duration.ofSeconds(60))
-                           .publishPercentiles(0.5, 0.9, 0.99, 0.999)
-                           .register(registry));
+                meter(() -> Timer.builder("tasks.complete.duration")
+                                 .description("Time of a task taken to be completed")
+                                 .tags(availableTags.partitionScope())
+                                 .distributionStatisticExpiry(Duration.ofSeconds(60))
+                                 .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                                 .register(registry));
 
         public final Timer tasksProcessDuration =
-                meter(Timer.builder("tasks.process.duration")
-                           .description("The time a task taken to be processed")
-                           .tags(availableTags.partitionScope())
-                           .distributionStatisticExpiry(Duration.ofSeconds(60))
-                           .publishPercentiles(0.5, 0.9, 0.99, 0.999)
-                           .register(registry));
+                meter(() -> Timer.builder("tasks.process.duration")
+                                 .description("The time a task taken to be processed")
+                                 .tags(availableTags.partitionScope())
+                                 .distributionStatisticExpiry(Duration.ofSeconds(60))
+                                 .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                                 .register(registry));
     }
 
     public class ResourceUtilizationMetrics extends AbstractMetrics {
         public final Timer processorProcessedTime =
-                meter(Timer.builder("processor.processed.time")
-                           .description("The accumulated time the processor were processing tasks")
-                           .tags(availableTags.subpartitionScope())
-                           .register(registry));
+                meter(() -> Timer.builder("processor.processed.time")
+                                 .description("The accumulated time the processor were processing tasks")
+                                 .tags(availableTags.subpartitionScope())
+                                 .register(registry));
 
         public final Counter tasksQueued =
-                meter(Counter.builder("tasks.queued")
-                             .description("The number of tasks queued per sub partitions")
-                             .tags(availableTags.subpartitionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("tasks.queued")
+                                   .description("The number of tasks queued per sub partitions")
+                                   .tags(availableTags.subpartitionScope())
+                                   .register(registry));
     }
 
     public class PartitionStateMetrics extends AbstractMetrics {
         public final ValueGauge tasksPending =
-                meter(ValueGauge.builder("tasks.pending")
-                                .description("The number of pending tasks")
-                                .tags(availableTags.partitionScope())
-                                .register(registry));
+                meter(() -> ValueGauge.builder("tasks.pending")
+                                      .description("The number of pending tasks")
+                                      .tags(availableTags.partitionScope())
+                                      .register(registry));
 
         public final Timer queueStarvedTime =
-                meter(Timer.builder("partition.queue.starved.time")
-                           .description("Total duration of time the partition's queue was starving")
-                           .tags(availableTags.partitionScope())
-                           .register(registry));
+                meter(() -> Timer.builder("partition.queue.starved.time")
+                                 .description("Total duration of time the partition's queue was starving")
+                                 .tags(availableTags.partitionScope())
+                                 .register(registry));
 
         public final Timer partitionPausedTime =
-                meter(Timer.builder("partition.paused.time")
-                           .description(
-                                   "The accumulated time the partition paused awaiting pending tasks' completion")
-                           .tags(availableTags.partitionScope())
-                           .register(registry));
+                meter(() -> Timer.builder("partition.paused.time")
+                                 .description(
+                                         "The accumulated time the partition paused awaiting pending tasks' completion")
+                                 .tags(availableTags.partitionScope())
+                                 .register(registry));
 
         public final ValueGauge partitionsPaused =
-                meter(ValueGauge.builder("partitions.paused")
-                                .description("The number of partitions currently paused for back pressure")
-                                .tags(availableTags.topicScope())
-                                .register(registry));
+                meter(() -> ValueGauge.builder("partitions.paused")
+                                      .description(
+                                              "The number of partitions currently paused for back pressure")
+                                      .tags(availableTags.topicScope())
+                                      .register(registry));
     }
 
     public class SchedulerMetrics extends AbstractMetrics {
         public final Timer tasksSchedulingDelay =
-                meter(Timer.builder("tasks.scheduling.delay")
-                           .description("The time a task waiting for scheduled time")
-                           .tags(availableTags.partitionScope())
-                           .distributionStatisticExpiry(Duration.ofSeconds(60))
-                           .publishPercentiles(0.5, 0.9, 0.99, 0.999)
-                           .register(registry));
+                meter(() -> Timer.builder("tasks.scheduling.delay")
+                                 .description("The time a task waiting for scheduled time")
+                                 .tags(availableTags.partitionScope())
+                                 .distributionStatisticExpiry(Duration.ofSeconds(60))
+                                 .publishPercentiles(0.5, 0.9, 0.99, 0.999)
+                                 .register(registry));
 
         public final Timer partitionThrottledTime =
-                meter(Timer.builder("partition.throttled.time")
-                           .description("The accumulated time the partition throttled by rate limiter")
-                           .tags(availableTags.partitionScope())
-                           .register(registry));
+                meter(() -> Timer.builder("partition.throttled.time")
+                                 .description("The accumulated time the partition throttled by rate limiter")
+                                 .tags(availableTags.partitionScope())
+                                 .register(registry));
     }
 
     public class RetryMetrics extends AbstractMetrics {
         public final Counter retryQueuedTasks =
-                meter(Counter.builder("retry.queued.tasks")
-                             .description("The number of tasks queued to retry topic")
-                             .tags(availableTags.subscriptionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("retry.queued.tasks")
+                                   .description("The number of tasks queued to retry topic")
+                                   .tags(availableTags.subscriptionScope())
+                                   .register(registry));
 
         public final Counter retryQueueingFailed =
-                meter(Counter.builder("retry.queueing.failed")
-                             .description("The number of tasks failed to enqueue in retry topic")
-                             .tags(availableTags.subscriptionScope())
-                             .register(registry));
+                meter(() -> Counter.builder("retry.queueing.failed")
+                                   .description("The number of tasks failed to enqueue in retry topic")
+                                   .tags(availableTags.subscriptionScope())
+                                   .register(registry));
     }
 
     public static Metrics withTags(String... keyValues) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -79,13 +79,13 @@ public class Metrics {
         @Override
         public void close() {
             for (Meter meter : meters) {
-                meter.close();
                 synchronized (meterRefCounts) {
                     Meter.Id id = meter.getId();
                     int count = meterRefCounts.get(id).decrementAndGet();
                     if (count == 0) {
                         meterRefCounts.remove(id);
                         registry.remove(meter);
+                        meter.close();
                     }
                 }
             }

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/ValueGauge.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/ValueGauge.java
@@ -88,10 +88,10 @@ public class ValueGauge implements Meter {
         public ValueGauge register(MeterRegistry registry) {
             AtomicInteger underlying = new AtomicInteger(0);
             Gauge gauge = Gauge.builder(name, underlying::get)
-                                  .description(description)
-                                  .baseUnit(baseUnit)
-                                  .tags(tags)
-                                  .register(registry);
+                               .description(description)
+                               .baseUnit(baseUnit)
+                               .tags(tags)
+                               .register(registry);
             return new ValueGauge(gauge, underlying);
         }
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/ValueGauge.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/ValueGauge.java
@@ -19,6 +19,8 @@ package com.linecorp.decaton.processor.metrics;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +35,13 @@ import lombok.experimental.Accessors;
  * <p>The reason why we introduce this class against 'heisen-gauge' principle is, once we adopt heisen-gauge
  * we have to maintain a lot of concurrent-access aware fields which might be a bit risky to take just for the metrics.
  */
-public class ValueGauge {
+public class ValueGauge implements Meter {
+    private final Gauge gauge;
     private final AtomicInteger underlying;
 
-    private ValueGauge(AtomicInteger value) {
-        this.underlying = value;
+    private ValueGauge(Gauge gauge, AtomicInteger underlying) {
+        this.gauge = gauge;
+        this.underlying = underlying;
     }
 
     public void increment() {
@@ -56,6 +60,21 @@ public class ValueGauge {
         return new Builder(name);
     }
 
+    @Override
+    public Id getId() {
+        return gauge.getId();
+    }
+
+    @Override
+    public Iterable<Measurement> measure() {
+        return gauge.measure();
+    }
+
+    @Override
+    public void close() {
+        gauge.close();
+    }
+
     @Setter
     @Accessors(fluent = true, chain = true)
     @RequiredArgsConstructor
@@ -68,12 +87,12 @@ public class ValueGauge {
 
         public ValueGauge register(MeterRegistry registry) {
             AtomicInteger underlying = new AtomicInteger(0);
-            Gauge.builder(name, underlying::get)
-                 .description(description)
-                 .baseUnit(baseUnit)
-                 .tags(tags)
-                 .register(registry);
-            return new ValueGauge(underlying);
+            Gauge gauge = Gauge.builder(name, underlying::get)
+                                  .description(description)
+                                  .baseUnit(baseUnit)
+                                  .tags(tags)
+                                  .register(registry);
+            return new ValueGauge(gauge, underlying);
         }
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/DecatonTaskRetryQueueingProcessor.java
@@ -77,5 +77,6 @@ class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[]> {
     @Override
     public void close() throws Exception {
         producer.close();
+        metrics.close();
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ExecutionScheduler.java
@@ -103,5 +103,6 @@ public class ExecutionScheduler implements AutoCloseable {
     @Override
     public void close() {
         terminateLatch.countDown();
+        metrics.close();
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
@@ -104,6 +104,7 @@ public class PartitionContext {
     public void destroyProcessors() throws Exception {
         partitionProcessor.close();
         processors.destroyPartitionScope(scope.subscriptionId(), scope.topicPartition());
+        metrics.close();
     }
 
     public boolean isOffsetRegressing(long offset) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
@@ -151,5 +151,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
     public void close() {
         terminated = true;
         scheduler.close();
+        processMetrics.close();
+        taskMetrics.close();
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -335,6 +335,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
     @Override
     public void awaitShutdown() throws InterruptedException {
         join();
+        metrics.close();
         logger.info("Subscription thread terminated: {}", getName());
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
@@ -89,5 +89,6 @@ public class ProcessorUnit implements AsyncShutdownable {
     @Override
     public void awaitShutdown() throws InterruptedException {
         executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+        metrics.close();
     }
 }

--- a/processor/src/test/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.metrics;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.linecorp.decaton.processor.metrics.Metrics.SchedulerMetrics;
+
+import io.micrometer.core.instrument.Meter;
+
+public class MetricsTest {
+
+    private static Set<Meter.Id> registeredIds() {
+        return Metrics.registry().getMeters().stream().map(Meter::getId).collect(toSet());
+    }
+
+    private static Set<Meter.Id> idSet(Meter.Id... ids) {
+        return new HashSet<>(Arrays.asList(ids));
+    }
+
+    @Test
+    public void testMetricsLifecycleManagement() {
+        String[] tags = {
+                "subscription", "abc",
+                "topic", "topic",
+                "partition", "1",
+        };
+        SchedulerMetrics m1 = Metrics.withTags(tags).new SchedulerMetrics();
+        SchedulerMetrics m2 = Metrics.withTags(tags).new SchedulerMetrics();
+        // Creating multiple instances with Metrics with same labels must leave only unique metrics
+        assertEquals(idSet(m1.partitionThrottledTime.getId(),
+                           m1.tasksSchedulingDelay.getId()),
+                     registeredIds());
+        m2.close();
+        // Closing one of them must not delete instances from registry yet
+        assertEquals(idSet(m1.partitionThrottledTime.getId(),
+                           m1.tasksSchedulingDelay.getId()),
+                     registeredIds());
+        m1.close();
+        // Closing all of them must clean up instances from registry
+        assertEquals(emptySet(), registeredIds());
+    }
+}


### PR DESCRIPTION
Currently once Decaton's internal metrics is created it never gets cleaned up. 
This is causing some metrics to leftover in scrape resulting making it very confusing to distinguish the value already became invalid by partition reassignment vs the currently active and value.
This PR ensures all metrics to cleanup at their corresponding scope's destruction time.

Also the micrometer dependency is upgraded to make the meter removal function work properly.