### PR TITLE
Add integration tests to check core functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ allprojects {
         micrometerVersion = "1.5.1"
         lombokVersion = "1.18.4"
         junitVersion = "4.12"
+        hamcrestVersion = "1.3"
 
         isReleaseVersion = !version.endsWith('-SNAPSHOT')
     }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     testCompile project(":protobuf")
 
     itCompile "junit:junit:$junitVersion"
-    itCompile "org.hamcrest:hamcrest-all:1.3"
     itCompile project(":protobuf")
     itCompile project(":testing")
     itCompile project(":benchmark")

--- a/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
@@ -24,7 +24,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.linecorp.decaton.testing.KafkaClusterRule;
-import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
 
 public class CoreFunctionalityTest {
@@ -64,12 +63,6 @@ public class CoreFunctionalityTest {
                         }
                     });
                 }))
-                // If task is completed asynchronously there's no guarantee about
-                // completion ordering nor serial processing
-                .excludeSemantics(
-                        GuaranteeType.PROCESS_ORDERING,
-                        GuaranteeType.SERIAL_PROCESSING
-                )
                 .build()
                 .run();
     }

--- a/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.linecorp.decaton.processor.runtime.ProcessorScope;
 import com.linecorp.decaton.testing.KafkaClusterRule;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
 
@@ -38,6 +39,34 @@ public class CoreFunctionalityTest {
                     // adding some random delay to simulate realistic usage
                     Thread.sleep(ThreadLocalRandom.current().nextLong(10L));
                 }))
+                .propertySupplier(StaticPropertySupplier.of(
+                        Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
+                ))
+                .build()
+                .run();
+    }
+
+    @Test(timeout = 30000)
+    public void testProcessConcurrent_PartitionScopeProcessor() {
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess(() -> (ctx, task) -> {
+                    Thread.sleep(ThreadLocalRandom.current().nextLong(10L));
+                }, ProcessorScope.PARTITION))
+                .propertySupplier(StaticPropertySupplier.of(
+                        Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
+                ))
+                .build()
+                .run();
+    }
+
+    @Test(timeout = 30000)
+    public void testProcessConcurrent_ThreadScopeProcessor() {
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess(() -> (ctx, task) -> {
+                    Thread.sleep(ThreadLocalRandom.current().nextLong(10L));
+                }, ProcessorScope.THREAD))
                 .propertySupplier(StaticPropertySupplier.of(
                         Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
                 ))

--- a/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+
+public class CoreFunctionalityTest {
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+
+    @Test(timeout = 30000)
+    public void testProcessConcurrent() {
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
+                    // adding some pseudo random delay to generate out-of-order completion
+                    Thread.sleep(Math.abs(task.hashCode()) % 10);
+                }))
+                .propertySupplier(StaticPropertySupplier.of(
+                        Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
+                ))
+                .build()
+                .run();
+    }
+
+    @Test(timeout = 30000)
+    public void testAsyncTaskCompletion() {
+        ExecutorService executorService = Executors.newFixedThreadPool(16);
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
+                    DeferredCompletion completion = ctx.deferCompletion();
+                    CompletableFuture.runAsync(() -> {
+                        try {
+                            Thread.sleep(Math.abs(task.hashCode()) % 10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(e);
+                        } finally {
+                            completion.complete();
+                        }
+                    }, executorService);
+                }))
+                // If task is completed asynchronously there's no guarantee about
+                // completion ordering nor serial processing
+                .semantics(EnumSet.of(
+                        GuaranteeType.AT_LEAST_ONCE_DELIVERY
+                ))
+                .build()
+                .run();
+    }
+}

--- a/processor/src/it/java/com/linecorp/decaton/processor/MetricsTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/MetricsTest.java
@@ -123,17 +123,12 @@ public class MetricsTest {
 
             // Wait in loop until the total pause count becomes the number of partitions.
             // Fail by test timeout if it doesn't.
-            while (true) {
-                long pausedCount = (long) Metrics.registry()
-                                                 .find("decaton.partition.paused")
-                                                 .tags("topic", topicName)
-                                                 .gauges().stream()
-                                                 .mapToDouble(Gauge::value).sum();
-                if (pausedCount == PARTITIONS) {
-                    break;
-                }
-                Thread.sleep(100);
-            }
+            TestUtils.awaitCondition("total pause count should becomes " + PARTITIONS,
+                                     () -> (long) Metrics.registry()
+                                                         .find("decaton.partition.paused")
+                                                         .tags("topic", topicName)
+                                                         .gauges().stream()
+                                                         .mapToDouble(Gauge::value).sum() == PARTITIONS);
         }
     }
 }

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -16,82 +16,86 @@
 
 package com.linecorp.decaton.processor;
 
-import static org.junit.Assert.assertEquals;
-
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.decaton.client.DecatonClient;
-import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
-import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
-import com.linecorp.decaton.protocol.Sample.HelloTask;
 import com.linecorp.decaton.testing.KafkaClusterRule;
 import com.linecorp.decaton.testing.TestUtils;
