### PR TITLE
Commits offsets within consume-loop asynchronously to avoid blocking loop

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -191,14 +191,15 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             Duration elapsed = timer.duration();
             if (pendingTasksCount == 0) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Waiting for task completion is successful {} ms", Utils.formatNum(elapsed.toMillis()));
+                    log.debug("Waiting for task completion is successful {} ms",
+                              Utils.formatNum(elapsed.toMillis()));
                 }
                 break;
             }
 
             if (elapsed.toNanos() >= timeoutNanos) {
                 log.warn("Timed out waiting {} tasks to complete after {} ms",
-                        Utils.formatNum(elapsed.toMillis()), pendingTasksCount);
+                         pendingTasksCount, Utils.formatNum(elapsed.toMillis()));
                 break;
             }
 
@@ -221,7 +222,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
         contexts.dropContexts(partitions);
         if (log.isInfoEnabled()) {
             log.info("Processed revoke {} partitions in {} ms",
-                    partitions.size(), Utils.formatNum(timer.elapsedMillis()));
+                     partitions.size(), Utils.formatNum(timer.elapsedMillis()));
         }
     }
 
@@ -236,7 +237,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
         }
         if (log.isInfoEnabled()) {
             log.info("Processed assign {} partitions in {} ms",
-                    partitions.size(), Utils.formatNum(timer.elapsedMillis()));
+                     partitions.size(), Utils.formatNum(timer.elapsedMillis()));
         }
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/Utils.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/Utils.java
@@ -84,7 +84,7 @@ final class Utils {
 
         @Override
         public String toString() {
-            return formatNanos(elapsedNanos()) + " ns";
+            return formatNum(elapsedNanos()) + " ns";
         }
     }
 
@@ -97,12 +97,12 @@ final class Utils {
     }
 
     /**
-     * Formats given {@param nanos} in human-readable, comma-separated string format.
-     * @param nanos nanoseconds to format.
-     * @return comma-separated string representation of given nanoseconds.
+     * Formats given {@param number} in human-readable, comma-separated string format.
+     * @param number number to format.
+     * @return comma-separated string representation of given number.
      */
