### PR TITLE
Update HW in shutdown procedure to reduce duplication fixes #23

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RateLimiterTest.java
@@ -69,10 +69,11 @@ public class RateLimiterTest {
         DynamicProperty<Long> rateProp = new DynamicProperty<>(ProcessorProperties.CONFIG_PROCESSING_RATE);
         try (ProcessorSubscription subscription = TestUtils.subscription(
                 rule.bootstrapServers(),
-                ProcessorsBuilder.consuming(topicName, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
-                                 .thenProcess(processor),
-                null,
-                StaticPropertySupplier.of(rateProp));
+                builder -> builder.processorsBuilder(ProcessorsBuilder
+                                                             .consuming(topicName,
+                                                                        new ProtocolBuffersDeserializer<>(HelloTask.parser()))
+                                                             .thenProcess(processor))
+                                  .properties(StaticPropertySupplier.of(rateProp)));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 
             int count = 0;

--- a/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.decaton.processor.SubscriptionStateListener.State;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+
+public class SubscriptionStateTest {
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+
+    @Test(timeout = 30000)
+    public void testStateTransition() {
+        Map<Integer, List<State>> subscriptionStates = new HashMap<>();
+        ProcessorTestSuite
+                .builder(rule)
+                .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {}))
+                .statesListener((instanceId, newState) -> {
+                    synchronized (subscriptionStates) {
+                        subscriptionStates.computeIfAbsent(instanceId, key -> new ArrayList<>()).add(newState);
+                    }
+                })
+                .build()
+                .run();
+
+        subscriptionStates.forEach((instanceId, stateHistory) -> {
+            assertEquals(State.INITIALIZING, stateHistory.get(0));
+            assertEquals(State.TERMINATED, stateHistory.get(stateHistory.size() - 1));
+
+            State state;
+            Deque<State> states = new ArrayDeque<>(stateHistory);
+            List<State> validTransition = Arrays.asList(State.INITIALIZING);
+            while ((state = states.pollFirst()) != null) {
+                if (!validTransition.contains(state)) {
+                    fail(String.format("Invalid state transition %s on subscription-%d",
+                                       stateHistory.stream().map(State::name).collect(Collectors.joining(",")),
+                                       instanceId));
+                }
+                switch (state) {
+                    case INITIALIZING:
+                    case REBALANCING:
+                        validTransition = Arrays.asList(State.RUNNING);
+                        break;
+                    case RUNNING:
+                        validTransition = Arrays.asList(State.REBALANCING, State.SHUTTING_DOWN);
+                        break;
+                    case SHUTTING_DOWN:
+                        validTransition = Arrays.asList(State.TERMINATED);
+                        break;
+                    case TERMINATED:
+                        // happen when subscription is restarted
+                        validTransition = Arrays.asList(State.INITIALIZING);
+                        break;
+                }
+            }
+        });
+    }
+}

