### PR TITLE
Add taskstats support for benchmark module to get insight about each thread's behavior

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:8
+MAINTAINER Decaton Developers
+
+# Make profiler and taskstats cache
+COPY ./debm.sh /decaton/debm.sh
+RUN /decaton/debm.sh --profile --taskstats --dummy-option-to-fail || true
+
+WORKDIR /decaton
+CMD ./debm.sh

--- a/benchmark/debm.sh
+++ b/benchmark/debm.sh
@@ -3,6 +3,9 @@ set -e
 
 ASYNC_PROFILER_VERSION=1.7
 ASYNC_PROFILER_URL_BASE="https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNC_PROFILER_VERSION}"
+JTASKSTATS_VERSION=0.2.0
+JTASKSTATS_URL_BASE="https://github.com/kawamuray/jtaskstats/releases/download/v${JTASKSTATS_VERSION}"
+
 extra_opts=""
 classpath="$CLASSPATH:$(ls $(dirname $0)/build/libs/benchmark-*-shadow.jar | sort -nr | head -1)"
 
@@ -20,6 +23,25 @@ if [[ "$*" == *--profile* ]] && [[ "$*" != *--profiler-bin* ]] && ! which profil
         curl -L "$url" | tar zx -C $dir
     fi
     extra_opts="$extra_opts --profiler-bin=$dir/profiler.sh"
+fi
+
+if [[ "$*" == *--taskstats* ]] && [[ "$*" != *--taskstats-bin* ]] && ! which jtaskstats >/dev/null 2>&1; then
+    file="/tmp/jtaskstats-${JTASKSTATS_VERSION}"
+    if ! [ -e "$file" ]; then
+        case "$(uname -s)" in
+            Linux*)     platform=linux;;
+            *)          echo "jtaskstats supports only linux" >&2; exit 1;;
+        esac
+        url="$JTASKSTATS_URL_BASE/jtaskstats-x86_64-linux-musl-${JTASKSTATS_VERSION}.gz"
+        echo "Downloading jtaskstats from $url into $file" >&2
+        curl -L "$url" | gunzip -c >$file
+        chmod +x $file
+        if [ "$DEBM_SKIP_SETCAP" != "yes" ]; then
+            echo "Running 'sudo setcap cap_net_admin+ep $file' to grant required capability for jtaskstats" >&2
+            sudo setcap cap_net_admin+ep $file
+        fi
+    fi
+    extra_opts="$extra_opts --taskstats-bin=$file"
 fi
 
 exec java -XX:+UseG1GC -cp "$classpath" com.linecorp.decaton.benchmark.Main $extra_opts "$@"

--- a/benchmark/run-bm-docker.sh
+++ b/benchmark/run-bm-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+opts=""
+while [[ "$1" == '-'* ]]; do
+    opts="$opts $1"
+    shift
+done
+
+root_dir=$(cd $(dirname $0); pwd)
+exec docker run --rm \
+     --network host --cap-add NET_ADMIN --cap-add SYS_PTRACE  \
+     -e DEBM_SKIP_SETCAP=yes \
+     -v $root_dir:/decaton \
+     $opts \
+     decaton-benchmark:latest "$@"

--- a/benchmark/run-bm-docker.sh
+++ b/benchmark/run-bm-docker.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Usage:
+# $ ./run-bm-docker.sh ./debm.sh --title "xxx" --tasks 10000 ...
+
 opts=""
 while [[ "$1" == '-'* ]]; do
     opts="$opts $1"

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/AsyncProfilerProfiling.java
@@ -18,7 +18,6 @@ package com.linecorp.decaton.benchmark;
 
 import java.io.File;
 import java.lang.ProcessBuilder.Redirect;
-import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -54,13 +53,8 @@ public class AsyncProfilerProfiling implements Profiling {
         }
     }
 
