### PR TITLE
Publish decaton testing

### DIFF
--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -15,20 +15,18 @@
  */
 
 dependencies {
-    implementation project(':processor')
-    implementation project(':protobuf')
+    compile project(':processor')
+    compile project(':protobuf')
 
-    implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
-    implementation "org.apache.kafka:kafka_2.12:$kafkaVersion"
-    implementation "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-    implementation "org.apache.kafka:kafka_2.12:$kafkaVersion:test"
+    compile "org.apache.kafka:kafka-clients:$kafkaVersion"
+    compile "org.apache.kafka:kafka_2.12:$kafkaVersion"
 
-    implementation('org.apache.zookeeper:zookeeper:3.5.6') {
+    compile('org.apache.zookeeper:zookeeper:3.5.6') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'log4j', module: 'log4j'
     }
-    implementation "junit:junit:$junitVersion"
-    implementation "org.hamcrest:hamcrest-all:$hamcrestVersion"
+    compile "junit:junit:$junitVersion"
+    compile "org.hamcrest:hamcrest-all:$hamcrestVersion"
 
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,9 +14,6 @@
  * under the License.
  */
 
-ext {
-    noPublish = true
-}
 dependencies {
     implementation project(':processor')
     implementation project(':protobuf')


### PR DESCRIPTION
## Summary
- `testing` module is useful not only for decaton-internal test, but also general Kafka-client integration testing
- publish `testing` module to make writing integration-test for users