### PR TITLE
ProcessorSubscription refactoring

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/DeferredCompletion.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/DeferredCompletion.java
@@ -35,12 +35,4 @@ public interface DeferredCompletion {
     default <T> CompletableFuture<T> completeWith(CompletableFuture<T> future) {
         return future.whenComplete((r, e) -> complete());
     }
-
-    static DeferredCompletion combine(DeferredCompletion... completions) {
-        return () -> {
-            for (DeferredCompletion completion : completions) {
-                completion.complete();
-            }
-        };
-    }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/AssignmentManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/AssignmentManager.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.kafka.common.TopicPartition;
+
+import com.linecorp.decaton.processor.runtime.Utils.Timer;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class AssignmentManager {
+    /**
+     * Configurations representing initial state of partition contexts to be created.
+     */
+    @Value
+    @Accessors(fluent = true)
+    static
+    class AssignmentConfig {
+        boolean paused;
+    }
+
+    /**
+     * Interface to an assignment store that stores assigned partitions and its metadata.
+     */
+    interface AssignmentStore {
+        /**
+         * Return set of {@link TopicPartition}s that are currently assigned.
+         * @return set of assigned topic-partitions.
+         */
+        Set<TopicPartition> assignedPartitions();
+
+        /**
+         * Add new topic-partitions with associated configurations.
+         * @param partitions newly assigned partitions.
+         */
+        void addPartitions(Map<TopicPartition, AssignmentConfig> partitions);
+
+        /**
+         * Remove previously assigned topic-partitions.
+         * @param partitions partitions to remove.
+         */
+        void removePartition(Collection<TopicPartition> partitions);
+    }
+
+    private final AssignmentStore store;
+
+    AssignmentManager(AssignmentStore store) {
+        this.store = store;
+    }
+
+    /**
+     * Update assignment with new set of partitions.
+     * Revoked partitions and newly assigned partitions are computed with previous assignment and removed/added
+     * from/to the store.
+     * @param newAssignment new set of topic-partitions to assign.
+     */
+    public void assign(Collection<TopicPartition> newAssignment) {
+        Set<TopicPartition> newSet = new HashSet<>(newAssignment);
+        Set<TopicPartition> oldSet = store.assignedPartitions();
+        List<TopicPartition> removed = computeRemovedPartitions(oldSet, newSet);
+        List<TopicPartition> added = computeAddedPartitions(oldSet, newSet);
+        log.debug("Assignment update: removed:{}, added:{}, assignment:{}", removed, added, newSet);
+
+        partitionsRevoked(removed);
+        partitionsAssigned(added);
+    }
+
+    /**
+     * Repair given topic-partition that has detected as its offset has regression.
+     * {@link PartitionContext} associated with the given topic-partition gets re-created.
+     * @param tp topic-partition to repair.
+     */
+    public void repair(TopicPartition tp) {
+        log.info("Repairing partition: {}", tp);
+        List<TopicPartition> target = Collections.singletonList(tp);
+        partitionsRevoked(target);
+        partitionsAssigned(target);
+    }
+
+    private static List<TopicPartition> computeRemovedPartitions(
+            Set<TopicPartition> oldSet, Set<TopicPartition> newSet) {
+        return oldSet.stream().filter(tp -> !newSet.contains(tp)).collect(toList());
+    }
+
+    private static List<TopicPartition> computeAddedPartitions(
+            Set<TopicPartition> oldSet, Set<TopicPartition> newSet) {
+        return newSet.stream().filter(tp -> !oldSet.contains(tp)).collect(toList());
+    }
+
+    private void partitionsRevoked(Collection<TopicPartition> partitions) {
+        if (partitions.isEmpty()) {
+            return;
+        }
+        Timer timer = Utils.timer();
+        store.removePartition(partitions);
+        if (log.isInfoEnabled()) {
+            log.info("Removed {} partitions in {} ms",
+                     partitions.size(), Utils.formatNum(timer.elapsedMillis()));
+        }
+    }
+
+    private void partitionsAssigned(Collection<TopicPartition> partitions) {
+        if (partitions.isEmpty()) {
+            return;
+        }
+        Timer timer = Utils.timer();
+
+        Map<TopicPartition, AssignmentConfig> configs =
+                partitions.stream().collect(toMap(Function.identity(), ignored -> new AssignmentConfig(false)));
+        store.addPartitions(configs);
+        if (log.isInfoEnabled()) {
+            log.info("Added {} partitions in {} ms",
+                     partitions.size(), Utils.formatNum(timer.elapsedMillis()));
+        }
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/AssignmentManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/AssignmentManager.java
@@ -42,8 +42,7 @@ class AssignmentManager {
      */
     @Value
     @Accessors(fluent = true)
-    static
-    class AssignmentConfig {
+    static class AssignmentConfig {
         boolean paused;
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/CommitManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/CommitManager.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import java.time.Clock;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.Property;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Coordinates consumer offset commits.
+ */
+@Slf4j
+class CommitManager {
+    /**
+     * Interface to offset store that provides offsets ready to be committed and receives offset that has been
+     * committed for recording purpose.
+     */
+    interface OffsetsStore {
+        /**
+         * Return the map of {@link TopicPartition} to {@link OffsetAndMetadata} that are ready to be committed.
+         * @return offset ready to be committed.
+         */
+        Map<TopicPartition, OffsetAndMetadata> commitReadyOffsets();
+
+        /**
+         * Report offsets that has been successfully committed.
+         * @param offsets offsets that has been committed.
+         */
+        void storeCommittedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets);
+    }
+
+    private final Consumer<?, ?> consumer;
+    private final Property<Long> commitIntervalMillis;
+    private final OffsetsStore store;
+    private final Clock clock;
+
+    private long lastCommittedMillis;
+    private boolean asyncCommitInFlight;
+
+    CommitManager(Consumer<?, ?> consumer,
+                  Property<Long> commitIntervalMillis,
+                  OffsetsStore store,
+                  Clock clock) {
+        this.consumer = consumer;
+        this.commitIntervalMillis = commitIntervalMillis;
+        this.store = store;
+        this.clock = clock;
+    }
+
+    CommitManager(Consumer<?, ?> consumer, Property<Long> commitIntervalMillis, OffsetsStore store) {
+        this(consumer, commitIntervalMillis, store, Clock.systemDefaultZone());
+    }
+
+    /**
+     * Commit ready offsets asynchronously if {@link ProcessorProperties#CONFIG_COMMIT_INTERVAL_MS} ms has been
+     * elapsed since the last commit attempt.
+     */
+    void maybeCommitAsync() {
+        if (clock.millis() - lastCommittedMillis >= commitIntervalMillis.value()) {
+            try {
+                commitAsync();
+            } finally {
+                lastCommittedMillis = clock.millis();
+            }
+        }
+    }
+
+    /**
+     * Commit ready offsets synchronously.
+     * Errors are reported through exception and successful return of this method implies offsets are persisted
+     * in Kafka.
+     */
+    void commitSync() {
+        Map<TopicPartition, OffsetAndMetadata> offsets = store.commitReadyOffsets();
+        if (offsets.isEmpty()) {
+            log.debug("No new offsets to commit, skipping commit");
+            return;
+        }
+
+        log.debug("Committing offsets SYNC: {}", offsets);
+        consumer.commitSync(offsets);
+        store.storeCommittedOffsets(offsets);
+    }
+
+    /**
+     * Commit ready offsets asynchronously.
+     * Errors are not reported.
+     * Subsequent calls of this method while there's still in-flight async commit are ignored.
+     */
+    void commitAsync() {
+        Map<TopicPartition, OffsetAndMetadata> offsets = store.commitReadyOffsets();
+        if (offsets.isEmpty()) {
+            log.debug("No new offsets to commit, skipping commit");
+            return;
+        }
+
+        if (asyncCommitInFlight) {
+            // We would end up making multiple OffsetCommit requests containing same set of offsets if we proceed
+            // another async commit without waiting the first one to complete.
+            // This would be harmless if `decaton.commit.interval.ms` is set to sufficiently large, but otherwise
+            // we would make abusive offset commits despite there's no progress in processing.
+            log.debug("Skipping commit due to another async commit is currently in-flight");
+            return;
+        }
+        Thread callingThread = Thread.currentThread();
+        consumer.commitAsync(offsets, (ignored, exception) -> {
+            asyncCommitInFlight = false;
+            if (exception != null) {
+                log.warn("Offset commit failed asynchronously", exception);
+                return;
+            }
+            if (Thread.currentThread() != callingThread) {
+                // This isn't expected to happen (see below comment) but we check it with cheap cost
+                // just in case to avoid silent corruption.
+                log.error("BUG: commitAsync callback triggered by an unexpected thread: {}." +
+                          " Please report this to Decaton developers", Thread.currentThread());
+                return;
+            }
+
+            // Exception raised from the commitAsync callback bubbles up to Consumer.poll() so it kills the
+            // subscription thread.
+            // Basically the exception thrown from here is considered a bug, but failing to commit offset itself
+            // isn't usually critical for consumer's continuation availability so we grab it here widely.
+            try {
+                // Some thread and timing safety consideration about below operation.
+                // Thread safety:
+                // Below operation touches some thread-unsafe resources such as ProcessingContexts map and
+                // variable storing committed offset in ProcessingContext but we can assume this callback is
+                // thread safe because in all cases a callback for commitAsync is called from inside of
+                // Consumer.poll() which is called only by this (subscription) thread.
+                // Timing safety:
+                // At the time this callback is triggered there might be a change in ProcessingContexts map
+                // underlying contexts. It would occur in two cases:
+                // 1. When group rebalance is triggered and the context is dropped by revoke at partitionsRevoked().
+                // 2. When dynamic processor reload is triggered and the context is renewed by
+                // PartitionContexts.maybeHandlePropertyReload.
+                // The case 2 is safe (safe to keep updating committed offset in renewed PartitionContext) because
+                // it caries previously consuming offset without reset.
+                // The case 1 is somewhat suspicious but should still be safe, because whenever partition revoke
+                // happens it calls commitSync() through onPartitionsRevoked(). According to the document of
+                // commitAsync(), it is guaranteed that its callback is called before subsequent commitSync()
+                // returns. So when a context is dropped from PartitionContexts, there should be no in-flight
+                // commitAsync().
+                store.storeCommittedOffsets(offsets);
+            } catch (RuntimeException e) {
+                log.error("Unexpected exception caught while updating committed offset", e);
+            }
+        });
+        asyncCommitInFlight = true;
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/OffsetRegressionException.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/OffsetRegressionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+class OffsetRegressionException extends RuntimeException {
+    OffsetRegressionException(String message) {
+        super(message);
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/OutOfOrderCommitControl.java
@@ -81,7 +81,7 @@ public class OutOfOrderCommitControl {
 
     public synchronized DeferredCompletion reportFetchedOffset(long offset) {
         if (isRegressing(offset)) {
-            throw new IllegalArgumentException(String.format(
+            throw new OffsetRegressionException(String.format(
                     "offset regression %s: %d > %d", topicPartition, offset, latest));
         }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContext.java
@@ -106,10 +106,6 @@ public class PartitionContext {
         metrics.close();
     }
 
-    public boolean isOffsetRegressing(long offset) {
-        return commitControl.isRegressing(offset);
-    }
-
     public void addRequest(TaskRequest request) {
         partitionProcessor.addTask(request);
         if (lastQueueStarvedTime > 0) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContexts.java
@@ -39,7 +39,7 @@ import com.linecorp.decaton.processor.Property;
 import com.linecorp.decaton.processor.runtime.AssignmentManager.AssignmentConfig;
 import com.linecorp.decaton.processor.runtime.AssignmentManager.AssignmentStore;
 import com.linecorp.decaton.processor.runtime.CommitManager.OffsetsStore;
-import com.linecorp.decaton.processor.runtime.TaskConsumer.PartitionStates;
+import com.linecorp.decaton.processor.runtime.ConsumeManager.PartitionStates;
 import com.linecorp.decaton.processor.runtime.Utils.Task;
 
 public class PartitionContexts implements OffsetsStore, AssignmentStore, PartitionStates {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/PartitionContexts.java
@@ -34,9 +34,10 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.Property;
+import com.linecorp.decaton.processor.runtime.CommitManager.OffsetsStore;
 import com.linecorp.decaton.processor.runtime.Utils.Task;
 
-public class PartitionContexts {
+public class PartitionContexts implements OffsetsStore {
     private static final Logger logger = LoggerFactory.getLogger(PartitionContexts.class);
 
     private final SubscriptionScope scope;
@@ -108,8 +109,9 @@ public class PartitionContexts {
         destroyProcessors(contexts.keySet());
     }
 
-    // visible for testing
-    public Map<TopicPartition, OffsetAndMetadata> commitOffsets() {
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> commitReadyOffsets() {
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         for (PartitionContext context : contexts.values()) {
             context.offsetWaitingCommit().ifPresent(
@@ -119,7 +121,8 @@ public class PartitionContexts {
         return offsets;
     }
 
-    public void updateCommittedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    @Override
+    public void storeCommittedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
         for (Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
             TopicPartition tp = entry.getKey();
             long offset = entry.getValue().offset();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskConsumer.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskConsumer.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+import com.linecorp.decaton.processor.metrics.Metrics.SubscriptionMetrics;
+import com.linecorp.decaton.processor.runtime.Utils.Timer;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Implements workflow of consuming tasks from Kafka.
+ */
+@Slf4j
+class TaskConsumer implements AutoCloseable {
+    private static final long POLL_TIMEOUT_MILLIS = 100;
+
+    /**
+     * Interface to class storing partition's consumption state information.
+     */
+    interface PartitionStates {
+        /**
+         * Update all partitions state to latest and make below methods to return the fresh information.
+         */
+        void updatePartitionsStatus();
+
+        /**
+         * Return the list of partitions that needs to enter pause state.
+         * @return list of partitions to pause.
+         */
+        List<TopicPartition> partitionsNeedsPause();
+
+        /**
+         * Return the list of partitions that needs to recover from pause state.
+         * @return list of partitions to resume.
+         */
+        List<TopicPartition> partitionsNeedsResume();
+
+        /**
+         * Report list of partitions that has been successfully paused.
+         * @param partitions partitions that has been paused.
+         */
+        void partitionsPaused(List<TopicPartition> partitions);
+
+        /**
+         * Report list of partitions that has been successfully resumed.
+         * @param partitions partitions that has been resumed.
+         */
+        void partitionsResumed(List<TopicPartition> partitions);
+    }
+
+    /**
+     * Interface to handler class that implements core logic in reaction to consumer events.
+     */
+    interface ConsumerHandler {
+        /**
+         * Do any preparation for upcoming rebalance.
+         */
+        void prepareForRebalance();
+
+        /**
+         * Update assignment with given partitions list.
+         * @param newAssignment list of partitions that are now actively assigned.
+         */
+        void updateAssignment(Collection<TopicPartition> newAssignment);
+
+        /**
+         * Process a {@link ConsumerRecord} that has been consumed from the topic.
+         * @param record a record that has been fetched from the target topic.
+         */
+        void receive(ConsumerRecord<String, byte[]> record);
+    }
+
+    private final Consumer<String, byte[]> consumer;
+    private final PartitionStates states;
+    private final ConsumerHandler handler;
+    private final SubscriptionMetrics metrics;
+    private final AtomicBoolean consumerClosing;
+
+    TaskConsumer(Consumer<String, byte[]> consumer,
+                 PartitionStates states,
+                 ConsumerHandler handler,
+                 SubscriptionMetrics metrics) {
+        this.consumer = consumer;
+        this.states = states;
+        this.handler = handler;
+        this.metrics = metrics;
+        consumerClosing = new AtomicBoolean();
+    }
+
+    void init(Collection<String> subscribeTopics) {
+        List<TopicPartition> pausedPartitions = new ArrayList<>();
+        consumer.subscribe(subscribeTopics, new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                // KafkaConsumer#close has been changed to invoke onPartitionRevoked since Kafka 2.4.0.
+                // Since we're doing cleanup procedure on shutdown manually
+                // so just immediately return if consumer is already closing
+                if (consumerClosing.get()) {
+                    return;
+                }
+
+                handler.prepareForRebalance();
+                pausedPartitions.addAll(consumer.paused());
+            }
+
+            @Override
+            public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                handler.updateAssignment(partitions);
+
+                // Consumer rebalance resets all pause states of assigned partitions even though they
+                // haven't moved over from/to different consumer instance.
+                // Need to re-call pause with originally paused partitions to bring state back consistent.
+                try {
+                    consumer.pause(pausedPartitions);
+                } finally {
+                    pausedPartitions.clear();
+                }
+            }
+        });
+    }
+
+    void poll() {
+        Timer timer = Utils.timer();
+        ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT_MILLIS);
+        metrics.consumerPollTime.record(timer.duration());
+
+        timer = Utils.timer();
+        records.forEach(handler::receive);
+        metrics.handleRecordsTime.record(timer.duration());
+
+        states.updatePartitionsStatus();
+
+        timer = Utils.timer();
+        pausePartitions(consumer);
+        resumePartitions(consumer);
+        metrics.handlePausesTime.record(timer.duration());
+    }
+
+    private void pausePartitions(Consumer<?, ?> consumer) {
+        List<TopicPartition> pausedPartitions = states.partitionsNeedsPause();
+        if (pausedPartitions.isEmpty()) {
+            return;
+        }
+
+        log.debug("Pausing partitions: {}", pausedPartitions);
+        consumer.pause(pausedPartitions);
+        states.partitionsPaused(pausedPartitions);
+    }
+
+    private void resumePartitions(Consumer<?, ?> consumer) {
+        List<TopicPartition> resumedPartitions = states.partitionsNeedsResume();
+        if (resumedPartitions.isEmpty()) {
+            return;
+        }
+
+        log.debug("Resuming partitions: {}", resumedPartitions);
+        consumer.resume(resumedPartitions);
+        states.partitionsResumed(resumedPartitions);
+    }
+
+    @Override
+    public void close() {
+        consumerClosing.set(true);
+        consumer.close();
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/AssignmentManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/AssignmentManagerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.runtime.AssignmentManager.AssignmentConfig;
+import com.linecorp.decaton.processor.runtime.AssignmentManager.AssignmentStore;
+
+public class AssignmentManagerTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Captor
+    private ArgumentCaptor<Map<TopicPartition, AssignmentConfig>> captor;
+
+    @Mock
+    private AssignmentStore store;
+
+    private AssignmentManager assignManager;
+
+    @Before
+    public void setUp() {
+        assignManager = new AssignmentManager(store);
+    }
+
+    private static TopicPartition tp(int partition) {
+        return new TopicPartition("topic", partition);
+    }
+
+    @Test
+    public void testAssign() {
+        doReturn(emptySet()).when(store).assignedPartitions();
+        List<TopicPartition> partitions = Arrays.asList(tp(1), tp(2), tp(3));
+        assignManager.assign(partitions);
+
+        verify(store, times(1)).addPartitions(captor.capture());
+        HashSet<TopicPartition> newAssign = new HashSet<>(partitions);
+        assertEquals(newAssign, captor.getValue().keySet());
+        verify(store, never()).removePartition(any());
+
+        doReturn(newAssign).when(store).assignedPartitions();
+        partitions = Arrays.asList(tp(2), tp(3), tp(4), tp(5));
+        assignManager.assign(partitions);
+
+        verify(store, times(2)).addPartitions(captor.capture());
+        assertEquals(new HashSet<>(Arrays.asList(tp(4), tp(5))), captor.getValue().keySet());
+        verify(store, never()).removePartition(new HashSet<>(Arrays.asList(tp(1))));
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/CommitManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/CommitManagerTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.DynamicProperty;
+import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.CommitManager.OffsetsStore;
+
+public class CommitManagerTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private Consumer<byte[], byte[]> consumer;
+
+    private final DynamicProperty<Long> commitIntervalMillis =
+            new DynamicProperty<>(ProcessorProperties.CONFIG_COMMIT_INTERVAL_MS);
+
+    @Mock
+    private OffsetsStore store;
+
+    @Mock
+    private Clock clock;
+
+    private CommitManager commitManager;
+
+    @Before
+    public void setUp() {
+        commitManager = spy(new CommitManager(consumer, commitIntervalMillis, store, clock));
+    }
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync() {
+        // When committed ended up successfully update committed offsets
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+
+        commitManager.commitSync();
+        verify(consumer, times(1)).commitSync(any(Map.class));
+        verify(store, times(1)).storeCommittedOffsets(offsets);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync_NO_COMMIT() {
+        // When target offsets is empty do not attempt any commit
+        doReturn(emptyMap()).when(store).commitReadyOffsets();
+
+        commitManager.commitSync();
+        verify(consumer, never()).commitSync(any(Map.class));
+        verify(consumer, never()).commitAsync(any(Map.class), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsSync_FAIL() {
+        // When commit raised an exception do not update committed offsets
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+        doThrow(new RuntimeException("error")).when(consumer).commitSync(any(Map.class));
+        try {
+            commitManager.commitSync();
+        } catch (RuntimeException ignored) {
+            // ignore
+        }
+        verify(store, never()).storeCommittedOffsets(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync() throws InterruptedException {
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            OffsetCommitCallback cb = invocation.getArgument(1);
+            cbRef.set(cb);
+            return null;
+        }).when(consumer).commitAsync(any(Map.class), any());
+
+        commitManager.commitAsync();
+
+        // Committed offsets should not be updated yet here
+        verify(consumer, times(1)).commitAsync(any(Map.class), any());
+        verify(store, never()).storeCommittedOffsets(any());
+
+        // Subsequent async commit attempt should be ignored until the in-flight one completes
+        commitManager.commitAsync();
+        verify(consumer, times(1)).commitAsync(any(Map.class), any());
+        verify(store, never()).storeCommittedOffsets(any());
+
+        // Committed offset should be updated once the in-flight request completes
+        cbRef.get().onComplete(offsets, null);
+        verify(store, times(1)).storeCommittedOffsets(offsets);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync_FAIL() throws InterruptedException {
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            OffsetCommitCallback cb = invocation.getArgument(1);
+            cbRef.set(cb);
+            return null;
+        }).when(consumer).commitAsync(any(Map.class), any());
+
+        commitManager.commitAsync();
+        // If async commit fails it should never update committed offset
+        cbRef.get().onComplete(offsets, new RuntimeException("failure"));
+        verify(store, never()).storeCommittedOffsets(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 5000)
+    public void testCommitCompletedOffsetsAsync_SUBSEQUENT_SYNC() {
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+
+        // No one completes async commit underlying this.
+        commitManager.commitAsync();
+
+        // Subsequent sync commit can proceed regardless of in-flight async commit
+        commitManager.commitSync();
+        verify(consumer, times(1)).commitSync(any(Map.class));
+    }
+
+    @Test
+    public void testMaybeCommitAsync() {
+        commitIntervalMillis.set(1000L);
+        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
+                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
+        doReturn(offsets).when(store).commitReadyOffsets();
+
+        doReturn(1000L).when(clock).millis();
+        commitManager.maybeCommitAsync();
+        verify(commitManager, times(1)).commitAsync();
+
+        doReturn(1001L).when(clock).millis();
+        commitManager.maybeCommitAsync();
+        // No new commits.
+        verify(commitManager, times(1)).commitAsync();
+
+        doReturn(1000L + commitIntervalMillis.value()).when(clock).millis();
+        commitManager.maybeCommitAsync();
+        verify(commitManager, times(2)).commitAsync();
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ConsumeManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ConsumeManagerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.metrics.Metrics.SubscriptionMetrics;
+import com.linecorp.decaton.processor.runtime.ConsumeManager.ConsumerHandler;
+import com.linecorp.decaton.processor.runtime.ConsumeManager.PartitionStates;
+
+public class ConsumeManagerTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    static final String TOPIC = "topic";
+
+    @Mock
+    Consumer<String, byte[]> consumer;
+
+    @Captor
+    ArgumentCaptor<ConsumerRecord<String, byte[]>> recordsCaptor;
+
+    @Mock
+    PartitionStates states;
+
+    @Mock
+    ConsumerHandler handler;
+
+    SubscriptionMetrics metrics;
+
+    private ConsumeManager consumeManager;
+
+    @Before
+    public void setUp() {
+        metrics = Metrics.withTags("subscription", "subsc").new SubscriptionMetrics();
+        consumeManager = new ConsumeManager(consumer, states, handler, metrics);
+        consumeManager.init(Collections.singletonList(TOPIC));
+    }
+
+    private static TopicPartition tp(int partition) {
+        return new TopicPartition(TOPIC, partition);
+    }
+
+    @Test
+    public void poll() {
+        List<ConsumerRecord<String, byte[]>> records = Arrays.asList(
+                new ConsumerRecord<>(TOPIC, 1, 100, "key", new byte[0]),
+                new ConsumerRecord<>(TOPIC, 1, 101, "key", new byte[0]),
+                new ConsumerRecord<>(TOPIC, 1, 102, "key", new byte[0]));
+        ConsumerRecords<String, byte[]> consumerRecords =
+                new ConsumerRecords<>(Collections.singletonMap(new TopicPartition(TOPIC, 1), records));
+        doReturn(consumerRecords).when(consumer).poll(anyLong());
+
+        List<TopicPartition> partitionsNeedsPause = new ArrayList<>(Arrays.asList(tp(1)));
+        List<TopicPartition> partitionsNeedsResume = new ArrayList<>(Arrays.asList(tp(2)));
+        List<TopicPartition> partitionsPaused = new ArrayList<>(Arrays.asList(tp(2)));
+
+        doAnswer(invocation -> {
+            partitionsNeedsPause.add(tp(3));
+            return null;
+        }).when(states).updatePartitionsStatus();
+        doReturn(partitionsNeedsPause).when(states).partitionsNeedsPause();
+        doReturn(partitionsNeedsResume).when(states).partitionsNeedsResume();
+        doAnswer(invocation -> {
+            partitionsPaused.addAll(invocation.getArgument(0));
+            return null;
+        }).when(states).partitionsPaused(any());
+        doAnswer(invocation -> {
+            partitionsPaused.removeAll(invocation.getArgument(0));
+            return null;
+        }).when(states).partitionsResumed(any());
+
+        consumeManager.poll();
+
+        // All records were passed to handler's receive
+        verify(handler, times(records.size())).receive(recordsCaptor.capture());
+        assertEquals(records, recordsCaptor.getAllValues());
+
+        // Pause/resume handling
+        verify(consumer, times(1)).pause(Arrays.asList(tp(1), tp(3)));
+        verify(consumer, times(1)).resume(Arrays.asList(tp(2)));
+        assertEquals(Arrays.asList(tp(1), tp(3)), partitionsPaused);
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionContextsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/PartitionContextsTest.java
@@ -109,7 +109,7 @@ public class PartitionContextsTest {
         long offset = 1L;
         doReturn(OptionalLong.of(offset)).when(context).offsetWaitingCommit();
 
-        Map<TopicPartition, OffsetAndMetadata> committedOffsets = contexts.commitOffsets();
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = contexts.commitReadyOffsets();
         assertEquals(offset + 1, committedOffsets.get(context.topicPartition()).offset());
     }
 
@@ -120,12 +120,12 @@ public class PartitionContextsTest {
         doReturn(OptionalLong.empty()).when(cts.get(0)).offsetWaitingCommit();
         doReturn(OptionalLong.empty()).when(cts.get(1)).offsetWaitingCommit();
 
-        Map<TopicPartition, OffsetAndMetadata> committedOffsets = contexts.commitOffsets();
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = contexts.commitReadyOffsets();
         // No record has been committed so returned map should be empty
         assertTrue(committedOffsets.isEmpty());
 
         doReturn(OptionalLong.of(1)).when(cts.get(0)).offsetWaitingCommit();
-        committedOffsets = contexts.commitOffsets();
+        committedOffsets = contexts.commitReadyOffsets();
         // No record has been committed for tp1 so the returned map shouldn't contain entry for it.
         assertEquals(1, committedOffsets.size());
         Entry<TopicPartition, OffsetAndMetadata> entry = committedOffsets.entrySet().iterator().next();
@@ -140,7 +140,7 @@ public class PartitionContextsTest {
         offsets.put(ctxs.get(0).topicPartition(), new OffsetAndMetadata(101));
         offsets.put(ctxs.get(1).topicPartition(), new OffsetAndMetadata(201));
 
-        contexts.updateCommittedOffsets(offsets);
+        contexts.storeCommittedOffsets(offsets);
 
         // PartitionContext manages their "completed" offset so its minus 1 from committed offset
         // which indicates the offset to "fetch next".

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -16,32 +16,19 @@
 
 package com.linecorp.decaton.processor.runtime;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Rule;
@@ -134,119 +121,5 @@ public class ProcessorSubscriptionTest {
                                    State.RUNNING,
                                    State.SHUTTING_DOWN,
                                    State.TERMINATED), states);
-    }
-
-    private ProcessorSubscription subscriptionForCommitTest() {
-        SubscriptionScope scope = scope("topic");
-        return new ProcessorSubscription(
-                scope,
-                () -> consumerMock,
-                null,
-                scope.props(),
-                null,
-                contextsMock);
-    }
-
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsSync() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        // When committed ended up successfully update committed offsets
-        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
-                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
-        doReturn(offsets).when(contextsMock).commitOffsets();
-        subscription.commitCompletedOffsets(consumerMock, true);
-        verify(contextsMock, times(1)).updateCommittedOffsets(offsets);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsSync_NO_COMMIT() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        // When target offsets is empty do not attempt any commit
-        doReturn(emptyMap()).when(contextsMock).commitOffsets();
-        subscription.commitCompletedOffsets(consumerMock, true);
-        verify(consumerMock, never()).commitSync(any(Map.class));
-        verify(consumerMock, never()).commitAsync(any(Map.class), any());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsSync_FAIL() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        // When commit raised an exception do not update committed offsets
-        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
-                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
-        doReturn(offsets).when(contextsMock).commitOffsets();
-        doThrow(new RuntimeException("error")).when(consumerMock).commitSync(any(Map.class));
-        try {
-            subscription.commitCompletedOffsets(consumerMock, true);
-        } catch (RuntimeException ignored) {
-            // ignore
-        }
-        verify(contextsMock, never()).updateCommittedOffsets(any());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsAsync() throws InterruptedException {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
-                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
-        doReturn(offsets).when(contextsMock).commitOffsets();
-        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
-        doAnswer(invocation -> {
-            OffsetCommitCallback cb = invocation.getArgument(1);
-            cbRef.set(cb);
-            return null;
-        }).when(consumerMock).commitAsync(any(Map.class), any());
-        subscription.commitCompletedOffsets(consumerMock, false);
-
-        // Committed offsets should not be updated yet here
-        verify(consumerMock, times(1)).commitAsync(any(Map.class), any());
-        verify(contextsMock, never()).updateCommittedOffsets(any());
-
-        // Subsequent async commit attempt should be ignored until the in-flight one completes
-        subscription.commitCompletedOffsets(consumerMock, false);
-        verify(consumerMock, times(1)).commitAsync(any(Map.class), any());
-        verify(contextsMock, never()).updateCommittedOffsets(any());
-
-        // Committed offset should be updated once the in-flight request completes
-        cbRef.get().onComplete(offsets, null);
-        verify(contextsMock, times(1)).updateCommittedOffsets(offsets);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsAsync_FAIL() throws InterruptedException {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
-                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
-        doReturn(offsets).when(contextsMock).commitOffsets();
-        AtomicReference<OffsetCommitCallback> cbRef = new AtomicReference<>();
-        doAnswer(invocation -> {
-            OffsetCommitCallback cb = invocation.getArgument(1);
-            cbRef.set(cb);
-            return null;
-        }).when(consumerMock).commitAsync(any(Map.class), any());
-        subscription.commitCompletedOffsets(consumerMock, false);
-        // If async commit fails it should never update committed offset
-        cbRef.get().onComplete(offsets, new RuntimeException("failure"));
-        verify(contextsMock, never()).updateCommittedOffsets(offsets);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testCommitCompletedOffsetsAsync_SUBSEQUENT_SYNC() {
-        ProcessorSubscription subscription = subscriptionForCommitTest();
-        Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(
-                new TopicPartition("topic", 0), new OffsetAndMetadata(1234, null));
-        doReturn(offsets).when(contextsMock).commitOffsets();
-
-        // No one completes async commit underlying this.
-        subscription.commitCompletedOffsets(consumerMock, false);
-
-        // Subsequent sync commit can proceed regardless of in-flight async commit
-        subscription.commitCompletedOffsets(consumerMock, true);
-        verify(consumerMock, times(1)).commitSync(any(Map.class));
     }
 }


### PR DESCRIPTION
As we talked in #53 , `ProcessorSubscription`'s getting bigger and complex by many functions being added to it.
I've attempted to refactor it by mainly extracting things into a separate classes.
The work is still in progress and I'm still considering what would be the best design (especially for TaskConsumer).
Please give early feedback if any!

Some notable changes that might impacts decaton's behavior:
* Stopped checking "offset regression" in rebalance listener and replaced it with `OffsetRegressionException` + on-demand repair.
* `contexts.maybeHandlePropertyReload()` now happens after updateHighWatermark, pause, resume