### PR TITLE
Prevent NPE when closing Metrics twice

### DIFF
--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -1,6 +1,6 @@
 Dynamic Property Configuration
 =============================
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: centraldogma,processor
 
 == Property Supplier

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,6 +1,6 @@
 Getting Started Decaton
 =======================
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: common,client,processor,protobuf
 
 Let's start from the most basic usage of Decaton client/processor.

--- a/docs/key-blocking.adoc
+++ b/docs/key-blocking.adoc
@@ -1,5 +1,5 @@
 = Key Blocking
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -1,6 +1,6 @@
 Monitoring Decaton
 ==================
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 This document guides you how to monitor your Decaton processor applications.

--- a/docs/rate-limiting.adoc
+++ b/docs/rate-limiting.adoc
@@ -1,5 +1,5 @@
 = Rate Limiting
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/retry-queueing.adoc
+++ b/docs/retry-queueing.adoc
@@ -1,5 +1,5 @@
 = Retry Queuing
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/task-compaction.adoc
+++ b/docs/task-compaction.adoc
@@ -1,5 +1,5 @@
 = Task Compaction
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/why-decaton.adoc
+++ b/docs/why-decaton.adoc
@@ -1,6 +1,6 @@
 Why Decaton
 ===========
-:base_version: 0.0.39
+:base_version: 0.0.40-SNAPSHOT
 :modules: processor
 
 This document explains why we have decided to create a new consumer framework.

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -77,7 +77,7 @@ public class Metrics {
         public void close() {
             synchronized (meterRefCounts) {
                 // traverse from the end to avoid arrayCopy
-                for (ListIterator<Meter> iterator = meters.listIterator(meters.size() - 1); iterator.hasNext(); ) {
+                for (ListIterator<Meter> iterator = meters.listIterator(meters.size()); iterator.hasPrevious(); ) {
                     Meter meter = iterator.previous();
                     Id id = meter.getId();
                     AtomicInteger count = meterRefCounts.get(id);


### PR DESCRIPTION
Fixes #58 

- Clear `meters` on `close()`
- Since `meters` is now mutable, synchronize `close()` and `meter()`
- Make `meterRefCounts` non-synchronized to avoid double locking
- Add nullcheck for counters in `meterRefCounts`