-    static String formatNanos(long nanos) {
-        return numberFormat.get().format(nanos);
+    static String formatNum(long number) {
+        return numberFormat.get().format(number);
     }
 
     /**
@@ -111,7 +111,7 @@ final class Utils {
      * @return comma-separated string representation of given duration.
      */
     static String formatNanos(Duration duration) {
-        return formatNanos(duration.toNanos());
+        return formatNum(duration.toNanos());
     }
 
     /**

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -16,22 +16,39 @@
 
 package com.linecorp.decaton.processor.runtime;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import com.linecorp.decaton.processor.DecatonTask;
 import com.linecorp.decaton.processor.ProcessorProperties;
@@ -41,6 +58,9 @@ import com.linecorp.decaton.processor.SubscriptionStateListener.State;
 import com.linecorp.decaton.processor.TaskMetadata;
 
 public class ProcessorSubscriptionTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     /**
      * A mock consumer which exposes rebalance listener so that can be triggered manually
      * ({@link MockConsumer} doesn't simulate rebalance listener invocation. refs: KAFKA-6968).
@@ -59,16 +79,25 @@ public class ProcessorSubscriptionTest {
         }
     }
 
+    @Mock
+    private Consumer<String, byte[]> consumerMock;
+
+    @Mock
+    private PartitionContexts contextsMock;
+
+    private static SubscriptionScope scope(String topic) {
+        return new SubscriptionScope(
+                "subscription",
+                topic,
+                Optional.empty(),
+                ProcessorProperties.builder().build());
+    }
+
     private static ProcessorSubscription subscription(Consumer<String, byte[]> consumer,
                                                       SubscriptionStateListener listener,
                                                       TopicPartition tp) {
-        SubscriptionScope scope = new SubscriptionScope(
-                "subscription",
-                tp.topic(),
-                Optional.empty(),
-                ProcessorProperties.builder().build());
-
-        ProcessorSubscription subscription = new ProcessorSubscription(
+        SubscriptionScope scope = scope(tp.topic());
+        return new ProcessorSubscription(
                 scope,
                 () -> consumer,
                 ProcessorsBuilder.consuming(scope.topic(),
@@ -77,7 +106,6 @@ public class ProcessorSubscriptionTest {
                                  .build(null),
                 scope.props(),
                 listener);
-        return subscription;
     }
 
     @Test(timeout = 10000L)
@@ -105,5 +133,118 @@ public class ProcessorSubscriptionTest {
                                    State.RUNNING,
                                    State.SHUTTING_DOWN,
                                    State.TERMINATED), states);
+    }
+
+    private ProcessorSubscription subscriptionForCommitTest() {
+        SubscriptionScope scope = scope("topic");
+        return new ProcessorSubscription(
+                scope,
+                () -> consumerMock,
+                null,
+                scope.props(),
+                null,
+                contextsMock);
+    }
+
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        // When committed ended up successfully update committed offsets
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(contextsMock).commitOffsets();
+        subscription.commitCompletedOffsets(consumerMock, true);
+        verify(contextsMock, times(1)).updateCommittedOffsets(offsets);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync_NO_COMMIT() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        // When target offsets is empty do not attempt any commit
+        doReturn(emptyMap()).when(contextsMock).commitOffsets();
+        subscription.commitCompletedOffsets(consumerMock, true);
+        verify(consumerMock, never()).commitSync(any(Map.class));
+        verify(consumerMock, never()).commitAsync(any(Map.class), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync_FAIL() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        // When commit raised an exception do not update committed offsets
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(contextsMock).commitOffsets();
+        doThrow(new RuntimeException("error")).when(consumerMock).commitSync(any(Map.class));
+        try {
+            subscription.commitCompletedOffsets(consumerMock, true);
+        } catch (RuntimeException ignored) {
+            // ignore
+        }
+        verify(contextsMock, never()).updateCommittedOffsets(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(contextsMock).commitOffsets();
+        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            OffsetCommitCallback cb = invocation.getArgument(1);
+            cbRef.set(cb);
+            return null;
+        }).when(consumerMock).commitAsync(any(Map.class), any());
+        subscription.commitCompletedOffsets(consumerMock, false);
+
+        // Committed offsets should not be updated yet here
+        verify(consumerMock, times(1)).commitAsync(any(Map.class), any());
+        verify(contextsMock, never()).updateCommittedOffsets(any());
+
+        // Subsequent async commit attempt should be ignored until the in-flight one completes
+        subscription.commitCompletedOffsets(consumerMock, false);
+        verify(consumerMock, times(1)).commitAsync(any(Map.class), any());
+        verify(contextsMock, never()).updateCommittedOffsets(any());
+
+        // Committed offset should be updated once the in-flight request completes
+        cbRef.get().onComplete(offsets, null);
+        verify(contextsMock, times(1)).updateCommittedOffsets(offsets);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync_FAIL() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(contextsMock).commitOffsets();
+        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            OffsetCommitCallback cb = invocation.getArgument(1);
+            cbRef.set(cb);
+            return null;
+        }).when(consumerMock).commitAsync(any(Map.class), any());
+        subscription.commitCompletedOffsets(consumerMock, false);
+        // If async commit fails it should never update committed offset
+        cbRef.get().onComplete(offsets, new RuntimeException("failure"));
+        verify(contextsMock, never()).updateCommittedOffsets(offsets);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync_SUBSEQUENT_SYNC() {
+        ProcessorSubscription subscription = subscriptionForCommitTest();
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(contextsMock).commitOffsets();
+
+        subscription.commitCompletedOffsets(consumerMock, false);
+
+        // Subsequent sync commit can proceed regardless of in-flight async commit
+        subscription.commitCompletedOffsets(consumerMock, true);
+        verify(consumerMock, times(1)).commitSync(any(Map.class));
     }
 }

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -34,6 +34,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -135,20 +137,36 @@ public class ProcessorSubscriptionTest {
                                    State.TERMINATED), states);
     }
 
-    private ProcessorSubscription subscriptionForCommitTest() {
+    private ProcessorSubscription subscriptionForCommitTest(BlockingQueue<Runnable> tasks) {
         SubscriptionScope scope = scope("topic");
-        return new ProcessorSubscription(
+        ProcessorSubscription subscription = new ProcessorSubscription(
                 scope,
                 () -> consumerMock,
                 null,
                 scope.props(),
                 null,
-                contextsMock);
+                contextsMock) {
+            @Override
+            public void run() {
+                if (tasks == null) {
+                    return;
+                }
+                while (true) {
+                    try {
+                        tasks.take().run();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        subscription.start();
+        return subscription;
     }
 
     @Test(timeout = 5000)
     public void testCommitCompletedOffsetsSync() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+        ProcessorSubscription subscription = subscriptionForCommitTest(null);
         // When committed ended up successfully update committed offsets
         Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
                 new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
@@ -160,7 +178,7 @@ public class ProcessorSubscriptionTest {
     @SuppressWarnings("unchecked")
     @Test(timeout = 5000)
     public void testCommitCompletedOffsetsSync_NO_COMMIT() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+        ProcessorSubscription subscription = subscriptionForCommitTest(null);
         // When target offsets is empty do not attempt any commit
         doReturn(emptyMap()).when(contextsMock).commitOffsets();
         subscription.commitCompletedOffsets(consumerMock, true);
@@ -171,7 +189,7 @@ public class ProcessorSubscriptionTest {
     @SuppressWarnings("unchecked")
     @Test(timeout = 5000)
     public void testCommitCompletedOffsetsSync_FAIL() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+        ProcessorSubscription subscription = subscriptionForCommitTest(null);
         // When commit raised an exception do not update committed offsets
         Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
                 new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
@@ -187,8 +205,9 @@ public class ProcessorSubscriptionTest {
 
     @SuppressWarnings("unchecked")
     @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsAsync() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+    public void testCommitCompletedOffsetsAsync() throws InterruptedException {
+        BlockingQueue<Runnable> tasks = new ArrayBlockingQueue<>(1);
+        ProcessorSubscription subscription = subscriptionForCommitTest(tasks);
         Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
                 new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
         doReturn(offsets).when(contextsMock).commitOffsets();
@@ -210,14 +229,21 @@ public class ProcessorSubscriptionTest {
         verify(contextsMock, never()).updateCommittedOffsets(any());
 
         // Committed offset should be updated once the in-flight request completes
-        cbRef.get().onComplete(offsets, null);
+        CountDownLatch latch = new CountDownLatch(1);
+        tasks.put(() -> {
+            // The callback is not thread-safe and is required to be called from the subscription thread.
+            cbRef.get().onComplete(offsets, null);
+            latch.countDown();
+        });
+        latch.await();
         verify(contextsMock, times(1)).updateCommittedOffsets(offsets);
     }
 
     @SuppressWarnings("unchecked")
     @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsAsync_FAIL() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+    public void testCommitCompletedOffsetsAsync_FAIL() throws InterruptedException {
+        BlockingQueue<Runnable> tasks = new ArrayBlockingQueue<>(1);
+        ProcessorSubscription subscription = subscriptionForCommitTest(tasks);
         Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
                 new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
         doReturn(offsets).when(contextsMock).commitOffsets();
@@ -229,18 +255,25 @@ public class ProcessorSubscriptionTest {
         }).when(consumerMock).commitAsync(any(Map.class), any());
         subscription.commitCompletedOffsets(consumerMock, false);
         // If async commit fails it should never update committed offset
-        cbRef.get().onComplete(offsets, new RuntimeException("failure"));
+        CountDownLatch latch = new CountDownLatch(1);
+        tasks.put(() -> {
+            // The callback is not thread-safe and is required to be called from the subscription thread.
+            cbRef.get().onComplete(offsets, new RuntimeException("failure"));
+            latch.countDown();
+        });
+        latch.await();
         verify(contextsMock, never()).updateCommittedOffsets(offsets);
     }
 
     @SuppressWarnings("unchecked")
     @Test(timeout = 5000)
     public void testCommitCompletedOffsetsAsync_SUBSEQUENT_SYNC() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
+        ProcessorSubscription subscription = subscriptionForCommitTest(null);
         Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
                 new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
         doReturn(offsets).when(contextsMock).commitOffsets();
 
+        // No one completes async commit underlying this.
         subscription.commitCompletedOffsets(consumerMock, false);
 
         // Subsequent sync commit can proceed regardless of in-flight async commit


### PR DESCRIPTION
# Motivation

Decaton has been using `commitSync()` in pool-loop but there was some cases where it becomes a bottleneck especially when consumer's consuming in batch style where processing itself doesn't take much long due to latency awaiting OffsetCommit response from broker.

I think there's no point to wait offset commit's result synchronously in poll-loop except at 1. shutdown and 2. before rebalance.
This PR attempts to leverage async commit when decaton instance is consuming in regular loop so it won't be affected by high OffsetCommit latency from broker anymore.
There should be no essential difference with current way in terms of failure handling since we're anyway crushing exception from `commitSync()` now.