-    private static long currentPid() {
-        String[] names = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
-        return Long.parseLong(names[0]);
-    }
-
     private static String outputFileName() {
-        return "profile-" + currentPid() + ".svg";
+        return "profile-" + JvmUtils.currentPid() + ".svg";
     }
 
     private void exec(String subCommand) {
@@ -68,7 +62,7 @@ public class AsyncProfilerProfiling implements Profiling {
         cmd.add(asyncProfilerBin.toString());
         cmd.addAll(asyncProfilerOpts);
         cmd.add(subCommand);
-        cmd.add(String.valueOf(currentPid()));
+        cmd.add(String.valueOf(JvmUtils.currentPid()));
         try {
             Process process = new ProcessBuilder(cmd)
                     .redirectOutput(new File("/dev/stderr"))

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -70,10 +70,21 @@ public class BenchmarkConfig {
      * Whether to run benchmark in forked JVM or within the same JVM.
      */
     boolean forking;
+    /**
+     * Taskstats config is optional and might be null.
+     */
+    TaskStatsConfig taskstats;
 
     @Value
     public static class ProfilingConfig {
         Path profilerBin;
         List<String> profilerOpts;
+    }
+    @Value
+    public static class TaskStatsConfig {
+        /**
+         * jtaskstats binary path (available only at Linux machines) that is optional and might be null.
+         */
+        Path jtaskstatsBin;
     }
 }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
@@ -118,8 +118,9 @@ public class BenchmarkResult {
 
     @Value
     public static class ExtraInfo {
-        public static final ExtraInfo EMPTY = new ExtraInfo(null);
+        public static final ExtraInfo EMPTY = new ExtraInfo(null, null);
         String profilerOutput;
+        String taskstatsOutput;
     }
 
     Performance performance;
@@ -140,6 +141,9 @@ public class BenchmarkResult {
         if (extraInfo != null) {
             if (extraInfo.profilerOutput != null) {
                 pw.printf("# Profiler Output: %s\n", extraInfo.profilerOutput);
+            }
+            if (extraInfo.taskstatsOutput != null) {
+                pw.printf("# Taskstats Output: %s\n", extraInfo.taskstatsOutput);
             }
         }
 

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/JvmUtils.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/JvmUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.lang.management.ManagementFactory;
+
+public final class JvmUtils {
+    private JvmUtils() {}
+
+    /**
+     * Get current process's PID.
+     * @return pid of the running JVM.
+     */
+    public static long currentPid() {
+        String[] names = ManagementFactory.getRuntimeMXBean().getName().split("@", 2);
+        return Long.parseLong(names[0]);
+    }
+
+    /**
+     * Detect operating system is Linux or else.
+     * @return true if the operating system is Linux, false otherwise.
+     */
+    public static boolean isOsLinux() {
+        String osName = System.getProperty("os.name");
+        if (osName == null) {
+            throw new RuntimeException("system property os.name isn't available");
+        }
+        return osName.startsWith("Linux");
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -28,6 +28,7 @@ import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
 
 import com.linecorp.decaton.benchmark.BenchmarkConfig.ProfilingConfig;
+import com.linecorp.decaton.benchmark.BenchmarkConfig.TaskStatsConfig;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -76,6 +77,12 @@ public final class Main implements Callable<Integer> {
     @Option(names = "--profiler-opts", description = "Options to pass for async-profiler's profiler.sh")
     private String profilerOpts;
 
+    @Option(names = "--taskstats", description = "Enable taskstats metric for the execution")
+    private boolean enableTaskstats;
+
+    @Option(names = "--taskstats-bin", description = "Path to jtaskstats", defaultValue = "jtaskstats")
+    private Path jtaskstatsBin;
+
     private static List<String> parseOptions(String opts) {
         if (opts == null) {
             return emptyList();
@@ -95,6 +102,10 @@ public final class Main implements Callable<Integer> {
         if (enableProfiling) {
             profiling = new ProfilingConfig(profilerBin, parseOptions(profilerOpts));
         }
+        BenchmarkConfig.TaskStatsConfig taskstats = null;
+        if (enableTaskstats) {
+            taskstats = new TaskStatsConfig(jtaskstatsBin);
+        }
         BenchmarkConfig config =
                 BenchmarkConfig.builder()
                                .title(title)
@@ -107,6 +118,7 @@ public final class Main implements Callable<Integer> {
                                .skipWaitingJIT(skipWaitingJIT)
                                .profiling(profiling)
                                .forking(true)
+                               .taskstats(taskstats)
                                .build();
         Benchmark benchmark = new Benchmark(config);
         BenchmarkResult result = benchmark.run();

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Taskstats.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Taskstats.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.lang.ProcessBuilder.Redirect;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Taskstats {
+    public static final Taskstats NOOP = new Taskstats(null);
+
+    private final Path jtaskstatsBin;
+
+    public Taskstats(Path jtaskstatsBin) {
+        this.jtaskstatsBin = jtaskstatsBin;
+    }
+
+    private static String outputFileName() {
+        return "taskstats-" + JvmUtils.currentPid();
+    }
+
+    /**
+     * Report taskstats of all java threads in the target JVM and return the path to the file
+     * containing the output.
+     * @return path to the file containing output.
+     */
+    public Optional<Path> reportStats() {
+        if (jtaskstatsBin == null) {
+            return Optional.empty();
+        }
+
+        String[] cmd = {
+                jtaskstatsBin.toString(),
+                String.valueOf(JvmUtils.currentPid())
+        };
+        Path output = Paths.get(outputFileName());
+        try {
+            Process process = new ProcessBuilder(cmd)
+                    .redirectOutput(output.toFile())
+                    .redirectError(Redirect.INHERIT)
+                    .start();
+            if (process.waitFor() != 0) {
+                throw new RuntimeException("jtaskstats exits with error: " + process.exitValue());
+            }
+        } catch (Exception e) {
+            log.error("Failed to run jtaskstats command: {}", cmd, e);
+            throw new RuntimeException(e);
+        }
+        return Optional.of(output);
+    }
+}


### PR DESCRIPTION
# Motivation

When I was investigating decaton's performance degaradation suspect regarding kafka-client upgrade (which was not the case though), I found that in addition to the profiling it's very helpful to have per-java thread activity information particularly, declay accounting of each tasks to distinguish whether the certain processing latency is due to wait such as I/O.
At that time I just used linux-dist supplied "getdelays.c" program with manual thread-task mapping but I made it much sophisticated and usable for jvm threads by https://github.com/kawamuray/jtaskstats and now attempting to integrate it into decaton's benchmark module.

This PR adds `--taskstats` and `--taskstats-bin` option to benchmark module to enable taskstats recording for the threads of JVM at the end of benchmark execution.

# Sample output
```
                                Task                                |  utime  |  stime  |    rss    |    vmem     |   read   | write  |    d:cpu    |   d:bio   | d:swap | d:reclaim 
 183 Thread 1 - main                                                | 1548000 | 1486000 | 133199517 |  8508932585 | 20465664 |   4096 |  1015070636 | 289685400 |      0 |         0 
 193 Thread 2 - Reference Handler                                   |    3000 |    1000 |    217679 |    11396523 |        0 |      0 |    18850513 |         0 |      0 |         0 
 194 Thread 3 - Finalizer                                           |    9000 |    4000 |    636425 |    37004468 |        0 |      0 |    23316256 |         0 |      0 |         0 
 195 Thread 4 - Surrogate Locker Thread (Concurrent GC)             |       0 |    1000 |    128199 |     2951324 |        0 |      0 |      709024 |         0 |      0 |         0 
 196 Thread 5 - Signal Dispatcher                                   |       0 |       0 |         0 |           0 |        0 |      0 |     2214877 |         0 |      0 |         0 
 204 Thread 9 - DecatonSubscriptionThread-decaton-benchmark         | 3306000 | 3288000 | 631455699 | 19159557294 | 14995456 | 112640 | 13270728132 | 191758100 |      0 |         0 
 205 Thread 11 - kafka-coordinator-hear...hread | decaton-benchmark |  294000 |  478000 |  78531401 |  2256268218 |   684032 |   7168 |  1081045410 |         0 |      0 |         0 
 208 Thread 12 - PartitionProcessorThre...2e0-b120-484265280e01-1-0 |   22000 |   31000 |   5568261 |   154490542 |    33792 |      0 |   314683683 |  27254300 |      0 |         0 
 209 Thread 13 - PartitionProcessorThre...2e0-b120-484265280e01-1-1 |   22000 |   31000 |   5702976 |   154960472 |        0 |      0 |   312651846 |         0 |      0 |         0 
 210 Thread 14 - PartitionProcessorThre...2e0-b120-484265280e01-1-2 |    8000 |   38000 |   5327851 |   134983796 |        0 |      0 |   220938991 |         0 |      0 |         0 
 211 Thread 15 - PartitionProcessorThre...2e0-b120-484265280e01-1-3 |   22000 |   36000 |   6476210 |   169842691 |     3072 |      0 |   375805774 |         0 |      0 |         0 
 212 Thread 16 - PartitionProcessorThre...2e0-b120-484265280e01-1-4 |   19000 |   30000 |   5415785 |   143642328 |        0 |      0 |   305531639 |         0 |      0 |         0 
 213 Thread 17 - PartitionProcessorThre...2e0-b120-484265280e01-1-5 |   18000 |   39000 |   6389132 |   167199281 |        0 |      0 |   336072260 |         0 |      0 |         0 
 214 Thread 18 - PartitionProcessorThre...2e0-b120-484265280e01-1-6 |   21000 |   33000 |   6177382 |   158346855 |     3072 |      0 |   226672490 |         0 |      0 |         0 
 215 Thread 19 - PartitionProcessorThre...2e0-b120-484265280e01-1-7 |   16000 |   37000 |   6173531 |   155745015 |        0 |      0 |   288567211 |         0 |      0 |         0 
 216 Thread 20 - PartitionProcessorThre...2e0-b120-484265280e01-1-8 |   19000 |   38000 |   6449773 |   167228828 |        0 |      0 |   306097892 |         0 |      0 |         0 
 217 Thread 21 - PartitionProcessorThre...2e0-b120-484265280e01-1-9 |   22000 |   45000 |   7360941 |   196116554 |    53248 |      0 |   314293689 |         0 |      0 |         0 
 218 Thread 22 - PartitionProcessorThre...e0-b120-484265280e01-1-10 |   27000 |   41000 |   7368663 |   198717382 |    65536 |      0 |   350077935 |         0 |      0 |         0 
 219 Thread 23 - PartitionProcessorThre...e0-b120-484265280e01-1-11 |   22000 |   30000 |   5820847 |   152612714 |        0 |      0 |   284143515 |         0 |      0 |         0 
 220 Thread 24 - PartitionProcessorThre...e0-b120-484265280e01-1-12 |   16000 |   48000 |   7049648 |   187692902 |        0 |      0 |   307241172 |         0 |      0 |         0 
 221 Thread 25 - PartitionProcessorThre...e0-b120-484265280e01-1-13 |   28000 |   36000 |   7299847 |   187952910 |        0 |      0 |   282594320 |         0 |      0 |         0 
 222 Thread 26 - PartitionProcessorThre...e0-b120-484265280e01-1-14 |   22000 |   40000 |   6821574 |   181494589 |    17408 |      0 |   257832096 |         0 |      0 |         0 
 223 Thread 27 - PartitionProcessorThre...e0-b120-484265280e01-1-15 |   25000 |   38000 |   6918281 |   184725507 |        0 |      0 |   320362396 |         0 |      0 |         0 
 224 Thread 28 - PartitionProcessorThre...e0-b120-484265280e01-1-16 |   23000 |   33000 |   6216613 |   164111718 |        0 |      0 |   412529264 |         0 |      0 |         0 
 225 Thread 29 - PartitionProcessorThre...e0-b120-484265280e01-1-17 |   25000 |   38000 |   6808144 |   184579808 |    23552 |      0 |   421818386 |         0 |      0 |         0 
 226 Thread 30 - PartitionProcessorThre...e0-b120-484265280e01-1-18 |   17000 |   25000 |   4741417 |   123258386 |        0 |      0 |   218424272 |  27443100 |      0 |         0 
```