### PR TITLE
Publish benchmark module locally to add capability to implement custom runner

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,11 +13,105 @@ Build a shadowJar:
 
 Run with arbitrary parameters:
 ```sh
-./debm.sh
+./debm.sh \
  --title "Decaton" \
  --runner com.linecorp.decaton.benchmark.DecatonRunner \
  --tasks 10000 \
  --warmup 100 \
  --simulate-latency=10 \
  --param=decaton.partition.concurrency=20 
+```
+
+How to run benchmark with custom Runner
+=======================================
+
+#### Publish `benchmark` module locally:
+
+```sh
+cd /path/to/decaton/benchmark
+
+../gradlew :benchmark:publishToMavenLocal -x sign
+```
+
+#### Add `decaton-benchmark` dependency to your custom runner project:
+
+build.gradle
+
+```groovy
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation "com.linecorp.decaton:decaton-benchmark:$DECATON_VERSION"
+}
+```
+
+#### Implement com.linecorp.decaton.benchmark.Runner:
+
+CustomRunner.java
+
+```java
+package com.example;
+
+import com.linecorp.decaton.benchmark.Recording;
+import com.linecorp.decaton.benchmark.ResourceTracker;
+import com.linecorp.decaton.benchmark.Runner;
+import com.linecorp.decaton.benchmark.Task;
+
+public class CustomRunner implements Runner {
+    @Override
+    public void init(Config config, Recording recording, ResourceTracker resourceTracker)
+            throws InterruptedException {
+        // initialize and start your consumer
+    }
+
+    @Override
+    public void close() throws Exception {
+        // cleanup
+    }
+}
+```
+
+#### Build a shadowJar of the custom runner:
+
+build.gradle
+
+```groovy
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+    }
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+```
+
+```sh
+cd /path/to/custom-runner
+
+./gradlew shadowJar
+```
+
+#### Build a shadowJar of the benchmark project:
+```sh
+cd /path/to/decaton/benchmark
+
+../gradlew :benchmark:shadowJar
+```
+
+Run:
+```sh
+export CLASSPATH=/path/to/custom-runner-all.jar
+
+./debm.sh \
+ --title "Custom" \
+ --runner com.example.CustomRunner \
+ --tasks 10000 \
+ --warmup 100 \
+ --simulate-latency=10 
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -97,16 +97,12 @@ cd /path/to/custom-runner
 ./gradlew shadowJar
 ```
 