+import com.linecorp.decaton.testing.processor.ProcessedRecord;
+import com.linecorp.decaton.testing.processor.ProcessingGuarantee;
+import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+import com.linecorp.decaton.testing.processor.ProducedRecord;
 
 public class RetryQueueingTest {
     @ClassRule
     public static KafkaClusterRule rule = new KafkaClusterRule();
 
-    private String topicName;
-    private String retryTopicName;
+    private String retryTopic;
 
     @Before
     public void setUp() {
-        topicName = rule.admin().createRandomTopic(3, 3);
-        retryTopicName = topicName + "-retry";
-        rule.admin().createTopic(retryTopicName, 3, 3);
+        retryTopic = rule.admin().createRandomTopic(3, 3);
     }
 
     @After
     public void tearDown() {
-        rule.admin().deleteTopics(topicName, retryTopicName);
+        rule.admin().deleteTopics(retryTopic);
+    }
+
+    private static class ProcessRetriedTask implements ProcessingGuarantee {
+        private final Set<String> producedIds = Collections.synchronizedSet(new HashSet<>());
+        private final Set<String> processedIds = Collections.synchronizedSet(new HashSet<>());
+
+        @Override
+        public void onProduce(ProducedRecord record) {
+            producedIds.add(record.task().getId());
+        }
+
+        @Override
+        public void onProcess(TaskMetadata metadata, ProcessedRecord record) {
+            if (metadata.retryCount() > 0) {
+                processedIds.add(record.task().getId());
+            }
+        }
+
+        @Override
+        public void doAssert() {
+            TestUtils.awaitCondition("all retried tasks must be processed",
+                                     () -> producedIds.size() == processedIds.size());
+        }
     }
 
     @Test(timeout = 30000)
     public void testRetryQueuing() throws Exception {
-        Set<String> keys = new HashSet<>();
-
         // scenario:
-        //   * produce 10000 tasks.
-        //   * all tasks will be retried once, and processed after retried
-        for (int i = 0; i < 10000; i++) {
-            keys.add("key" + i);
-        }
-        Set<String> processedKeys = Collections.synchronizedSet(new HashSet<>());
-        CountDownLatch processLatch = new CountDownLatch(keys.size());
-
-        DecatonProcessor<HelloTask> processor = (context, task) -> {
-            String key = context.key();
-
-            if (context.metadata().retryCount() == 0) {
-                context.retry();
-            } else {
-                processedKeys.add(key);
-                processLatch.countDown();
-            }
-        };
-
-        try (ProcessorSubscription subscription = TestUtils.subscription(
-                rule.bootstrapServers(),
-                ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
-                                 .thenProcess(processor),
-                RetryConfig.withBackoff(Duration.ofMillis(10)),
-                null);
-             DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
-
-            keys.forEach(key -> client.put(key, HelloTask.getDefaultInstance()));
-            processLatch.await();
-        }
-
-        assertEquals(10000, processedKeys.size());
+        //   * all arrived tasks are retried once
+        //   * after retried (i.e. retryCount() > 0), no more retry
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
+                    if (ctx.metadata().retryCount() == 0) {
+                        ctx.retry();
+                    }
+                }))
+                .retryConfig(RetryConfig.builder()
+                                        .retryTopic(retryTopic)
+                                        .backoff(Duration.ofMillis(10))
+                                        .build())
+                // If we retry tasks, there's no guarantee about ordering nor serial processing
+                .excludeSemantics(
+                        GuaranteeType.PROCESS_ORDERING,
+                        GuaranteeType.SERIAL_PROCESSING)
+                .customSemantics(new ProcessRetriedTask())
+                .build()
+                .run();
     }
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -31,7 +31,7 @@ dependencies {
         exclude group: 'log4j', module: 'log4j'
     }
     implementation "junit:junit:$junitVersion"
-    implementation "org.hamcrest:hamcrest-all:1.3"
+    implementation "org.hamcrest:hamcrest-all:$hamcrestVersion"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -31,6 +31,7 @@ dependencies {
         exclude group: 'log4j', module: 'log4j'
     }
     implementation "junit:junit:$junitVersion"
