### PR TITLE
Exclude class-path header from manifest fixes #66

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,7 @@ subprojects {
 
     configurations {
         shade
-        // A configuration that indicates a dependency is not necessary to be added to resulting shadow jar.
-        // We define this instead of using built-in "shadow" configuration not to include these dependencies in
-        // manifest's class-path header. (refs: https://github.com/johnrengelman/shadow/issues/324)
-        shadowed
-
-        compile.extendsFrom(shade, shadowed)
+        compile.extendsFrom(shade)
         itCompile.extendsFrom(compile)
     }
 
@@ -135,14 +130,17 @@ subprojects {
                                 } else {
                                     depListNode = new Node(rootNode, 'dependencies')
                                 }
-                                project.configurations.shadowed.allDependencies.each { dep ->
-                                    if (project.configurations.compile.allDependencies.find { compileDep -> compileDep.name == dep.name }) {
-                                        def depNode = new Node(depListNode, 'dependency')
-                                        depNode.appendNode('groupId', dep.group)
-                                        def prefix = dep.group == 'com.linecorp.decaton' && !dep.name.startsWith('decaton-') ? 'decaton-' : ''
-                                        depNode.appendNode('artifactId', prefix + dep.name)
-                                        depNode.appendNode('version', dep.version)
-                                        depNode.appendNode('scope', 'compile')
+
+                                project.configurations.compile.allDependencies.each { dep ->
+                                    if (!shadeAllDependencies) {
+                                        if (!project.configurations.shade.allDependencies.contains(dep)) {
+                                            def depNode = new Node(depListNode, 'dependency')
+                                            depNode.appendNode('groupId', dep.group)
+                                            def prefix = dep.group == 'com.linecorp.decaton' && !dep.name.startsWith('decaton-') ? 'decaton-' : ''
+                                            depNode.appendNode('artifactId', prefix + dep.name)
+                                            depNode.appendNode('version', dep.version)
+                                            depNode.appendNode('scope', 'compile')
+                                        }
                                     }
                                 }
                             }
@@ -178,18 +176,6 @@ subprojects {
             signing {
                 required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
                 sign publishing.publications.mavenJava
-            }
-        }
-
-        if (!shadeAllDependencies) {
-            // Copy all dependencies declared with `runtime`(and so `compile`) configuration to `shadowed`
-            // configuration unless they declared as `shade` dependency.
-            // This copy is necessary because we're making `compile` configuration to extend `shade`
-            // configuration in order to add `shade` dependencies to compilation classpath as well.
-            project.configurations.runtime.allDependencies.each { dep ->
-                if (!project.configurations.shade.allDependencies.contains(dep)) {
-                    project.dependencies.add("shadowed", dep)
-                }
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,13 @@ subprojects {
 
     configurations {
         shade
-        compile.extendsFrom(shade)
-        itCompile.extendsFrom compile
+        // A configuration that indicates a dependency is not necessary to be added to resulting shadow jar.
+        // We define this instead of using built-in "shadow" configuration not to include these dependencies in
+        // manifest's class-path header. (refs: https://github.com/johnrengelman/shadow/issues/324)
+        shadowed
+
+        compile.extendsFrom(shade, shadowed)
+        itCompile.extendsFrom(compile)
     }
 
     sourceSets.create('it') {
@@ -130,7 +135,7 @@ subprojects {
                                 } else {
                                     depListNode = new Node(rootNode, 'dependencies')
                                 }
-                                project.configurations.shadow.allDependencies.each { dep ->
+                                project.configurations.shadowed.allDependencies.each { dep ->
                                     if (project.configurations.compile.allDependencies.find { compileDep -> compileDep.name == dep.name }) {
                                         def depNode = new Node(depListNode, 'dependency')
                                         depNode.appendNode('groupId', dep.group)
@@ -177,13 +182,13 @@ subprojects {
         }
 
         if (!shadeAllDependencies) {
-            // Copy all dependencies declared with `runtime`(and so `compile`) configuration to `shadow`
+            // Copy all dependencies declared with `runtime`(and so `compile`) configuration to `shadowed`
             // configuration unless they declared as `shade` dependency.
             // This copy is necessary because we're making `compile` configuration to extend `shade`
             // configuration in order to add `shade` dependencies to compilation classpath as well.
             project.configurations.runtime.allDependencies.each { dep ->
                 if (!project.configurations.shade.allDependencies.contains(dep)) {
-                    project.dependencies.add("shadow", dep)
+                    project.dependencies.add("shadowed", dep)
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,8 @@ subprojects {
                                     depListNode = new Node(rootNode, 'dependencies')
                                 }
 
-                                project.configurations.compile.allDependencies.each { dep ->
-                                    if (!shadeAllDependencies) {
+                                if (!shadeAllDependencies) {
+                                    project.configurations.compile.allDependencies.each { dep ->
                                         if (!project.configurations.shade.allDependencies.contains(dep)) {
                                             def depNode = new Node(depListNode, 'dependency')
                                             depNode.appendNode('groupId', dep.group)


### PR DESCRIPTION
- As #66 describes, shadowJar task includes class-path header which lists `shadow` dependencies in MANIFEST.MF
- Checking johnrengelman/shadow#324, it seems like built-in `shadow` configuration is "reserved" for the purpose to exclude dependency from resulting executable jar, which indeed needs manifest's class-path attributes
- This PR tries not to include class-path in manifest by stopping to use `shadow` configuration