-#### Build a shadowJar of the benchmark project:
-```sh
-cd /path/to/decaton/benchmark
+### Run benchmark:
 
-../gradlew :benchmark:shadowJar
-```
-
-Run:
 ```sh
 export CLASSPATH=/path/to/custom-runner-all.jar
+
+cd /path/to/decaton/benchmark
 
 ./debm.sh \
  --title "Custom" \

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -3,6 +3,7 @@ ext {
     shadeAllDependencies = true
 
     picoVersion = "4.2.0"
+    jacksonVersion = "2.10.3"
 }
 
 dependencies {

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,9 +1,8 @@
 ext {
-    noPublish = true
+    publishOnlyLocal = true
     shadeAllDependencies = true
 
     picoVersion = "4.2.0"
-    jacksonVersion = "2.10.3"
 }
 
 dependencies {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
@@ -32,6 +32,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import com.linecorp.decaton.benchmark.Execution.Stage;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -45,8 +47,13 @@ class BenchmarkRmi implements AutoCloseable {
     private static final String REMOTE_NAME = "BenchmarkRmi";
 
     private final BlockingQueue<Stage> stageQueue = new LinkedBlockingQueue<>();
-    private int port;
     private RemoteCallback callback;
+    /**
+     * Port of the RMI registry
+     */
+    @Getter
+    @Accessors(fluent = true)
+    private int port;
 
     interface RemoteCallback extends Remote {
         /**
@@ -74,14 +81,6 @@ class BenchmarkRmi implements AutoCloseable {
             this.port = sock.getLocalPort();
             return sock;
         }
-    }
-
-    /**
-     * Port of the RMI registry
-     * @return port
-     */
-    int port() {
-        return port;
     }
 
     /**
@@ -158,7 +157,7 @@ class BenchmarkRmi implements AutoCloseable {
      */
     static RemoteCallback lookup(int port) {
         try {
-            return (RemoteCallback)LocateRegistry.getRegistry(port).lookup(REMOTE_NAME);
+            return (RemoteCallback) LocateRegistry.getRegistry(port).lookup(REMOTE_NAME);
         } catch (IOException | NotBoundException e) {
             throw new RuntimeException(e);
         }

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
@@ -35,7 +35,10 @@ import com.linecorp.decaton.benchmark.Execution.Stage;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Remote interface used for communication between forked execution and benchmark controller
+ * Remote interface used for communication between forked execution and benchmark controller.
+ *
+ * {@link Stage} changes are notified through {@link BenchmarkRmi#pollStage()} rather than
+ * RMI callback directly which requires benchmark controller to be concurrent aware.
  */
 @Slf4j
 class BenchmarkRmi implements AutoCloseable {
@@ -85,7 +88,7 @@ class BenchmarkRmi implements AutoCloseable {
      * Poll {@link Stage} changes which is emitted from forked execution
      * @return {@link Stage} of the execution
      */
-    Stage poll() {
+    Stage pollStage() {
         try {
             return stageQueue.take();
         } catch (InterruptedException e) {

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkRmi.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.benchmark;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.rmi.AlreadyBoundException;
+import java.rmi.NotBoundException;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.server.RMIServerSocketFactory;
+import java.rmi.server.RMISocketFactory;
+import java.rmi.server.UnicastRemoteObject;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.linecorp.decaton.benchmark.Execution.Stage;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Remote interface used for communication between forked execution and benchmark controller
+ */
+@Slf4j
+class BenchmarkRmi implements AutoCloseable {
+    private static final String REMOTE_NAME = "BenchmarkRmi";
+
+    private final BlockingQueue<Stage> stageQueue = new LinkedBlockingQueue<>();
+    private int port;
+    private RemoteCallback callback;
+
+    interface RemoteCallback extends Remote {
+        /**
+         * Called when {@link Stage} of the execution has changed
+         * @param stage updated {@link Stage}
+         */
+        void onStage(Stage stage) throws RemoteException;
+
+        /**
+         * Called when the execution has done
+         * @param serializedResult JSON-serialized result of the benchmark execution
+         */
+        void onResult(String serializedResult) throws RemoteException;
+    }
+
+    /**
+     * {@link RMIServerSocketFactory} impl which stores actual bound port
+     */
+    private static class SocketFactory implements RMIServerSocketFactory {
+        private int port;
+
+        @Override
+        public ServerSocket createServerSocket(int port) throws IOException {
+            ServerSocket sock = RMISocketFactory.getDefaultSocketFactory().createServerSocket(port);
+            this.port = sock.getLocalPort();
+            return sock;
+        }
+    }
+
+    /**
+     * Port of the RMI registry
+     * @return port
+     */
+    int port() {
+        return port;
+    }
+
+    /**
+     * Poll {@link Stage} changes which is emitted from forked execution
+     * @return {@link Stage} of the execution
+     */
+    Stage poll() {
+        try {
+            return stageQueue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Start RMI server then accept {@link RemoteCallback} invocation from forked execution
+     * @return future of the JSON-serialized {@link BenchmarkResult}
+     */
+    CompletableFuture<String> start() {
+        CompletableFuture<String> resultFuture = new CompletableFuture<>();
+        callback = new RemoteCallback() {
+            @Override
+            public void onStage(Stage stage) throws RemoteException {
+                try {
+                    stageQueue.put(stage);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onResult(String serializedResult) throws RemoteException {
+                resultFuture.complete(serializedResult);
+            }
+        };
+
+        SocketFactory socketFactory = new SocketFactory();
+        try {
+            LocateRegistry.createRegistry(0, RMISocketFactory.getSocketFactory(), socketFactory)
+                          .bind(REMOTE_NAME, UnicastRemoteObject.exportObject(callback, 0));
+            port = socketFactory.port;
+            log.debug("Started registry on port: {}", port);
+
+            return resultFuture;
+        } catch (RemoteException | AlreadyBoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (callback != null) {
+            try {
+                UnicastRemoteObject.unexportObject(callback, true);
+            } catch (Exception e) {
+                log.warn("Failed to unexport remote object", e);
+            }
+        }
+        if (port != 0) {
+            try {
+                LocateRegistry.getRegistry(port).unbind(REMOTE_NAME);
+            } catch (Exception e) {
+                log.warn("Failed to unbind registry", e);
+            }
+        }
+    }
+
+    /**
+     * Lookup {@link RemoteCallback} instance from RMI registry
+     * @param port port of the registry
+     * @return remote {@link RemoteCallback} instance
+     */
+    static RemoteCallback lookup(int port) {
+        try {
+            return (RemoteCallback)LocateRegistry.getRegistry(port).lookup(REMOTE_NAME);
+        } catch (IOException | NotBoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/ForkingExecution.java
@@ -91,7 +91,7 @@ public class ForkingExecution implements Execution {
                     .start();
 
             Stage stage;
-            while ((stage = rmi.poll()) != Stage.FINISH) {
+            while ((stage = rmi.pollStage()) != Stage.FINISH) {
                 stageCallback.accept(stage);
             }
             result = mapper.readValue(resultFuture.join(), BenchmarkResult.class);

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Runner.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Runner.java
@@ -40,7 +40,7 @@ public interface Runner extends AutoCloseable {
      * and pass it immediately to {@link Recording#process(Task)} which is given by an argument.
      *
      * @param config runner configurations.
-     * @param recording recording for this benchmark.
+     * @param recording recording of the benchmark.
      * @param resourceTracker resource tracking interface (use is optional).
      * @throws InterruptedException whenever appropriate.
      */

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Runner.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Runner.java
@@ -40,7 +40,7 @@ public interface Runner extends AutoCloseable {
      * and pass it immediately to {@link Recording#process(Task)} which is given by an argument.
      *
      * @param config runner configurations.
-     * @param recording recording of the benchmark.
+     * @param recording recording for this benchmark.
      * @param resourceTracker resource tracking interface (use is optional).
      * @throws InterruptedException whenever appropriate.
      */

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     ext {
         shadeAllDependencies = false // Whether this project should results uber jar or not
         noPublish = false // Whether to publish this artifact to maven or not
-        publishOnlyLocal = false // Whether to publish this artifact to local maven only (ignored if noPublish = true)
+        publishOnlyLocal = false // Whether to publish this artifact to local maven only (no effect if noPublish = true)
         relocatePb = true // Whether to relocate package name of protocol buffers classes
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ allprojects {
         lombokVersion = "1.18.4"
         junitVersion = "4.12"
         hamcrestVersion = "1.3"
-        jacksonVersion = "2.10.3"
 
         isReleaseVersion = !version.endsWith('-SNAPSHOT')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
         lombokVersion = "1.18.4"
         junitVersion = "4.12"
         hamcrestVersion = "1.3"
+        jacksonVersion = "2.10.3"
 
         isReleaseVersion = !version.endsWith('-SNAPSHOT')
     }
@@ -54,6 +55,7 @@ subprojects {
     ext {
         shadeAllDependencies = false // Whether this project should results uber jar or not
         noPublish = false // Whether to publish this artifact to maven or not
+        publishOnlyLocal = false // Whether to publish this artifact to local maven only (ignored if noPublish = true)
         relocatePb = true // Whether to relocate package name of protocol buffers classes
     }
 
@@ -191,6 +193,12 @@ subprojects {
             if (relocatePb) {
                 // Relocate protobuf package prefixing unique identifier `com.linecorp.decaton`
                 relocate "com.google.protobuf.", "com.linecorp.decaton.com.google.protobuf."
+            }
+        }
+
+        tasks.withType(PublishToMavenRepository) {
+            onlyIf {
+                !publishOnlyLocal
             }
         }
 


### PR DESCRIPTION
## Motivation
- `benchmark` module is designed to be able to run arbitrary `Runner` implementation, not only built-in `DecatonRunner`
- But currently, running custom Runner implementation cannot be done without modifying decaton repository itself since `benchmark` module is not published
- This PR publishes `benchmark` module locally to be able to depend on it from custom runner

## Changes
### publish `benchmark` module only locally
- not to maven central. to avoid a lot of redistributions
### communicate ForkingExecution <-> benchmarker via RMI
- change interprocess communication to RMI
- currently, interprocess communication is done through stdout
  * but this forces custom runner not to output any information to stdout (and it isn't documented anywhere)
  * we shouldn't restrict use of stdout since we usually output debug information to stdout