### PR TITLE
Follow-up document regarding breaking change for metric decaton.partitions.paused

### DIFF
--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -52,9 +52,10 @@ In such situation, extending partition concurrency might help to improve the thr
 |The quantile summary of the time of a task taken to be completed.
 This metric is basically same as `tasks.process.duration` unless you use asynchronous processing completion.
 
-|decaton.partitions.paused
-|The number of partitions currently paused for back pressure.
-If this value is greater than 0 constantly, it means that your processor's throughput is insufficient against incoming tasks.
+|decaton.partition.paused
+|Indicate whether the partition (identified by `partition` label) is currently paused by back pressure or not by 1 or 0 value.
+You can compute sum of all partitions on your monitoring system to tell how many partitions on an instance is currently paused.
+If your consumer experiences many pauses, it might be indicating that your processor's throughput is not sufficient compared to tasks inflow.
 |===
 
 == Kafka Client Metrics


### PR DESCRIPTION
Follow-up for #40 