--- a/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
@@ -26,7 +26,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -62,9 +61,7 @@ public class SubscriptionStateTest {
             List<State> validTransition = Arrays.asList(State.INITIALIZING);
             while ((state = states.pollFirst()) != null) {
                 if (!validTransition.contains(state)) {
-                    fail(String.format("Invalid state transition %s on subscription-%d",
-                                       stateHistory.stream().map(State::name).collect(Collectors.joining(",")),
-                                       instanceId));
+                    fail(String.format("Invalid state transition %s on subscription-%d", stateHistory, instanceId));
                 }
                 switch (state) {
                     case INITIALIZING:

--- a/processor/src/main/java/com/linecorp/decaton/processor/SubscriptionStateListener.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/SubscriptionStateListener.java
@@ -45,7 +45,8 @@ public interface SubscriptionStateListener {
      * The expected state transition is:
      * <pre>
      * {@code
-     * INITIALIZING -> REBALANCING <-> RUNNING -> SHUTTING_DOWN -> TERMINATED
+     * INITIALIZING -> RUNNING <-> REBALANCING
+     *                    └──────> SHUTTING_DOWN -> TERMINATED
      * }
      * </pre>
      *
@@ -69,7 +70,7 @@ public interface SubscriptionStateListener {
         RUNNING,
         /**
          * Entered shutdown sequence.
-         * No extra tasks will be queued, but existing queued tasks will be processed.
+         * No extra tasks will be queued, but started tasks will not be interrupted.
          */
         SHUTTING_DOWN,
         /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/SubscriptionStateListener.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/SubscriptionStateListener.java
@@ -70,7 +70,7 @@ public interface SubscriptionStateListener {
         RUNNING,
         /**
          * Entered shutdown sequence.
-         * No extra tasks will be queued, but started tasks will not be interrupted.
+         * No extra tasks will be queued, but the tasks that are already in process continues till it completes.
          */
         SHUTTING_DOWN,
         /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -173,15 +173,16 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
         updateState(SubscriptionStateListener.State.INITIALIZING);
 
         Consumer<String, byte[]> consumer = consumerSupplier.get();
-
+        AtomicBoolean consumerClosing = new AtomicBoolean(false);
         final Collection<TopicPartition> currentAssignment = new HashSet<>();
         try {
             consumer.subscribe(subscribeTopics(), new ConsumerRebalanceListener() {
                 @Override
                 public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
                     // KafkaConsumer#close has been changed to invoke onPartitionRevoked since Kafka 2.4.0.
-                    // Since we're doing cleanup procedure on shutdown individually so just immediately return if terminated
-                    if (terminated.get()) {
+                    // Since we're doing cleanup procedure on shutdown manually
+                    // so just immediately return if consumer is already closing
+                    if (consumerClosing.get()) {
                         return;
                     }
                     updateState(SubscriptionStateListener.State.REBALANCING);
@@ -248,14 +249,20 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
 
             Timer timer = Utils.timer();
             contexts.destroyAllProcessors();
+
+            // Since kafka-clients version 2.4.0 ConsumerRebalanceListener#onPartitionsRevoked gets triggered
+            // at close so the same thing is supposed to happen, but its not true for older kafka-clients version
+            // so we're manually handling this here instead of relying on rebalance listener for better compatibility
+            contexts.updateHighWatermarks();
             try {
-                contexts.updateHighWatermarks();
                 commitCompletedOffsets(consumer);
             } catch (RuntimeException e) {
                 logger.error("Offset commit failed before closing consumer", e);
             }
 
             processors.destroySingletonScope(scope.subscriptionId());
+
+            consumerClosing.set(true);
             consumer.close();
             logger.info("ProcessorSubscription {} terminated in {} ms", scope,
                         timer.elapsedMillis());

--- a/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.decaton.testing;
 
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import com.linecorp.decaton.processor.SubscriptionStateListener;
@@ -34,11 +37,8 @@ import com.linecorp.decaton.client.DecatonClient;
 import com.linecorp.decaton.client.kafka.PrintableAsciiStringSerializer;
 import com.linecorp.decaton.client.kafka.ProtocolBuffersKafkaSerializer;
 import com.linecorp.decaton.common.Serializer;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
-import com.linecorp.decaton.processor.PropertySupplier;
 import com.linecorp.decaton.processor.SubscriptionStateListener.State;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
-import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersSerializer;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
@@ -112,22 +112,14 @@ public class TestUtils {
      * and unique subscription id assigned
      *
      * @param bootstrapServers bootstrap servers to connect
-     * @param processorsBuilder actual processing logic. This parameter is mandatory
-     * @param retryConfig can be null if you don't enable retry queueing feature
-     * @param propertySupplier can be null if you don't supply extra Decaton configs
-     * @param <T> type of tasks
+     * @param builderConfigurer configure subscription builder to fit test requirements
      * @return {@link ProcessorSubscription} instance which is already running with unique subscription id assigned
      */
-    public static <T> ProcessorSubscription subscription(String bootstrapServers,
-                                                         ProcessorsBuilder<T> processorsBuilder,
-                                                         RetryConfig retryConfig,
-                                                         PropertySupplier propertySupplier) {
+    public static ProcessorSubscription subscription(String bootstrapServers,
+                                                     Consumer<SubscriptionBuilder> builderConfigurer) {
         return subscription("subscription-" + sequence(),
                             bootstrapServers,
-                            processorsBuilder,
-                            retryConfig,
-                            propertySupplier,
-                            null);
+                            builderConfigurer);
     }
 
     /**
@@ -136,42 +128,39 @@ public class TestUtils {
      *
      * @param subscriptionId subscription id of the instance
      * @param bootstrapServers bootstrap servers to connect
-     * @param processorsBuilder actual processing logic. This parameter is mandatory
-     * @param retryConfig can be null if you don't enable retry queueing feature
-     * @param propertySupplier can be null if you don't supply extra Decaton configs
-     * @param stateListener can be null if you don't need to listen subscription state
-     * @param <T> type of tasks
+     * @param builderConfigurer configure subscription builder to fit test requirements
      * @return {@link ProcessorSubscription} instance which is already running
      */
-    public static <T> ProcessorSubscription subscription(String subscriptionId,
-                                                         String bootstrapServers,
-                                                         ProcessorsBuilder<T> processorsBuilder,
-                                                         RetryConfig retryConfig,
-                                                         PropertySupplier propertySupplier,
-                                                         SubscriptionStateListener stateListener) {
+    public static ProcessorSubscription subscription(String subscriptionId,
+                                                     String bootstrapServers,
+                                                     Consumer<SubscriptionBuilder> builderConfigurer) {
+        AtomicReference<SubscriptionStateListener> stateListenerRef = new AtomicReference<>();
+        CountDownLatch initializationLatch = new CountDownLatch(1);
+        SubscriptionStateListener outerStateListener = state -> {
+            if (state == State.RUNNING) {
+                initializationLatch.countDown();
+            }
+            Optional.ofNullable(stateListenerRef.get()).ifPresent(s -> s.onChange(state));
+        };
+
+        SubscriptionBuilder builder = new SubscriptionBuilder(subscriptionId) {
+            @Override
+            public SubscriptionBuilder stateListener(SubscriptionStateListener stateListener) {
+                if (stateListener != outerStateListener) {
+                    stateListenerRef.set(stateListener);
+                }
+                return super.stateListener(stateListener);
+            }
+        };
         Properties props = new Properties();
         props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "test-" + subscriptionId);
         props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, DEFAULT_GROUP_ID);
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        CountDownLatch initializationLatch = new CountDownLatch(1);
-        SubscriptionBuilder builder = SubscriptionBuilder.newBuilder(subscriptionId)
-                                                         .consumerConfig(props)
-                                                         .processorsBuilder(processorsBuilder)
-                                                         .stateListener(state -> {
-                                                             if (state == State.RUNNING) {
-                                                                 initializationLatch.countDown();
-                                                             }
-                                                             if (stateListener != null) {
-                                                                 stateListener.onChange(state);
-                                                             }
-                                                         });
-        if (retryConfig != null) {
-            builder.enableRetry(retryConfig);
-        }
-        if (propertySupplier != null) {
-            builder.properties(propertySupplier);
-        }
+
+        builderConfigurer.accept(builder);
+        builder.consumerConfig(props)
+               .stateListener(outerStateListener);
         ProcessorSubscription subscription = builder.buildAndStart();
 
         try {

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -227,10 +227,16 @@ public class ProcessorTestSuite {
 
         return TestUtils.subscription("subscription-" + id,
                                       rule.bootstrapServers(),
-                                      processorsBuilder,
-                                      retryConfig,
-                                      propertySuppliers,
-                                      state -> statesListener.onChange(id, state));
+                                      builder -> {
+                                          builder.processorsBuilder(processorsBuilder);
+                                          if (retryConfig != null) {
+                                              builder.enableRetry(retryConfig);
+                                          }
+                                          if (propertySuppliers != null) {
+                                              builder.properties(propertySuppliers);
+                                          }
+                                          builder.stateListener(state -> statesListener.onChange(id, state));
+                                      });
     }
 
     private static void performRollingRestart(ProcessorSubscription[] subscriptions,

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -41,6 +41,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.PropertySupplier;
+import com.linecorp.decaton.processor.SubscriptionStateListener;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
@@ -77,11 +78,25 @@ public class ProcessorTestSuite {
     private final RetryConfig retryConfig;
     private final PropertySupplier propertySuppliers;
     private final Set<ProcessingGuarantee> semantics;
+    private final SubscriptionStatesListener statesListener;
 
     private static final int NUM_TASKS = 10000;
     private static final int NUM_KEYS = 100;
     private static final int NUM_SUBSCRIPTION_INSTANCES = 3;
     private static final int NUM_PARTITIONS = 8;
+
+    /**
+     * An interface to listen multiple subscription's state changes
+     */
+    @FunctionalInterface
+    public interface SubscriptionStatesListener {
+        /**
+         * Called at state transitioned to new state
+         * @param instanceId id of the subscription instance which state has changed. Possible values are 0..{@link #NUM_SUBSCRIPTION_INSTANCES} - 1
+         * @param newState new state of the subscription
+         */
+        void onChange(int instanceId, SubscriptionStateListener.State newState);
+    }
 
     @Setter
     @Accessors(fluent = true)
@@ -103,6 +118,10 @@ public class ProcessorTestSuite {
          * Supply additional {@link ProcessorProperties} through {@link PropertySupplier}
          */
         private PropertySupplier propertySupplier;
+        /**
+         * Listen every subscription's state changes
+         */
+        private SubscriptionStatesListener statesListener;
         /**
          * Exclude semantics from assertion.
          * Intended to be used when we test a feature which breaks subset of semantics
@@ -133,11 +152,16 @@ public class ProcessorTestSuite {
             }
             semantics.addAll(customSemantics);
 
+            if (statesListener == null) {
+                statesListener = (id, state) -> {};
+            }
+
             return new ProcessorTestSuite(rule,
                                           configureProcessorsBuilder,
                                           retryConfig,
                                           propertySupplier,
-                                          semantics);
+                                          semantics,
+                                          statesListener);
         }
     }
 
@@ -205,7 +229,8 @@ public class ProcessorTestSuite {
                                       rule.bootstrapServers(),
                                       processorsBuilder,
                                       retryConfig,
-                                      propertySuppliers);
+                                      propertySuppliers,
+                                      state -> statesListener.onChange(id, state));
     }
 
     private static void performRollingRestart(ProcessorSubscription[] subscriptions,


### PR DESCRIPTION
## Summary
- Update H/W before shutting down to reduce process duplication
- By this fix, as long as we set partition.concurrency to 1 as like vanilla consumer, we can expect process duplication not to occur.
  * Added a test about that