### PR TITLE
Make key deserializer of KafkaConsumer configurable

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/BlacklistedKeysFilter.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/BlacklistedKeysFilter.java
@@ -37,11 +37,11 @@ class BlacklistedKeysFilter {
              .listen((oldValue, newValue) -> ignoreKeys = new HashSet<>(newValue));
     }
 
-    boolean shouldTake(ConsumerRecord<String, byte[]> record) {
+    boolean shouldTake(String key) {
         // Preceding isEmpty() check is for reducing tiny overhead applied for each contains() by calling
         // Object#hashCode. Since ignoreKeys should be empty for most cases..
-        if (!ignoreKeys.isEmpty() && ignoreKeys.contains(record.key())) {
-            logger.debug("Ignore task which has key configured to ignore: {}", record.key());
+        if (!ignoreKeys.isEmpty() && ignoreKeys.contains(key)) {
+            logger.debug("Ignore task which has key configured to ignore: {}", key);
             return false;
         }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumerSupplier.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumerSupplier.java
@@ -27,14 +27,10 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 
-public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
+public class ConsumerSupplier implements Supplier<Consumer<byte[], byte[]>> {
     public static final int MAX_MAX_POLL_RECORDS = 100;
 
-    private static final Map<String, String> configDefaults = new HashMap<String, String>() {{
-        put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-    }};
     private static final Map<String, String> configOverwrites = new HashMap<String, String>() {{
         put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     }};
@@ -46,15 +42,12 @@ public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
     }
 
     @Override
-    public Consumer<String, byte[]> get() {
-        return new KafkaConsumer<>(mergedProps(), null, new ByteArrayDeserializer());
+    public Consumer<byte[], byte[]> get() {
+        return new KafkaConsumer<>(mergedProps(), new ByteArrayDeserializer(), new ByteArrayDeserializer());
     }
 
     private Properties mergedProps() {
         Properties props = new Properties();
-        for (Entry<String, String> entry : configDefaults.entrySet()) {
-            props.setProperty(entry.getKey(), entry.getValue());
-        }
         for (String key : config.stringPropertyNames()) {
             props.setProperty(key, config.getProperty(key));
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumerSupplier.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumerSupplier.java
@@ -32,6 +32,9 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
     public static final int MAX_MAX_POLL_RECORDS = 100;
 
+    private static final Map<String, String> configDefaults = new HashMap<String, String>() {{
+        put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    }};
     private static final Map<String, String> configOverwrites = new HashMap<String, String>() {{
         put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     }};
@@ -44,11 +47,14 @@ public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
 
     @Override
     public Consumer<String, byte[]> get() {
-        return new KafkaConsumer<>(mergedProps(), new StringDeserializer(), new ByteArrayDeserializer());
+        return new KafkaConsumer<>(mergedProps(), null, new ByteArrayDeserializer());
     }
 
     private Properties mergedProps() {
         Properties props = new Properties();
+        for (Entry<String, String> entry : configDefaults.entrySet()) {
+            props.setProperty(entry.getKey(), entry.getValue());
+        }
         for (String key : config.stringPropertyNames()) {
             props.setProperty(key, config.getProperty(key));
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/Processors.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/Processors.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.decaton.common.Deserializer;
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.TaskExtractor;
 import com.linecorp.decaton.processor.metrics.Metrics;
@@ -33,15 +34,18 @@ public class Processors<T> {
 
     private final List<DecatonProcessorSupplier<T>> suppliers;
     private final DecatonProcessorSupplier<byte[]> retryProcessorSupplier;
+    private final Deserializer<String> keyDeserializer;
     private final TaskExtractor<T> taskExtractor;
     private final TaskExtractor<T> retryTaskExtractor;
 
     public Processors(List<DecatonProcessorSupplier<T>> suppliers,
                       DecatonProcessorSupplier<byte[]> retryProcessorSupplier,
+                      Deserializer<String> keyDeserializer,
                       TaskExtractor<T> taskExtractor,
                       TaskExtractor<T> retryTaskExtractor) {
         this.suppliers = Collections.unmodifiableList(suppliers);
         this.retryProcessorSupplier = retryProcessorSupplier;
+        this.keyDeserializer = keyDeserializer;
         this.taskExtractor = taskExtractor;
         this.retryTaskExtractor = retryTaskExtractor;
     }
@@ -111,5 +115,9 @@ public class Processors<T> {
         if (retryProcessorSupplier != null) {
             retryProcessorSupplier.leaveThreadScope(subscriptionId, tp, threadId);
         }
+    }
+
+    public Deserializer<String> keyDeserializer() {
+        return keyDeserializer;
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/serialization/StringDeserializer.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/serialization/StringDeserializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.serialization;
+
+import com.linecorp.decaton.common.Deserializer;
+
+public class StringDeserializer implements Deserializer<String> {
+    @Override
+    public String deserialize(byte[] bytes) {
+        if (bytes == null)
+            return null;
+        else
+            return new String(bytes);
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -67,7 +67,7 @@ public class ProcessorSubscriptionTest {
      * A mock consumer which exposes rebalance listener so that can be triggered manually
      * ({@link MockConsumer} doesn't simulate rebalance listener invocation. refs: KAFKA-6968).
      */
-    private static class DecatonMockConsumer extends MockConsumer<String, byte[]> {
+    private static class DecatonMockConsumer extends MockConsumer<byte[], byte[]> {
         private volatile ConsumerRebalanceListener rebalanceListener;
 
         private DecatonMockConsumer() {
@@ -82,7 +82,7 @@ public class ProcessorSubscriptionTest {
     }
 
     @Mock
-    private Consumer<String, byte[]> consumerMock;
+    private Consumer<byte[], byte[]> consumerMock;
 
     @Mock
     private PartitionContexts contextsMock;
@@ -95,7 +95,7 @@ public class ProcessorSubscriptionTest {
                 ProcessorProperties.builder().build());
     }
 
-    private static ProcessorSubscription subscription(Consumer<String, byte[]> consumer,
+    private static ProcessorSubscription subscription(Consumer<byte[], byte[]> consumer,
                                                       SubscriptionStateListener listener,
                                                       TopicPartition tp) {
         SubscriptionScope scope = scope(tp.topic());

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorsTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.serialization.StringDeserializer;
 import com.linecorp.decaton.protocol.Sample.HelloTask;
 
 public class ProcessorsTest {
@@ -64,6 +65,7 @@ public class ProcessorsTest {
 
         Processors<HelloTask> processors = new Processors<>(
                 suppliers, null,
+                new StringDeserializer(),
                 new DefaultTaskExtractor<>(bytes -> HelloTask.getDefaultInstance()),
                 null);
 


### PR DESCRIPTION
Hello, decaton team.

We are consuming non-decaton topic using decaton processor.
https://github.com/line/decaton/blob/master/docs/consuming-any-data.adoc

Decaton only accepts `String` key for consuming topic now.
Current implementation is using hard-coded `StringDeserializer`.
However, Our topic is using `Long` type key.
We want to use `ProcessingContext.key()` inside the processor, but it will be broken string.

This patch enables to handle any type of the key correctly.
You can specify original `Deserializer` to `KafkaConsumer` by consumer property `key.deserializer`.
This patch will not change consumer key type from `String` for compatibility.
So `key.deserializer` property only accepts subclass of `Deserializer<String>`.

In our case, we can use a arbitrary deserializer such as `LongToStringDeserializer` for `Long` key topics by this patch.
It's better than broken string.
This is just a special use case of decaton, so I don't think decaton should handle the key by raw type for non-decaton topics.