+    implementation "org.hamcrest:hamcrest-all:1.3"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/testing/src/main/java/com/linecorp/decaton/testing/KafkaAdmin.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/KafkaAdmin.java
@@ -18,12 +18,15 @@ package com.linecorp.decaton.testing;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * A wrapper of {@link AdminClient} for providing easy operation to manage topics
@@ -62,6 +65,14 @@ public class KafkaAdmin implements AutoCloseable {
     public void deleteTopics(String... topicNames) {
         try {
             adminClient.deleteTopics(Arrays.asList(topicNames)).all().get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Map<TopicPartition, OffsetAndMetadata> consumerGroupOffsets(String groupId) {
+        try {
+            return adminClient.listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata().get();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testing/src/main/java/com/linecorp/decaton/testing/RandomRule.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/RandomRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing;
+
+import java.util.Random;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Test rule to provide {@link Random} instance with including
+ * random seed info in error message for reproducibility
+ */
+public class RandomRule implements TestRule {
+    @Getter
+    @Accessors(fluent = true)
+    private Random random;
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                long seed = System.currentTimeMillis();
+                random = new Random(seed);
+
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    throw new Exception(String.format("%s failed. [randomSeed=%d]",
+                                                      description.getDisplayName(),
+                                                      seed), t);
+                }
+            }
+        };
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
@@ -107,8 +107,8 @@ public class TestUtils {
     }
 
     /**
-     * A helper to instantiate {@link ProcessorSubscription} with preset configuration
-     * with unique subscription id assigned
+     * A helper to instantiate {@link ProcessorSubscription} with preset configurations
+     * and unique subscription id assigned
      *
      * @param bootstrapServers bootstrap servers to connect
      * @param processorsBuilder actual processing logic. This parameter is mandatory
@@ -129,8 +129,8 @@ public class TestUtils {
     }
 
     /**
-     * A helper to instantiate {@link ProcessorSubscription} with preset configuration.
-     * This method returns after a subscription has been transitioned to {@link State#RUNNING}.
+     * A helper to instantiate {@link ProcessorSubscription} with preset configurations.
+     * This method returns after a subscription has been transitioned to {@link State#RUNNING} state.
      *
      * @param subscriptionId subscription id of the instance
      * @param bootstrapServers bootstrap servers to connect
@@ -177,7 +177,7 @@ public class TestUtils {
     }
 
     /**
-     * Wait for a condition to be met indefinitely
+     * Wait indefinitely for a condition to be met
      * @param message assertion message
      * @param condition expected condition to be met
      */

--- a/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
@@ -19,12 +19,19 @@ package com.linecorp.decaton.testing;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import com.google.protobuf.MessageLite;
 
 import com.linecorp.decaton.client.DecatonClient;
+import com.linecorp.decaton.client.kafka.PrintableAsciiStringSerializer;
+import com.linecorp.decaton.client.kafka.ProtocolBuffersKafkaSerializer;
+import com.linecorp.decaton.common.Serializer;
 import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.PropertySupplier;
 import com.linecorp.decaton.processor.SubscriptionStateListener.State;
@@ -32,6 +39,7 @@ import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersSerializer;
+import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 
 public class TestUtils {
     private static final AtomicInteger sequence = new AtomicInteger(0);
@@ -41,16 +49,37 @@ public class TestUtils {
         return sequence.getAndIncrement();
     }
 
-    public static <T extends MessageLite> DecatonClient<T> client(String topic,
-                                                                  String bootstrapServers) {
+    private static Properties defaultProducerProps(String bootstrapServers) {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "test-client-" + sequence());
-        return DecatonClient.producing(topic, new ProtocolBuffersSerializer<T>())
+        props.setProperty(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1");
+        props.setProperty(ProducerConfig.ACKS_CONFIG, "all");
+        props.setProperty(ProducerConfig.LINGER_MS_CONFIG, "10");
+        return props;
+    }
+
+    public static final String DEFAULT_GROUP_ID = "test-group";
+
+    public static <T extends MessageLite> DecatonClient<T> client(String topic,
+                                                                  String bootstrapServers) {
+        return client(topic, bootstrapServers, new ProtocolBuffersSerializer<>());
+    }
+
+    public static <T> DecatonClient<T> client(String topic,
+                                              String bootstrapServers,
+                                              Serializer<T> serializer) {
+        return DecatonClient.producing(topic, serializer)
                             .applicationId("test-application")
                             .instanceId("test-instance")
-                            .producerConfig(props)
+                            .producerConfig(defaultProducerProps(bootstrapServers))
                             .build();
+    }
+
+    public static Producer<String, DecatonTaskRequest> producer(String bootstrapServers) {
+        return new KafkaProducer<>(defaultProducerProps(bootstrapServers),
+                                   new PrintableAsciiStringSerializer(),
+                                   new ProtocolBuffersKafkaSerializer<>());
     }
 
     public static <T> ProcessorSubscription subscription(String bootstrapServers,
@@ -58,18 +87,19 @@ public class TestUtils {
                                                          RetryConfig retryConfig,
                                                          PropertySupplier propertySupplier) {
         Properties props = new Properties();
-        props.setProperty("bootstrap.servers", bootstrapServers);
-        props.setProperty("client.id", "test-processor-" + sequence());
-        props.setProperty("group.id", "test-group");
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "test-processor" + sequence());
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, DEFAULT_GROUP_ID);
+        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         CountDownLatch initializationLatch = new CountDownLatch(1);
         SubscriptionBuilder builder = SubscriptionBuilder.newBuilder("test-subscription")
-                                                                     .consumerConfig(props)
-                                                                     .processorsBuilder(processorsBuilder)
-                                                                     .stateListener(state -> {
-                                                                         if (state == State.RUNNING) {
-                                                                             initializationLatch.countDown();
-                                                                         }
-                                                                     });
+                                                         .consumerConfig(props)
+                                                         .processorsBuilder(processorsBuilder)
+                                                         .stateListener(state -> {
+                                                             if (state == State.RUNNING) {
+                                                                 initializationLatch.countDown();
+                                                             }
+                                                         });
         if (retryConfig != null) {
             builder.enableRetry(retryConfig);
         }
@@ -85,5 +115,30 @@ public class TestUtils {
             throw new RuntimeException(e);
         }
         return subscription;
+    }
+
+    public static void awaitCondition(String message,
+                                      Supplier<Boolean> condition) {
+        awaitCondition(message, condition, Long.MAX_VALUE);
+    }
+
+    public static void awaitCondition(String message,
+                                      Supplier<Boolean> condition,
+                                      long timeoutMillis) {
+        long t = System.currentTimeMillis();
+        while (!condition.get()) {
+            long now = System.currentTimeMillis();
+            timeoutMillis -= now - t;
+            t = now;
+            if (timeoutMillis <= 0) {
+                throw new AssertionError(message);
+            }
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.testing.processor;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -38,6 +39,8 @@ public class AtLeastOnceDelivery implements ProcessingGuarantee {
 
     @Override
     public void doAssert() {
+        assertEquals(producedIds.size(), processedIds.size());
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(producedIds.equals(processedIds));
     }
 }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AtLeastOnceDelivery implements ProcessingGuarantee {
+    private final Set<String> producedIds = Collections.synchronizedSet(new HashSet<>());
+    private final Set<String> processedIds = Collections.synchronizedSet(new HashSet<>());
+
+    @Override
+    public void onProduce(ProducedRecord record) {
+        producedIds.add(record.task().getId());
+    }
+
+    @Override
+    public void onProcess(ProcessedRecord record) {
+        processedIds.add(record.task().getId());
+    }
+
+    @Override
+    public void doAssert() {
+        assertTrue(producedIds.equals(processedIds));
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/AtLeastOnceDelivery.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.linecorp.decaton.processor.TaskMetadata;
+
 public class AtLeastOnceDelivery implements ProcessingGuarantee {
     private final Set<String> producedIds = Collections.synchronizedSet(new HashSet<>());
     private final Set<String> processedIds = Collections.synchronizedSet(new HashSet<>());
@@ -33,7 +35,7 @@ public class AtLeastOnceDelivery implements ProcessingGuarantee {
     }
 
     @Override
-    public void onProcess(ProcessedRecord record) {
+    public void onProcess(TaskMetadata metadata, ProcessedRecord record) {
         processedIds.add(record.task().getId());
     }
 

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessOrdering.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessOrdering.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.testing.processor;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-public class ReprocessAwareOrdering implements ProcessingGuarantee {
+public class ProcessOrdering implements ProcessingGuarantee {
     private final List<ProducedRecord> producedRecords =
             Collections.synchronizedList(new ArrayList<>());
     private final List<ProcessedRecord> processedRecords =
@@ -107,6 +108,8 @@ public class ReprocessAwareOrdering implements ProcessingGuarantee {
             currentOffset = offset;
         }
 
+        assertEquals(produced.size(), excludeReprocess.size());
+        //noinspection SimplifiableJUnitAssertion
         assertTrue(produced.equals(new ArrayList<>(excludeReprocess)));
     }
 }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessOrdering.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessOrdering.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.linecorp.decaton.processor.TaskMetadata;
+
 public class ProcessOrdering implements ProcessingGuarantee {
     private final Map<TestTask, Long> taskToOffset = new HashMap<>();
     private final Map<String, List<TestTask>> producedRecords = new HashMap<>();
@@ -42,7 +44,7 @@ public class ProcessOrdering implements ProcessingGuarantee {
     }
 
     @Override
-    public synchronized void onProcess(ProcessedRecord record) {
+    public synchronized void onProcess(TaskMetadata metadata, ProcessedRecord record) {
         processedRecords.computeIfAbsent(record.key(),
                                          key -> new ArrayList<>()).add(record.task());
     }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessedRecord.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessedRecord.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.decaton.testing.processor;
 
+import com.linecorp.decaton.processor.DecatonProcessor;
+
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -39,7 +41,7 @@ public class ProcessedRecord {
     long startTimeNanos;
 
     /**
-     * {@link System#nanoTime()} at the time when completed to process the task
+     * {@link System#nanoTime()} at the time when {@link DecatonProcessor#process} for the task returned
      */
-    long completeTimeNanos;
+    long endTimeNanos;
 }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessedRecord.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessedRecord.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * A class which holds processed task along with processing time
+ */
+@Value
+@Accessors(fluent = true)
+public class ProcessedRecord {
+    /**
+     * Key of the task
+     */
+    String key;
+    /**
+     * Processed task
+     */
+    TestTask task;
+    /**
+     * {@link System#nanoTime()} at the time when started to process the task
+     */
+    long startTimeNanos;
+
+    /**
+     * {@link System#nanoTime()} at the time when completed to process the task
+     */
+    long completeTimeNanos;
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
@@ -50,9 +50,9 @@ public interface ProcessingGuarantee {
          * Decaton doesn't wait all pending tasks till complete before rebalance (and it's a design choice)
          *
          * Hence, what Decaton guarantees for process ordering can be formulated as below:
-         * - if a task (offset:N) gets (re)processed, offset:N+M (M > 0) always gets processed
+         * - if a task (offset:N) gets (re)processed, offset:N+M (M ≥ 1) always gets processed
          *
-         * Additionally, it's also be checked that if a task is committed, the task and preceding tasks never be reprocessed.
+         * In addition, it's also be checked that if a task is committed, the task and preceding tasks never be reprocessed.
          *
          * Example:
          * <pre>

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import java.util.EnumSet;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+
+/**
+ * Interface for processing guarantee in Decaton stream-processing.
+ *
+ * Implementation classes should store produced records and processed records
+ * when {@link #onProduce(ProducedRecord)} and {@link #onProcess(ProcessedRecord)} are invoked respectively,
+ * and checks if the guarantee is met in {@link #doAssert()}
+ */
+public interface ProcessingGuarantee {
+    /**
+     * Default processing semantics Decaton provides
+     */
+    static EnumSet<GuaranteeType> defaultSemantics() {
+        return EnumSet.of(
+                GuaranteeType.AT_LEAST_ONCE_DELIVERY,
+                GuaranteeType.REPROCESS_AWARE_ORDERING,
+                GuaranteeType.SERIAL_PROCESSING);
+    }
+
+    enum GuaranteeType implements Supplier<ProcessingGuarantee> {
+        /**
+         * All produced messages are delivered and processed at least once.
+         */
+        AT_LEAST_ONCE_DELIVERY,
+        /**
+         * All messages are processed in same order as produced, allowing re-processing.
+         *
+         * Example:
+         * <pre>
+         * {@code
+         *   say produced offsets are: [1,2,3,4,5]
+         *   valid processing order:
+         *     - [1,2,3,4,5]
+         *     - [1,2,1,2,3,4,5]: when processor restarted right after processed 2 before committing offset 1
+         *     - [1,2,3,4,5,5]: when processor restarted right after processed 5 and committed 4 before committing offset 5
+         *   invalid processing order:
+         *     - [1,3,2,4,5] => gapping
+         *     - [1,2,3,4,5,4,3] => re-consuming from 4 implies offset 3 is committed. 3 cannot appear after processing 4
+         * }
+         * </pre>
+         */
+        REPROCESS_AWARE_ORDERING,
+        /**
+         * Tasks which have same key never be processed simultaneously
+         */
+        SERIAL_PROCESSING;
+
+        @Override
+        public ProcessingGuarantee get() {
+            switch (this) {
+                case AT_LEAST_ONCE_DELIVERY:
+                    return new AtLeastOnceDelivery();
+                case REPROCESS_AWARE_ORDERING:
+                    return new ReprocessAwareOrdering();
+                case SERIAL_PROCESSING:
+                    return new SerialProcessing();
+            }
+            throw new RuntimeException("Unreachable");
+        }
+    }
+
+    /**
+     * Called when a task is produced.
+     *
+     * Must be thread safe since this method will be called from {@link KafkaProducer}'s I/O thread
+     */
+    void onProduce(ProducedRecord record);
+
+    /**
+     * Called when a task has been completed to process.
+     *
+     * Must be thread safe since this method will be called from
+     * multiple threads of multiple {@link ProcessorSubscription}
+     */
+    void onProcess(ProcessedRecord record);
+
+    /**
+     * Checks if the processing guarantee is satisfied.
+     *
+     * Should throw {@link AssertionError} if the guarantee is not met
+     */
+    void doAssert();
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 
+import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 
 /**
@@ -96,7 +97,7 @@ public interface ProcessingGuarantee {
     void onProduce(ProducedRecord record);
 
     /**
-     * Called when a task has been completed to process.
+     * Called when {@link DecatonProcessor#process} returned from processing a task.
      *
      * Must be thread safe since this method will be called from
      * multiple threads of multiple {@link ProcessorSubscription}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessingGuarantee.java
@@ -21,13 +21,14 @@ import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 
 /**
  * Interface for processing guarantee in Decaton stream-processing.
  *
  * Implementation classes should store produced records and processed records
- * when {@link #onProduce(ProducedRecord)} and {@link #onProcess(ProcessedRecord)} are invoked respectively,
+ * when {@link #onProduce(ProducedRecord)} and {@link #onProcess(TaskMetadata, ProcessedRecord)} are invoked respectively,
  * and checks if the guarantee is met in {@link #doAssert()}
  */
 public interface ProcessingGuarantee {
@@ -102,7 +103,7 @@ public interface ProcessingGuarantee {
      * Must be thread safe since this method will be called from
      * multiple threads of multiple {@link ProcessorSubscription}
      */
-    void onProcess(ProcessedRecord record);
+    void onProcess(TaskMetadata metadata, ProcessedRecord record);
 
     /**
      * Checks if the processing guarantee is satisfied.

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -1,0 +1,268 @@
+package com.linecorp.decaton.testing.processor;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import com.google.protobuf.ByteString;
+
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.ProcessorsBuilder;
+import com.linecorp.decaton.processor.PropertySupplier;
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.RetryConfig;
+import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
+import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.TestUtils;
+import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
+import com.linecorp.decaton.testing.processor.TestTask.TestTaskDeserializer;
+import com.linecorp.decaton.testing.processor.TestTask.TestTaskSerializer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Test suite that checks Decaton's core functionality, especially for processing semantics.
+ *
+ * Test suite will perform following procedure:
+ *   1. Start multiple subscription instances
+ *   2. Produce tasks
+ *   3. When half of tasks are processed, restart subscriptions one by one
+ *   4. Await all produced offsets are committed
+ *   5. Assert processing semantics
+ *
+ * Expected semantics can be customized according to each test instance.
+ * (e.g. process ordering will be no longer kept if the processor uses retry-queueing feature)
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ProcessorTestSuite {
+    private final KafkaClusterRule rule;
+    private final Function<ProcessorsBuilder<TestTask>, ProcessorsBuilder<TestTask>> configureProcessorsBuilder;
+    private final RetryConfig retryConfig;
+    private final PropertySupplier propertySuppliers;
+    private final EnumSet<GuaranteeType> semantics;
+
+    private static final int NUM_TASKS = 10000;
+    private static final int NUM_KEYS = 100;
+    private static final int NUM_SUBSCRIPTION_INSTANCES = 3;
+    private static final int NUM_PARTITIONS = 8;
+
+    @Setter
+    @Accessors(fluent = true)
+    public static class Builder {
+        private final KafkaClusterRule rule;
+
+        /**
+         * Configure test-specific processing logic
+         */
+        private Function<ProcessorsBuilder<TestTask>, ProcessorsBuilder<TestTask>> configureProcessorsBuilder;
+        /**
+         * Configure retry-queueing feature for the subscription
+         */
+        private RetryConfig retryConfig;
+        /**
+         * Supply additional {@link ProcessorProperties} through {@link PropertySupplier}
+         */
+        private PropertySupplier propertySupplier;
+        /**
+         * Processing semantics the processor should satisfy
+         */
+        private EnumSet<GuaranteeType> semantics = ProcessingGuarantee.defaultSemantics();
+
+        private Builder(KafkaClusterRule rule) {
+            this.rule = rule;
+        }
+
+        public ProcessorTestSuite build() {
+            return new ProcessorTestSuite(rule,
+                                          configureProcessorsBuilder,
+                                          retryConfig,
+                                          propertySupplier,
+                                          semantics);
+        }
+    }
+
+    public static Builder builder(KafkaClusterRule rule) {
+        return new Builder(rule);
+    }
+
+    public void run() {
+        String topic = rule.admin().createRandomTopic(NUM_PARTITIONS, 3);
+        CountDownLatch rollingRestartLatch = new CountDownLatch(NUM_TASKS / 2);
+        List<ProcessingGuarantee> semantics = this.semantics.stream()
+                                                            .map(GuaranteeType::get)
+                                                            .collect(Collectors.toList());
+
+        DecatonProcessor<TestTask> preprocessor = (context, task) -> {
+            long startTime = System.nanoTime();
+            context.deferCompletion()
+                   .completeWith(context.push(task))
+                   .whenComplete((r, e) -> {
+                       semantics.forEach(
+                               g -> g.onProcess(new ProcessedRecord(context.key(),
+                                                                    task,
+                                                                    startTime,
+                                                                    System.nanoTime())));
+                   });
+            rollingRestartLatch.countDown();
+        };
+
+        Supplier<ProcessorSubscription> subscriptionSupplier = () -> {
+            ProcessorsBuilder<TestTask> processorsBuilder =
+                    configureProcessorsBuilder.apply(
+                            ProcessorsBuilder.consuming(topic, new TestTaskDeserializer())
+                                             .thenProcess(preprocessor));
+
+            return TestUtils.subscription(rule.bootstrapServers(),
+                                          processorsBuilder,
+                                          retryConfig,
+                                          propertySuppliers);
+        };
+
+        Producer<String, DecatonTaskRequest> producer = null;
+        ProcessorSubscription[] subscriptions = new ProcessorSubscription[NUM_SUBSCRIPTION_INSTANCES];
+        try {
+            producer = TestUtils.producer(rule.bootstrapServers());
+            for (int i = 0; i < subscriptions.length; i++) {
+                subscriptions[i] = subscriptionSupplier.get();
+            }
+            CompletableFuture<Map<Integer, Long>> produceFuture =
+                    produceTasks(producer, topic, record -> semantics.forEach(g -> g.onProduce(record)));
+
+            // perform rolling restart
+            rollingRestartLatch.await();
+            for (int i = 0; i < subscriptions.length; i++) {
+                log.info("Start restarting subscription-{} (threadId: {})", i, subscriptions[i].getId());
+                subscriptions[i].close();
+                subscriptions[i] = subscriptionSupplier.get();
+                log.info("Finished restarting subscription-{} (threadId: {})", i, subscriptions[i].getId());
+            }
+
+            // await all produced offsets are committed
+            Map<Integer, Long> producedOffsets = produceFuture.join();
+            TestUtils.awaitCondition("all produced offsets should be committed", () -> {
+                Map<TopicPartition, OffsetAndMetadata> committed =
+                        rule.admin().consumerGroupOffsets(TestUtils.DEFAULT_GROUP_ID);
+
+                for (Entry<Integer, Long> entry : producedOffsets.entrySet()) {
+                    int partition = entry.getKey();
+                    long produced = entry.getValue();
+
+                    OffsetAndMetadata metadata = committed.get(new TopicPartition(topic, partition));
+                    if (metadata == null || metadata.offset() <= produced) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+
+            for (int i = 0; i < subscriptions.length; i++) {
+                log.info("Closing subscription-{} (threadId: {})", i, subscriptions[i].getId());
+                subscriptions[i].close();
+            }
+
+            for (ProcessingGuarantee guarantee : semantics) {
+                guarantee.doAssert();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            safeClose(producer);
+            for (ProcessorSubscription subscription : subscriptions) {
+                if (subscription != null && subscription.isAlive()) {
+                    safeClose(subscription);
+                }
+            }
+            rule.admin().deleteTopics(topic);
+        }
+    }
+
+    private static void safeClose(AutoCloseable resource) {
+        try {
+            if (resource != null) {
+                resource.close();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to close the resource", e);
+        }
+    }
+
+    /**
+     * Generate and produce {@link #NUM_TASKS} tasks
+     * @param producer Producer instance to be used
+     * @param topic Topic to be sent tasks
+     * @param onProduce Callback which is called when a task is complete to be sent
+     * @return A CompletableFuture of Map, which holds partition as the key and max offset as the value
+     */
+    private static CompletableFuture<Map<Integer, Long>> produceTasks(
+            Producer<String, DecatonTaskRequest> producer,
+            String topic,
+            Consumer<ProducedRecord> onProduce) {
+        @SuppressWarnings("unchecked")
+        CompletableFuture<RecordMetadata>[] produceFutures = new CompletableFuture[NUM_TASKS];
+
+        TestTaskSerializer serializer = new TestTaskSerializer();
+        for (int i = 0; i < produceFutures.length; i++) {
+            TestTask task = new TestTask(String.valueOf(i));
+            String key = String.valueOf(i % NUM_KEYS);
+            TaskMetadataProto taskMetadata =
+                    TaskMetadataProto.newBuilder()
+                                     .setTimestampMillis(System.currentTimeMillis())
+                                     .setSourceApplicationId("test-application")
+                                     .setSourceInstanceId("test-instance")
+                                     .build();
+            DecatonTaskRequest request =
+                    DecatonTaskRequest.newBuilder()
+                                      .setMetadata(taskMetadata)
+                                      .setSerializedTask(ByteString.copyFrom(serializer.serialize(task)))
+                                      .build();
+            ProducerRecord<String, DecatonTaskRequest> record =
+                    new ProducerRecord<>(topic, null, taskMetadata.getTimestampMillis(), key, request);
+            CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+            produceFutures[i] = future;
+
+            producer.send(record, (metadata, exception) -> {
+                if (exception == null) {
+                    future.complete(metadata);
+                    onProduce.accept(new ProducedRecord(key,
+                                                        new TopicPartition(metadata.topic(), metadata.partition()),
+                                                        metadata.offset(),
+                                                        task));
+                } else {
+                    future.completeExceptionally(exception);
+                }
+            });
+        }
+
+        return CompletableFuture.allOf(produceFutures).thenApply(notUsed -> {
+            Map<Integer, Long> result = new HashMap<>();
+            for (CompletableFuture<RecordMetadata> future : produceFutures) {
+                RecordMetadata metadata = future.join();
+                long offset = result.getOrDefault(metadata.partition(), -1L);
+                if (offset < metadata.offset()) {
+                    result.put(metadata.partition(), metadata.offset());
+                }
+            }
+            return result;
+        });
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducedRecord.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducedRecord.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import org.apache.kafka.common.TopicPartition;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * A class which holds produced task along with produce metadata
+ */
+@Value
+@Accessors(fluent = true)
+public class ProducedRecord {
+    /**
+     * Key of the task
+     */
+    String key;
+    /**
+     * Topic partition the record was sent to
+     */
+    TopicPartition topicPartition;
+    /**
+     * Offset in the partition
+     */
+    long offset;
+    /**
+     * Produced task
+     */
+    TestTask task;
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ReprocessAwareOrdering.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ReprocessAwareOrdering.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class ReprocessAwareOrdering implements ProcessingGuarantee {
+    private final List<ProducedRecord> producedRecords =
+            Collections.synchronizedList(new ArrayList<>());
+    private final List<ProcessedRecord> processedRecords =
+            Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public void onProduce(ProducedRecord record) {
+        producedRecords.add(record);
+    }
+
+    @Override
+    public void onProcess(ProcessedRecord record) {
+        processedRecords.add(record);
+    }
+
+    @Override
+    public void doAssert() {
+        Map<String, List<TestTask>> perKeyProducedRecords = new HashMap<>();
+        Map<String, List<TestTask>> perKeyProcessedRecords = new HashMap<>();
+        Map<TestTask, Long> taskToOffset = new HashMap<>();
+
+        for (ProducedRecord record : producedRecords) {
+            taskToOffset.put(record.task(), record.offset());
+            perKeyProducedRecords.computeIfAbsent(record.key(),
+                                                  key -> new ArrayList<>()).add(record.task());
+        }
+
+        for (ProcessedRecord record : processedRecords) {
+            perKeyProcessedRecords.computeIfAbsent(record.key(),
+                                                   key -> new ArrayList<>()).add(record.task());
+        }
+
+        for (Entry<String, List<TestTask>> entry : perKeyProducedRecords.entrySet()) {
+            String key = entry.getKey();
+            List<TestTask> produced = entry.getValue();
+            List<TestTask> processed = perKeyProcessedRecords.get(key);
+
+            assertNotNull(processed);
+            assertOrdering(taskToOffset, produced, processed);
+        }
+    }
+
+    static void assertOrdering(Map<TestTask, Long> taskToOffset,
+                               List<TestTask> produced,
+                               List<TestTask> processed) {
+        Deque<TestTask> excludeReprocess = new ArrayDeque<>();
+
+        TestTask headTask = processed.get(0);
+        excludeReprocess.addLast(headTask);
+        long currentOffset = taskToOffset.get(headTask);
+
+        long committed = -1L;
+        for (int i = 1; i < processed.size(); i++) {
+            TestTask task = processed.get(i);
+            long offset = taskToOffset.get(task);
+
+            if (offset < committed) {
+                fail("offset cannot be regressed beyond committed offset");
+            }
+            if (offset <= currentOffset) {
+                // offset regression implies reprocessing from committed offset happened
+                committed = offset;
+
+                // rewind records to committed offset
+                TestTask last;
+                while ((last = excludeReprocess.peekLast()) != null) {
+                    if (taskToOffset.get(last) == offset) {
+                        break;
+                    }
+                    excludeReprocess.removeLast();
+                }
+            } else {
+                excludeReprocess.add(task);
+            }
+            currentOffset = offset;
+        }
+
+        assertTrue(produced.equals(new ArrayList<>(excludeReprocess)));
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
@@ -52,7 +52,7 @@ public class SerialProcessing implements ProcessingGuarantee {
                 ProcessedRecord current = perKeyRecords.get(i);
 
                 assertThat("Process time shouldn't overlap. key: " + entry.getKey(),
-                           prev.completeTimeNanos(), lessThan(current.startTimeNanos()));
+                           prev.endTimeNanos(), lessThan(current.startTimeNanos()));
             }
         }
     }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class SerialProcessing implements ProcessingGuarantee {
+    private final List<ProcessedRecord> records =
+            Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public void onProduce(ProducedRecord record) {
+        // noop
+    }
+
+    @Override
+    public void onProcess(ProcessedRecord record) {
+        records.add(record);
+    }
+
+    @Override
+    public void doAssert() {
+        Map<String, List<ProcessedRecord>> recordsMap = new HashMap<>();
+
+        for (ProcessedRecord record : records) {
+            recordsMap.computeIfAbsent(record.key(),
+                                       key -> new ArrayList<>()).add(record);
+        }
+
+        // Checks there's no overlap between two consecutive records' processing time
+        for (Entry<String, List<ProcessedRecord>> entry : recordsMap.entrySet()) {
+            List<ProcessedRecord> perKeyRecords = entry.getValue();
+            perKeyRecords.sort(Comparator.comparingLong(ProcessedRecord::startTimeNanos));
+
+            for (int i = 1; i < perKeyRecords.size(); i++) {
+                ProcessedRecord prev = perKeyRecords.get(i - 1);
+                ProcessedRecord current = perKeyRecords.get(i);
+
+                assertThat("Process time shouldn't overlap. key: " + entry.getKey(),
+                           prev.completeTimeNanos(), lessThan(current.startTimeNanos()));
+            }
+        }
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/SerialProcessing.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.linecorp.decaton.processor.TaskMetadata;
+
 public class SerialProcessing implements ProcessingGuarantee {
     private final Map<String, List<ProcessedRecord>> records = new HashMap<>();
 
@@ -35,7 +37,7 @@ public class SerialProcessing implements ProcessingGuarantee {
     }
 
     @Override
-    public synchronized void onProcess(ProcessedRecord record) {
+    public synchronized void onProcess(TaskMetadata metadata, ProcessedRecord record) {
         records.computeIfAbsent(record.key(),
                                 key -> new ArrayList<>()).add(record);
     }

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTask.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTask.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.decaton.common.Deserializer;
+import com.linecorp.decaton.common.Serializer;
+
+import lombok.Value;
+
+/**
+ * A test task for {@link ProcessorTestSuite}.
+ *
+ * Intended to be assigned unique id for each tasks so that every task can be differentiated.
+ */
+@Value
+public class TestTask {
+    /**
+     * Unique id of the task
+     */
+    String id;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static class TestTaskSerializer implements Serializer<TestTask> {
+        @Override
+        public byte[] serialize(TestTask data) {
+            try {
+                return MAPPER.writeValueAsBytes(data);
+            } catch (JsonProcessingException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    public static class TestTaskDeserializer implements Deserializer<TestTask> {
+        @Override
+        public TestTask deserialize(byte[] bytes) {
+            try {
+                return MAPPER.readValue(bytes, TestTask.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTask.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTask.java
@@ -39,13 +39,13 @@ public class TestTask {
      */
     String id;
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     public static class TestTaskSerializer implements Serializer<TestTask> {
         @Override
         public byte[] serialize(TestTask data) {
             try {
-                return MAPPER.writeValueAsBytes(data);
+                return mapper.writeValueAsBytes(data);
             } catch (JsonProcessingException e) {
                 throw new UncheckedIOException(e);
             }
@@ -56,7 +56,7 @@ public class TestTask {
         @Override
         public TestTask deserialize(byte[] bytes) {
             try {
-                return MAPPER.readValue(bytes, TestTask.class);
+                return mapper.readValue(bytes, TestTask.class);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
## Summary
- This PR adds integration tests to check processing guarantees which are expected Decaton to always satisfy
- By this tests, we can make sure that future code changes don't break processing semantics of Decaton
- [ProcessingGuarantee.java](https://github.com/line/decaton/pull/35/files#diff-76bb76bb3bdb59bf6dca0f19c07e0a04R33) contains the interface for guarantee and enums of available guarantees.
- [ProcessorTestSuite](https://github.com/line/decaton/pull/35/files#diff-75717a8b58a436b83a3fcecd1d91733dR57) is the class that performs integration test
- For how to use `ProcessorTestSuite`, please see [CoreFunctionalityTest](https://github.com/line/decaton/pull/35/files#diff-e7d47fe3e6d50565c8109a715d581436R31)