### PR TITLE
Add manual git-based continuous benchmark

### DIFF
--- a/benchmark/debm.sh
+++ b/benchmark/debm.sh
@@ -7,7 +7,7 @@ JTASKSTATS_VERSION=0.2.0
 JTASKSTATS_URL_BASE="https://github.com/kawamuray/jtaskstats/releases/download/v${JTASKSTATS_VERSION}"
 
 extra_opts=""
-classpath="$CLASSPATH:$(ls $(dirname $0)/build/libs/benchmark-*-shadow.jar | sort -nr | head -1)"
+classpath="${CLASSPATH:-$(ls $(dirname $0)/build/libs/benchmark-*-shadow.jar | sort -nr | head -1)}"
 
 if [[ "$*" == *--profile* ]] && [[ "$*" != *--profiler-bin* ]] && ! which profiler.sh >/dev/null 2>&1; then
     dir="/tmp/async-profiler-${ASYNC_PROFILER_VERSION}"

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -74,6 +74,10 @@ public class BenchmarkConfig {
      * Taskstats config is optional and might be null.
      */
     TaskStatsConfig taskstats;
+    /**
+     * Trim file paths in result from its path to filename only.
+     */
+    boolean fileNameOnly;
 
     @Value
     public static class ProfilingConfig {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -84,11 +84,16 @@ public class BenchmarkConfig {
         Path profilerBin;
         List<String> profilerOpts;
     }
+
     @Value
     public static class TaskStatsConfig {
         /**
          * jtaskstats binary path (available only at Linux machines) that is optional and might be null.
          */
         Path jtaskstatsBin;
+        /**
+         * jtaskstats result output path.
+         */
+        Path jtaskstatsOutput;
     }
 }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
@@ -130,11 +130,11 @@ public class BenchmarkResult {
         return new BenchmarkResult(performance.plus(other.performance),
                                    resource.plus(other.resource),
                                    jvmStats.plus(other.jvmStats),
-                                   ExtraInfo.EMPTY);
+                                   other.extraInfo);
     }
 
     public BenchmarkResult div(int d) {
-        return new BenchmarkResult(performance.div(d), resource.div(d), jvmStats.div(d), ExtraInfo.EMPTY);
+        return new BenchmarkResult(performance.div(d), resource.div(d), jvmStats.div(d), extraInfo);
     }
 
     public static BenchmarkResult aggregateAverage(List<BenchmarkResult> results) {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkResult.java
@@ -18,8 +18,6 @@ package com.linecorp.decaton.benchmark;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -127,45 +125,6 @@ public class BenchmarkResult {
     ResourceUsage resource;
     JvmStats jvmStats;
     ExtraInfo extraInfo;
-
-    public void print(BenchmarkConfig config, OutputStream out) {
-        PrintWriter pw = new PrintWriter(out);
-
-        pw.printf("=== %s (%d tasks) ===\n", config.title(), performance.totalTasks);
-        pw.printf("# Runner: %s\n", config.runner());
-        pw.printf("# Tasks: %d (warmup: %d)\n", config.tasks(), config.warmupTasks());
-        pw.printf("# Simulated Latency(ms): %d\n", config.simulateLatencyMs());
-        for (Entry<String, String> e : config.params().entrySet()) {
-            pw.printf("# Param: %s=%s\n", e.getKey(), e.getValue());
-        }
-        if (extraInfo != null) {
-            if (extraInfo.profilerOutput != null) {
-                pw.printf("# Profiler Output: %s\n", extraInfo.profilerOutput);
-            }
-            if (extraInfo.taskstatsOutput != null) {
-                pw.printf("# Taskstats Output: %s\n", extraInfo.taskstatsOutput);
-            }
-        }
-
-        pw.printf("--- Performance ---\n");
-        pw.printf("Execution Time(ms): %.2f\n", performance.executionTime.toNanos() / 1_000_000.0);
-        pw.printf("Throughput: %.2f tasks/sec\n", performance.throughput);
-        pw.printf("Delivery Latency(ms): mean=%d max=%d\n",
-                  performance.deliveryLatency.avg.toMillis(), performance.deliveryLatency.max.toMillis());
-
-        pw.printf("--- Resource Usage (%d threads observed) ---\n", resource.threads);
-        pw.printf("Cpu Time(ms): %.2f\n", resource.totalCpuTimeNs / 1_000_000.0);
-        pw.printf("Allocated Heap(KiB): %.2f\n", resource.totalAllocatedBytes / 1024.0);
-
-        pw.printf("--- JVM ---\n");
-        jvmStats.gcStats.keySet().stream().sorted().forEach(name -> {
-            JvmStats.GcStats values = jvmStats.gcStats.get(name);
-            pw.printf("GC (%s) Count: %d\n", name, values.count);
-            pw.printf("GC (%s) Time(ms): %d\n", name, values.time);
-        });
-
-        pw.flush();
-    }
 
     public BenchmarkResult plus(BenchmarkResult other) {
         return new BenchmarkResult(performance.plus(other.performance),

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -95,7 +95,7 @@ public class InProcessExecution implements Execution {
         }
 
         stageCallback.accept(Stage.FINISH);
-        return assembleResult(recording, resourceUsageReport, jvmReport, profilerOutput, taskstatsOutput);
+        return assembleResult(bmConfig, recording, resourceUsageReport, jvmReport, profilerOutput, taskstatsOutput);
     }
 
     private static Profiling profiling(BenchmarkConfig bmConfig) {
@@ -136,7 +136,8 @@ public class InProcessExecution implements Execution {
         }
     }
 
-    private static BenchmarkResult assembleResult(Recording recording,
+    private static BenchmarkResult assembleResult(BenchmarkConfig bmConfig,
+                                                  Recording recording,
                                                   Map<Long, TrackingValues> resourceUsageReport,
                                                   Map<String, GcStats> jvmReport,
                                                   Optional<Path> profilerOutput,
@@ -156,6 +157,11 @@ public class InProcessExecution implements Execution {
                 Entry::getKey,
                 e -> new JvmStats.GcStats(e.getValue().count(), e.getValue().time())));
         JvmStats jvmStats = new JvmStats(gcStats);
+
+        if (bmConfig.fileNameOnly()) {
+            profilerOutput = profilerOutput.map(Path::getFileName);
+            taskstatsOutput = taskstatsOutput.map(Path::getFileName);
+        }
         ExtraInfo extraInfo = new ExtraInfo(
                 profilerOutput.map(String::valueOf).orElse(null),
                 taskstatsOutput.map(String::valueOf).orElse(null));

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/InProcessExecution.java
@@ -117,7 +117,7 @@ public class InProcessExecution implements Execution {
         if (config == null) {
             return Taskstats.NOOP;
         } else {
-            return new Taskstats(config.jtaskstatsBin());
+            return new Taskstats(config.jtaskstatsBin(), config.jtaskstatsOutput());
         }
     }
 

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/JsonResultFormat.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/JsonResultFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Duration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Format {@link BenchmarkResult} into JSON object.
+ */
+public class JsonResultFormat implements ResultFormat {
+    private static final ObjectWriter writer;
+    static {
+        // Configure custom serializer to serialize Duration into number in nanos
+        ObjectMapper mapper = new ObjectMapper()
+                .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+                .configure(WRITE_DURATIONS_AS_TIMESTAMPS, true)
+                .configure(WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, true);
+        JavaTimeModule module = new JavaTimeModule();
+        module.addSerializer(Duration.class, new JsonSerializer<Duration>() {
+            @Override
+            public void serialize(Duration value, JsonGenerator gen, SerializerProvider serializers)
+                    throws IOException {
+                gen.writeNumber(value.toNanos());
+            }
+        });
+        mapper.registerModule(module);
+        writer = mapper.writerWithDefaultPrettyPrinter();
+    }
+
+    @Override
+    public void print(BenchmarkConfig config, OutputStream out, BenchmarkResult result) throws IOException {
+        writer.writeValue(out, result);
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -84,6 +84,9 @@ public final class Main implements Callable<Integer> {
     @Option(names = "--taskstats-bin", description = "Path to jtaskstats", defaultValue = "jtaskstats")
     private Path jtaskstatsBin;
 
+    @Option(names = "--taskstats-output", description = "Path to write jtaskstats output")
+    private Path jtaskstatsOutput;
+
     @Option(names = "--format", description = "Result format, one of: text(default), json",
             defaultValue = "text")
     private String resultFormat;
@@ -124,7 +127,7 @@ public final class Main implements Callable<Integer> {
         }
         BenchmarkConfig.TaskStatsConfig taskstats = null;
         if (enableTaskstats) {
-            taskstats = new TaskStatsConfig(jtaskstatsBin);
+            taskstats = new TaskStatsConfig(jtaskstatsBin, jtaskstatsOutput);
         }
         ResultFormat resultFormat = resultFormat();
         BenchmarkConfig config =

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -88,6 +88,10 @@ public final class Main implements Callable<Integer> {
             defaultValue = "text")
     private String resultFormat;
 
+    @Option(names = "--file-name-only",
+            description = "Trim file paths in result from its path to filename only")
+    private boolean fileNameOnly;
+
     private static List<String> parseOptions(String opts) {
         if (opts == null) {
             return emptyList();
@@ -136,6 +140,7 @@ public final class Main implements Callable<Integer> {
                                .profiling(profiling)
                                .forking(true)
                                .taskstats(taskstats)
+                               .fileNameOnly(fileNameOnly)
                                .build();
         Benchmark benchmark = new Benchmark(config);
         BenchmarkResult result = benchmark.run();

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/ResultFormat.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/ResultFormat.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An interface to implement formatter for {@link BenchmarkResult}.
+ */
+public interface ResultFormat {
+    /**
+     * Format the given {@link BenchmarkResult} and write into {@link OutputStream}.
+     * @param config the benchmark config.
+     * @param out stream to write formatted output.
+     * @param result the {@link BenchmarkResult} to format.
+     * @throws IOException when IO error happens.
+     */
+    void print(BenchmarkConfig config, OutputStream out, BenchmarkResult result) throws IOException;
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Taskstats.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Taskstats.java
@@ -25,12 +25,18 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Taskstats {
-    public static final Taskstats NOOP = new Taskstats(null);
+    public static final Taskstats NOOP = new Taskstats(null, null);
 
     private final Path jtaskstatsBin;
+    private final Path outputPath;
 
-    public Taskstats(Path jtaskstatsBin) {
+    public Taskstats(Path jtaskstatsBin, Path outputPath) {
         this.jtaskstatsBin = jtaskstatsBin;
+        if (outputPath == null) {
+            this.outputPath = Paths.get(outputFileName());
+        } else {
+            this.outputPath = outputPath;
+        }
     }
 
     private static String outputFileName() {
@@ -40,6 +46,7 @@ public class Taskstats {
     /**
      * Report taskstats of all java threads in the target JVM and return the path to the file
      * containing the output.
+     *
      * @return path to the file containing output.
      */
     public Optional<Path> reportStats() {
@@ -51,10 +58,9 @@ public class Taskstats {
                 jtaskstatsBin.toString(),
                 String.valueOf(JvmUtils.currentPid())
         };
-        Path output = Paths.get(outputFileName());
         try {
             Process process = new ProcessBuilder(cmd)
-                    .redirectOutput(output.toFile())
+                    .redirectOutput(outputPath.toFile())
                     .redirectError(Redirect.INHERIT)
                     .start();
             if (process.waitFor() != 0) {
@@ -64,6 +70,6 @@ public class Taskstats {
             log.error("Failed to run jtaskstats command: {}", cmd, e);
             throw new RuntimeException(e);
         }
-        return Optional.of(output);
+        return Optional.of(outputPath);
     }
 }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/TextResultFormat.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/TextResultFormat.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Map.Entry;
+
+import com.linecorp.decaton.benchmark.BenchmarkResult.ExtraInfo;
+import com.linecorp.decaton.benchmark.BenchmarkResult.JvmStats;
+import com.linecorp.decaton.benchmark.BenchmarkResult.Performance;
+import com.linecorp.decaton.benchmark.BenchmarkResult.ResourceUsage;
+
+/**
+ * Format {@link BenchmarkResult} into human-readable text format.
+ */
+public class TextResultFormat implements ResultFormat {
+    @Override
+    public void print(BenchmarkConfig config, OutputStream out, BenchmarkResult result) {
+        PrintWriter pw = new PrintWriter(out);
+
+        Performance perf = result.performance();
+        pw.printf("=== %s (%d tasks) ===\n", config.title(), perf.totalTasks());
+        pw.printf("# Runner: %s\n", config.runner());
+        pw.printf("# Tasks: %d (warmup: %d)\n", config.tasks(), config.warmupTasks());
+        pw.printf("# Simulated Latency(ms): %d\n", config.simulateLatencyMs());
+        for (Entry<String, String> e : config.params().entrySet()) {
+            pw.printf("# Param: %s=%s\n", e.getKey(), e.getValue());
+        }
+        ExtraInfo extraInfo = result.extraInfo();
+        if (extraInfo != null) {
+            if (extraInfo.profilerOutput() != null) {
+                pw.printf("# Profiler Output: %s\n", extraInfo.profilerOutput());
+            }
+            if (extraInfo.taskstatsOutput() != null) {
+                pw.printf("# Taskstats Output: %s\n", extraInfo.taskstatsOutput());
+            }
+        }
+
+        pw.printf("--- Performance ---\n");
+        pw.printf("Execution Time(ms): %.2f\n", perf.executionTime().toNanos() / 1_000_000.0);
+        pw.printf("Throughput: %.2f tasks/sec\n", perf.throughput());
+        pw.printf("Delivery Latency(ms): mean=%d max=%d\n",
+                  perf.deliveryLatency().avg().toMillis(), perf.deliveryLatency().max().toMillis());
+
+        ResourceUsage resource = result.resource();
+        pw.printf("--- Resource Usage (%d threads observed) ---\n", resource.threads());
+        pw.printf("Cpu Time(ms): %.2f\n", resource.totalCpuTimeNs() / 1_000_000.0);
+        pw.printf("Allocated Heap(KiB): %.2f\n", resource.totalAllocatedBytes() / 1024.0);
+
+        JvmStats jvmStats = result.jvmStats();
+        pw.printf("--- JVM ---\n");
+        jvmStats.gcStats().keySet().stream().sorted().forEach(name -> {
+            JvmStats.GcStats values = jvmStats.gcStats().get(name);
+            pw.printf("GC (%s) Count: %d\n", name, values.count());
+            pw.printf("GC (%s) Time(ms): %d\n", name, values.time());
+        });
+
+        pw.flush();
+    }
+}

--- a/cb/cb.sh
+++ b/cb/cb.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -eu
+
+config="${1:-}"
+if [ -z "$config" ]; then
+    echo "Usage: $0 PATH_TO_CONFIG" >&2
+    exit 1
+fi
+. "$config"
+
+base_dir=$(dirname $0)
+repo=$WORK_DIR/repo
+last_rev_file=$WORK_DIR/last_revision
+store_dir=$repo/$STORE_DIR
+
+function log() {
+    echo "[$(date +%Y-%m-%dT%H:%M:%S)] $*" >&2
+}
+
+function checkout() {
+    log "Checking out '$1'"
+    cleanup
+    git checkout "$1"
+}
+
+function pull() {
+    log "Pulling latest revision"
+    git pull
+}
+
+function load_last_revision() {
+    if [ ! -e $last_rev_file ]; then
+        log "Last revision file $last_rev_file missing, creating with current HEAD"
+        git rev-parse HEAD > $last_rev_file
+    fi
+    cat $last_rev_file
+}
+
+function revisions_since() {
+    git rev-list --reverse $1..HEAD
+}
+
+function commit_rev() {
+    rev=$1
+    log "Committing revision $rev"
+    git --git-dir=$repo/.git --work-tree=$repo add $store_dir/$rev
+    git --git-dir=$repo/.git --work-tree=$repo commit -m"Auto add commit data: $rev"
+    git --git-dir=$repo/.git --work-tree=$repo push
+}
+
+function update_last_rev() {
+    log "Updating last revision to: $rev"
+    echo -n "$1" > $last_rev_file
+}
+
+function cleanup() {
+    git checkout .
+    git clean -f .
+}
+
+mkdir -p $WORK_DIR
+if [ ! -e $repo ]; then
+    url=$(git config --get remote.origin.url)
+    log "Cloning $url into $repo"
+    git clone $url $repo
+fi
+
+log "Checking out $STORE_BRANCH at $repo"
+git --git-dir=$repo/.git --work-tree=$repo checkout $STORE_BRANCH
+
+checkout $BUILD_BRANCH
+pull
+
+last_rev=$(load_last_revision)
+log "Loaded last revision: $last_rev"
+
+mkdir -p $store_dir
+for rev in $(revisions_since $last_rev); do
+    rev_dir=$store_dir/$rev
+    if [ -e $rev_dir ]; then
+        log "Removing old commit data: $rev_dir"
+        rm -rf $rev_dir
+    fi
+    mkdir -p $rev_dir
+
+    checkout $rev
+    log "Running benchmark for the revision $rev"
+    $base_dir/run-bm.sh $config $rev_dir $rev
+
+    commit_rev $rev
+    update_last_rev $rev
+done

--- a/cb/cb.sh
+++ b/cb/cb.sh
@@ -43,14 +43,14 @@ function revisions_since() {
 function commit_rev() {
     rev=$1
     log "Committing revision $rev"
-    git --git-dir=$repo/.git --work-tree=$repo add $store_dir/$rev
-    git --git-dir=$repo/.git --work-tree=$repo commit -m"Auto add commit data: $rev"
+    git -C $repo add $store_dir/$rev
+    git -C $repo commit -m"Auto add commit data: $rev"
 
     origin="origin"
     if [ -n "$GH_USERNAME" ]; then
         origin="$(git remote get-url origin | sed 's/https:\/\//https:\/\/${GH_USERNAME}:${GH_PASSWORD}@/')"
     fi
-    git --git-dir=$repo/.git --work-tree=$repo push $origin HEAD
+    git -C $repo push $origin HEAD
 }
 
 function update_last_rev() {
@@ -71,7 +71,7 @@ if [ ! -e $repo ]; then
 fi
 
 log "Checking out $STORE_BRANCH at $repo"
-git --git-dir=$repo/.git --work-tree=$repo checkout $STORE_BRANCH
+git -C $repo checkout $STORE_BRANCH
 
 checkout $BUILD_BRANCH
 pull

--- a/cb/cb.sh
+++ b/cb/cb.sh
@@ -45,7 +45,12 @@ function commit_rev() {
     log "Committing revision $rev"
     git --git-dir=$repo/.git --work-tree=$repo add $store_dir/$rev
     git --git-dir=$repo/.git --work-tree=$repo commit -m"Auto add commit data: $rev"
-    git --git-dir=$repo/.git --work-tree=$repo push
+
+    origin="origin"
+    if [ -n "$GH_USERNAME" ]; then
+        origin="$(git remote get-url origin | sed 's/https:\/\//https:\/\/${GH_USERNAME}:${GH_PASSWORD}@/')"
+    fi
+    git --git-dir=$repo/.git --work-tree=$repo push $origin HEAD
 }
 
 function update_last_rev() {

--- a/cb/config.template
+++ b/cb/config.template
@@ -1,0 +1,5 @@
+BUILD_BRANCH=master
+WORK_DIR=# path to persistent working directory
+STORE_BRANCH=gh-pages
+STORE_DIR=commit-data
+PROFILER_BIN=$WORK_DIR/async-profiler-1.7/profiler.sh

--- a/cb/config.template
+++ b/cb/config.template
@@ -3,3 +3,4 @@ WORK_DIR=# path to persistent working directory
 STORE_BRANCH=gh-pages
 STORE_DIR=commit-data
 PROFILER_BIN=$WORK_DIR/async-profiler-1.7/profiler.sh
+JTASKSTATS_BIN=$WORK_DIR/jtaskstats-0.2.0/jtaskstats

--- a/cb/config.template
+++ b/cb/config.template
@@ -2,5 +2,7 @@ BUILD_BRANCH=master
 WORK_DIR=# path to persistent working directory
 STORE_BRANCH=gh-pages
 STORE_DIR=commit-data
+GH_USERNAME=# github username to push commits
+GH_ACCESS_TOKEN=# personal access token to authenticate the above user
 PROFILER_BIN=$WORK_DIR/async-profiler-1.7/profiler.sh
 JTASKSTATS_BIN=$WORK_DIR/jtaskstats-0.2.0/jtaskstats

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -22,6 +22,7 @@ function run_with_opts() {
         --profile \
         --profiler-bin="$PROFILER_BIN"  \
         --profiler-opts="-f $out_dir/$name-profile.svg" \
+        --file-name-only \
         --warmup 100000 \
         --param=decaton.max.pending.records=10000 \
         "$@" \

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eu
+
+config="${1:-}"
+out_dir="${2:-}"
+rev="${3:-}"
+if [ -z "$config" ] || [ -z "$out_dir" ] || [ -z "$rev" ]; then
+    echo "Usage: $0 PATH_TO_CONFIG OUT_DIR REVISION" >&2
+    exit 1
+fi
+. "$config"
+
+root_dir=$(dirname $0)/..
+
+$root_dir/gradlew clean benchmark:shadowJar
+
+function run_with_opts() {
+    name=$1; shift
+    $root_dir/benchmark/debm.sh \
+        --title "$rev-$name" \
+        --format=json \
+        --profile \
+        --profiler-bin="$PROFILER_BIN"  \
+        --profiler-opts="-f $out_dir/$name-profile.svg" \
+        --warmup 100000 \
+        --param=decaton.max.pending.records=10000 \
+        "$@" \
+        >$out_dir/$name-benchmark.json
+}
+
+run_with_opts "tasks_10k_latency_10ms_concurrency_20" --tasks 10000 --simulate-latency=10 --param=decaton.partition.concurrency=20
+run_with_opts "tasks_100k_latency_0ms_concurrency_20" --tasks 100000 --simulate-latency=0 --param=decaton.partition.concurrency=20

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -12,7 +12,7 @@ fi
 
 root_dir=$(dirname $0)/..
 
-$root_dir/gradlew clean benchmark:shadowJar
+$root_dir/gradlew --no-daemon clean benchmark:shadowJar
 
 function run_with_opts() {
     name=$1; shift

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -32,5 +32,7 @@ function run_with_opts() {
         >$out_dir/$name-benchmark.json
 }
 
+$root_dir/cb/sysinfo.sh >$out_dir/sysinfo.json
+
 run_with_opts "tasks_10k_latency_10ms_concurrency_20" --tasks 10000 --simulate-latency=10 --param=decaton.partition.concurrency=20
 run_with_opts "tasks_100k_latency_0ms_concurrency_20" --tasks 100000 --simulate-latency=0 --param=decaton.partition.concurrency=20

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -17,6 +17,7 @@ $root_dir/gradlew clean benchmark:shadowJar
 function run_with_opts() {
     name=$1; shift
     $root_dir/benchmark/debm.sh \
+        --runs 3 \
         --title "$rev-$name" \
         --format=json \
         --profile \

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -22,6 +22,9 @@ function run_with_opts() {
         --profile \
         --profiler-bin="$PROFILER_BIN"  \
         --profiler-opts="-f $out_dir/$name-profile.svg" \
+        --taskstats \
+        --taskstats-bin="$JTASKSTATS_BIN" \
+        --taskstats-output="$out_dir/$name-taskstats.txt" \
         --file-name-only \
         --warmup 100000 \
         --param=decaton.max.pending.records=10000 \

--- a/cb/sysinfo.sh
+++ b/cb/sysinfo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ue
+
+cpu_model=$(grep 'model name' /proc/cpuinfo  | head -1 | awk 'BEGIN {FS=": "}; {print $2}')
+cpu_cores=$(grep 'vendor_id' /proc/cpuinfo  | wc -l)
+mem_kb=$(grep 'MemTotal' /proc/meminfo | grep -oE '[0-9]+ kB' | awk '{print $1}')
+mem_bytes=$(($mem_kb * 1024))
+java_version=$(java -version 2>&1 | head -1 | grep -oE '"[^"]+"' | sed 's/"//g')
+env_id=$(echo -n "$cpu_model:$cpu_cores:$mem_bytes:$java_version" | md5sum  | awk '{print $1}')
+
+
+cat <<EOF
+{
+    "cpuModel": "$cpu_model",
+    "cpuCores": $cpu_cores,
+    "memoryBytes": $mem_bytes,
+    "javaVersion": "$java_version",
+    "envId": "$env_id"
+}
+EOF


### PR DESCRIPTION
This PR attempts to address #45 .

# Motivation
As I reverted the previous `PerformanceBoundTest` in https://github.com/line/decaton/pull/44, the way to run benchmark in CI showed a stability issue in terms of benchmark results.
It might be an option to pursue another CI service that provides stabler environment, but I think it's much better to take full control of benchmark environment that provides predictable resource and stable results.
To do that, I propose a new manual way of executing benchmark in our own servers along with the way to visualize trend of results that was also missing in our first attempt.

# Workflow
1. A commit pushed
2. A scheduled job in our own machine continuously polls for new commits
3. Once detected, job executes benchmark and store the result into a dedicated directory `commit-data/`
4. The job commits and pushes new file in `commit-data` into `gh-pages` branch.
5. If the result value regressed N% since the last run, it indicates us by leaving comment in PR or for a commit through github API (still in consideration).
6. We can access gh-page of this repo (to be created) to see the trend of performance transitions.

One of the downsides of this way is that we cannot detect regression while working on PR. However, since it's relatively more  difficult to properly judge performance regression is valid or not, I think it still make sense to deal with it not simply as "success/error" but in wider scope as trend.

This PR doesn't implements part 5 of the above steps. I'll follow it up later.
You can see demo of trend visualization at my personal fork:
- https://github.com/kawamuray/decaton/tree/gh-pages
- https://kawamuray.github.io/decaton/