### PR TITLE
Fix calling thread assertion to be applicable for usage treating ProcessorSubscription as Runnable

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -133,13 +133,15 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
                 log.debug("Skipping commit due to another async commit is currently in-flight");
                 return;
             }
+
+            Thread pollThread = Thread.currentThread();
             consumer.commitAsync(commitOffsets, (offsets, exception) -> {
                 asyncCommitInFlight = false;
                 if (exception != null) {
                     log.warn("Offset commit failed asynchronously", exception);
                     return;
                 }
-                if (Thread.currentThread() != this) {
+                if (Thread.currentThread() != pollThread) {
                     // This isn't expected to happen (see below comment) but we check it with cheap cost
                     // just in case to avoid silent corruption.
                     log.error("BUG: commitAsync callback triggered by an unexpected thread: {}." +


### PR DESCRIPTION
Fixes #62 

`ProcessorSubscription` is a `Thread` hence it's `Runnable` as well, means it might be executed in a thread different from `ProcessorSubscription` itself.
The point of the assertion is to make sure the thread calling async commit's callback is the same as the thread called `commitAsync` so we should be able to relax the check to expect this case.

/cc @mauhiz 