### PR TITLE
Fix flaky tests

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -81,6 +81,7 @@ public class RetryQueueingTest {
         //   * after retried (i.e. retryCount() > 0), no more retry
         ProcessorTestSuite
                 .builder(rule)
+                .numTasks(1000)
                 .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
                     if (ctx.metadata().retryCount() == 0) {
                         ctx.retry();

--- a/processor/src/it/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.decaton.processor;
+package com.linecorp.decaton.processor.metrics;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
@@ -35,7 +35,11 @@ import org.junit.Test;
 import com.linecorp.decaton.client.DecatonClient;
 import com.linecorp.decaton.client.kafka.PrintableAsciiStringSerializer;
 import com.linecorp.decaton.client.kafka.ProtocolBuffersKafkaSerializer;
-import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.ProcessorsBuilder;
+import com.linecorp.decaton.processor.Property;
+import com.linecorp.decaton.processor.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
@@ -68,6 +72,11 @@ public class MetricsTest {
 
     @Test(timeout = 30000)
     public void testMetricsCleanup() throws Exception {
+        // Any neighbor integration tests that ran in the same JVM could leak subscription unclosed
+        // (e.g, test timeout) and that causes this test to fail unless we clear the registry here.
+        Metrics.registry().clear();
+        Metrics.AbstractMetrics.meterRefCounts.clear();
+
         CountDownLatch processLatch = new CountDownLatch(1);
         try (ProcessorSubscription subscription = TestUtils.subscription(
                 rule.bootstrapServers(),

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -60,7 +60,7 @@ public class Metrics {
      * the instance from {@link MeterRegistry} when the last reference to the meter closed and disappeared.
      */
     abstract static class AbstractMetrics implements AutoCloseable {
-        private static final Map<Id, AtomicInteger> meterRefCounts = new HashMap<>();
+        static final Map<Id, AtomicInteger> meterRefCounts = new HashMap<>();
         private final List<Meter> meters = new ArrayList<>();
 
         <T extends Meter> T meter(Supplier<T> ctor) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/CompactionProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/CompactionProcessor.java
@@ -210,7 +210,8 @@ public class CompactionProcessor<T> implements DecatonProcessor<T> {
                     // By race condition, there is a chance that the scheduled flush for preceding task just
                     // got fired right after this method checked the key's existence at the beginning of this
                     // method.
-                    // In such case we have to re-schedule flush for the new entry that we being added just now.
+                    // In such case we have to re-schedule flush for the new entry that we've been added just
+                    // now.
                     scheduleFlush(context);
                 } else {
                     // Mark previous(looser) task as completed.


### PR DESCRIPTION
Attempt to fix #56 

* `testRetryQueuing` => not very sure but suspecting CI server's resource simply lacks to complete the workload
* `testMetricsCleanup` => likely involved by the above test's failure. timed out test likely gets terminated w/o completing finally block and it'll laves garbage in metrics registry on shared JVM.
* `testRaceConditionOnFlush` => no idea yet. occurrence is too rare and not a subject of this PR.