### PR TITLE
Make "child" traces around each processor within the ProcessingPipeline

### DIFF
--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveProcessorTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveProcessorTraceHandle.java
@@ -16,22 +16,28 @@
 
 package com.linecorp.decaton.processor.runtime;
 
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.ProcessorTraceHandle;
 
 import brave.Span;
 import brave.messaging.MessagingTracing;
+import brave.propagation.CurrentTraceContext.Scope;
 
-class BraveTraceHandle implements TraceHandle {
-    protected final MessagingTracing messagingTracing;
-    protected final Span span;
+final class BraveProcessorTraceHandle extends BraveTraceHandle implements ProcessorTraceHandle {
+    private Scope scope;
 
-    BraveTraceHandle(MessagingTracing messagingTracing, Span span) {
-        this.messagingTracing = messagingTracing;
-        this.span = span;
+    BraveProcessorTraceHandle(MessagingTracing messagingTracing, Span span) {
+        super(messagingTracing, span);
     }
 
     @Override
-    public void processingCompletion() {
-        span.finish();
+    public void processingStart() {
+        scope = messagingTracing.tracing().currentTraceContext().newScope(span.context());
+    }
+
+    @Override
+    public void processingReturn() {
+        span.annotate("return");
+        scope.close();
     }
 }
+

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveRecordTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveRecordTraceHandle.java
@@ -16,22 +16,22 @@
 
 package com.linecorp.decaton.processor.runtime;
 
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 
 import brave.Span;
 import brave.messaging.MessagingTracing;
 
-class BraveTraceHandle implements TraceHandle {
-    protected final MessagingTracing messagingTracing;
-    protected final Span span;
-
-    BraveTraceHandle(MessagingTracing messagingTracing, Span span) {
-        this.messagingTracing = messagingTracing;
-        this.span = span;
+final class BraveRecordTraceHandle extends BraveTraceHandle implements RecordTraceHandle {
+    BraveRecordTraceHandle(MessagingTracing messagingTracing, Span span) {
+        super(messagingTracing, span);
     }
 
     @Override
-    public void processingCompletion() {
-        span.finish();
+    public BraveProcessorTraceHandle childFor(DecatonProcessor<?> processor) {
+        final Span childSpan = messagingTracing.tracing().tracer().newChild(span.context())
+                                               .name(processor.name())
+                                               .start();
+        return new BraveProcessorTraceHandle(messagingTracing, childSpan);
     }
 }

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
@@ -17,7 +17,7 @@
 package com.linecorp.decaton.processor.runtime;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 
 import brave.Span;
 import brave.messaging.MessagingTracing;

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
@@ -36,12 +36,11 @@ class BraveTraceHandle implements TraceHandle {
     @Override
     public void processingStart() {
         scope = messagingTracing.tracing().currentTraceContext().newScope(span.context());
-        span.annotate("decaton.start");
     }
 
     @Override
     public void processingReturn() {
-        span.annotate("decaton.return");
+        span.annotate("return");
         scope.close();
     }
 

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.runtime;
+
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+
+import brave.Span;
+import brave.messaging.MessagingTracing;
+import brave.propagation.CurrentTraceContext.Scope;
+
+class BraveTraceHandle implements TraceHandle {
+    private final MessagingTracing messagingTracing;
+    private final Span span;
+    private Scope scope;
+
+    public BraveTraceHandle(MessagingTracing messagingTracing, Span span) {
+        this.messagingTracing = messagingTracing;
+        this.span = span;
+    }
+
+    @Override
+    public void processingStart() {
+        scope = messagingTracing.tracing().currentTraceContext().newScope(span.context());
+        span.annotate("decaton.start");
+    }
+
+    @Override
+    public void processingReturn() {
+        span.annotate("decaton.return");
+        scope.close();
+    }
+
+    @Override
+    public void processingCompletion() {
+        span.finish();
+    }
+
+    @Override
+    public TraceHandle childFor(DecatonProcessor<?> processor) {
+        final Span childSpan = messagingTracing.tracing().tracer().newChild(span.context())
+                                               .name(processor.getClass().getSimpleName())
+                                               .start();
+        return new BraveTraceHandle(messagingTracing, childSpan);
+    }
+}

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTraceHandle.java
@@ -28,7 +28,7 @@ class BraveTraceHandle implements TraceHandle {
     private final Span span;
     private Scope scope;
 
-    public BraveTraceHandle(MessagingTracing messagingTracing, Span span) {
+    BraveTraceHandle(MessagingTracing messagingTracing, Span span) {
         this.messagingTracing = messagingTracing;
         this.span = span;
     }
@@ -53,7 +53,7 @@ class BraveTraceHandle implements TraceHandle {
     @Override
     public TraceHandle childFor(DecatonProcessor<?> processor) {
         final Span childSpan = messagingTracing.tracing().tracer().newChild(span.context())
-                                               .name(processor.getClass().getSimpleName())
+                                               .name(processor.name())
                                                .start();
         return new BraveTraceHandle(messagingTracing, childSpan);
     }

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTracingProvider.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTracingProvider.java
@@ -19,6 +19,8 @@ package com.linecorp.decaton.processor.runtime;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import com.linecorp.decaton.processor.TracingProvider;
+
 import brave.kafka.clients.KafkaTracing;
 
 public class BraveTracingProvider implements TracingProvider {

--- a/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTracingProvider.java
+++ b/brave/src/main/java/com/linecorp/decaton/processor/runtime/BraveTracingProvider.java
@@ -25,17 +25,15 @@ import brave.kafka.clients.KafkaTracing;
 
 public class BraveTracingProvider implements TracingProvider {
     private final KafkaTracing kafkaTracing;
-
     public BraveTracingProvider(KafkaTracing kafkaTracing) {
         this.kafkaTracing = kafkaTracing;
     }
 
     @Override
-    public TraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
-        return new BraveTraceHandle(
+    public BraveRecordTraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
+        return new BraveRecordTraceHandle(
                 kafkaTracing.messagingTracing(),
                 kafkaTracing.nextSpan(record).name("decaton").tag("subscriptionId", subscriptionId)
                             .start());
     }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'java'
+    apply plugin: "java-test-fixtures"
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'io.franzbecker.gradle-lombok'
@@ -77,6 +78,8 @@ subprojects {
     sourceSets.create('it') {
         compileClasspath += sourceSets.main.output
         runtimeClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.testFixtures.output
+        runtimeClasspath += sourceSets.testFixtures.output
     }
 
     task integrationTest(type: Test) {

--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -1,6 +1,6 @@
 Dynamic Property Configuration
 =============================
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: centraldogma,processor
 
 == Property Supplier

--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -1,6 +1,6 @@
 Dynamic Property Configuration
 =============================
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: centraldogma,processor
 
 == Property Supplier

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,6 +1,6 @@
 Getting Started Decaton
 =======================
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: common,client,processor,protobuf
 
 Let's start from the most basic usage of Decaton client/processor.

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,6 +1,6 @@
 Getting Started Decaton
 =======================
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: common,client,processor,protobuf
 
 Let's start from the most basic usage of Decaton client/processor.

--- a/docs/key-blocking.adoc
+++ b/docs/key-blocking.adoc
@@ -1,5 +1,5 @@
 = Key Blocking
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/key-blocking.adoc
+++ b/docs/key-blocking.adoc
@@ -1,5 +1,5 @@
 = Key Blocking
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 == Introduction

--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -1,6 +1,6 @@
 Monitoring Decaton
 ==================
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 This document guides you how to monitor your Decaton processor applications.

--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -1,6 +1,6 @@
 Monitoring Decaton
 ==================
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 This document guides you how to monitor your Decaton processor applications.

--- a/docs/rate-limiting.adoc
+++ b/docs/rate-limiting.adoc
@@ -1,5 +1,5 @@
 = Rate Limiting
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/rate-limiting.adoc
+++ b/docs/rate-limiting.adoc
@@ -1,5 +1,5 @@
 = Rate Limiting
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 == Introduction

--- a/docs/retry-queueing.adoc
+++ b/docs/retry-queueing.adoc
@@ -1,5 +1,5 @@
 = Retry Queuing
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/retry-queueing.adoc
+++ b/docs/retry-queueing.adoc
@@ -1,5 +1,5 @@
 = Retry Queuing
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 == Introduction

--- a/docs/spring-integration.adoc
+++ b/docs/spring-integration.adoc
@@ -1,6 +1,6 @@
 Spring Integration
 ==================
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules:
 
 TBC

--- a/docs/spring-integration.adoc
+++ b/docs/spring-integration.adoc
@@ -1,6 +1,6 @@
 Spring Integration
 ==================
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules:
 
 TBC

--- a/docs/task-compaction.adoc
+++ b/docs/task-compaction.adoc
@@ -1,5 +1,5 @@
 = Task Compaction
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 == Introduction

--- a/docs/task-compaction.adoc
+++ b/docs/task-compaction.adoc
@@ -1,5 +1,5 @@
 = Task Compaction
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/tracing.adoc
+++ b/docs/tracing.adoc
@@ -1,5 +1,5 @@
 = Tracing
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: brave,processor
 
 Decaton can integrate with distributed tracing frameworks so that you can associate the processing of a message

--- a/docs/tracing.adoc
+++ b/docs/tracing.adoc
@@ -1,5 +1,5 @@
 = Tracing
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: brave,processor
 
 Decaton can integrate with distributed tracing frameworks so that you can associate the processing of a message

--- a/docs/why-decaton.adoc
+++ b/docs/why-decaton.adoc
@@ -1,6 +1,6 @@
 Why Decaton
 ===========
-:base_version: 0.0.43
+:base_version: 0.0.43-SNAPSHOT
 :modules: processor
 
 This document explains why we have decided to create a new consumer framework.

--- a/docs/why-decaton.adoc
+++ b/docs/why-decaton.adoc
@@ -1,6 +1,6 @@
 Why Decaton
 ===========
-:base_version: 0.0.42
+:base_version: 0.0.43
 :modules: processor
 
 This document explains why we have decided to create a new consumer framework.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 }
 
 apply plugin: "me.champeau.gradle.jmh"
+apply plugin: "java-test-fixtures"
 
 dependencies {
     compile project(":common")
@@ -16,6 +17,9 @@ dependencies {
     compile "io.micrometer:micrometer-core:$micrometerVersion"
 
     testCompile project(":protobuf")
+
+    testFixturesCompile "junit:junit:$junitVersion"
+    testFixturesCompileOnly "org.projectlombok:lombok:$lombokVersion"
 
     itCompile "junit:junit:$junitVersion"
     itCompile project(":protobuf")

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 }
 
 apply plugin: "me.champeau.gradle.jmh"
-apply plugin: "java-test-fixtures"
 
 dependencies {
     compile project(":common")

--- a/processor/src/it/java/com/linecorp/decaton/processor/TracingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/TracingTest.java
@@ -16,7 +16,9 @@
 
 package com.linecorp.decaton.processor;
 
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Duration;
 import java.util.Map;
@@ -37,7 +39,6 @@ import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
 import com.linecorp.decaton.testing.processor.ProducedRecord;
 import com.linecorp.decaton.testing.processor.TestTracingProducer;
-import com.linecorp.decaton.testing.processor.TestTracingProvider;
 
 public class TracingTest {
     public static class TracePropagation implements ProcessingGuarantee {
@@ -56,7 +57,10 @@ public class TracingTest {
 
         @Override
         public void doAssert() {
-            assertEquals(consumedTraceIds, producedTraceIds);
+            assertEquals(producedTraceIds.keySet(), consumedTraceIds.keySet());
+            for (Map.Entry<String, String> e: producedTraceIds.entrySet()) {
+                assertThat(consumedTraceIds.get(e.getKey()), startsWith(e.getValue()));
+            }
             TestTracingProvider.assertAllTracesWereClosed();
         }
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/DecatonProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/DecatonProcessor.java
@@ -45,6 +45,13 @@ public interface DecatonProcessor<T> extends AutoCloseable {
     void process(ProcessingContext<T> context, T task) throws InterruptedException;
 
     /**
+     * @return The name of this processor. (Used in Zipkin traces).
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+
+    /**
      * The default close method which doesn't do anything.
      */
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/DecatonProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/DecatonProcessor.java
@@ -45,7 +45,10 @@ public interface DecatonProcessor<T> extends AutoCloseable {
     void process(ProcessingContext<T> context, T task) throws InterruptedException;
 
     /**
-     * @return The name of this processor. (Used in Zipkin traces).
+     * @return A human-readable name for this processor.
+     * This is used for observability (in particular, Zipkin traces), so it should be distinct enough
+     * to let a reader identify how this processor is configured
+     * (but does not necessarily have to be completely unique).
      */
     default String name() {
         return getClass().getSimpleName();

--- a/processor/src/main/java/com/linecorp/decaton/processor/TracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/TracingProvider.java
@@ -19,9 +19,6 @@ package com.linecorp.decaton.processor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import com.linecorp.decaton.client.KafkaProducerSupplier;
-import com.linecorp.decaton.processor.DecatonProcessor;
-import com.linecorp.decaton.processor.DeferredCompletion;
-import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
 
 /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/TracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/TracingProvider.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.decaton.processor.runtime;
+package com.linecorp.decaton.processor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -22,6 +22,7 @@ import com.linecorp.decaton.client.KafkaProducerSupplier;
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
+import com.linecorp.decaton.processor.runtime.RetryConfig;
 
 /**
  * Interface for distributed tracing implementations that track traces via Kafka {@link ConsumerRecord}s

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
@@ -18,6 +18,8 @@ package com.linecorp.decaton.processor.runtime;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import com.linecorp.decaton.processor.DecatonProcessor;
+
 public enum NoopTracingProvider implements TracingProvider {
     INSTANCE;
     public enum NoopTrace implements TraceHandle {
@@ -31,6 +33,11 @@ public enum NoopTracingProvider implements TracingProvider {
 
         @Override
         public void processingCompletion() {}
+
+        @Override
+        public TraceHandle childFor(DecatonProcessor<?> processor) {
+            return this;
+        }
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
@@ -23,7 +23,7 @@ import com.linecorp.decaton.processor.TracingProvider;
 
 public enum NoopTracingProvider implements TracingProvider {
     INSTANCE;
-    public enum NoopTrace implements TraceHandle {
+    public enum NoopTrace implements RecordTraceHandle, ProcessorTraceHandle {
         INSTANCE;
 
         @Override
@@ -36,13 +36,13 @@ public enum NoopTracingProvider implements TracingProvider {
         public void processingCompletion() {}
 
         @Override
-        public TraceHandle childFor(DecatonProcessor<?> processor) {
+        public ProcessorTraceHandle childFor(DecatonProcessor<?> processor) {
             return this;
         }
     }
 
     @Override
-    public TraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
+    public RecordTraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
         return NoopTrace.INSTANCE;
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/NoopTracingProvider.java
@@ -19,6 +19,7 @@ package com.linecorp.decaton.processor.runtime;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.TracingProvider;
 
 public enum NoopTracingProvider implements TracingProvider {
     INSTANCE;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessPipeline.java
@@ -109,11 +109,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
         Timer timer = Utils.timer();
         CompletableFuture<Void> processResult;
         try (LoggingContext ignored = context.loggingContext()) {
-            try {
-                request.trace().processingStart();
-            } catch(Exception e) {
-                log.error("Exception from tracing", e);
-            }
             processResult = context.push(task.taskData());
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
@@ -126,11 +121,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
                       scope, request, e);
         } finally {
             Duration elapsed = timer.duration();
-            try {
-                request.trace().processingReturn();
-            } catch(Exception e) {
-                log.error("Exception from tracing", e);
-            }
             if (log.isTraceEnabled()) {
                 log.trace("Processing task [{}] took {} ns", request.id(), Utils.formatNanos(elapsed));
             }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DecatonTask;
@@ -33,6 +34,15 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ProcessingContextImpl<T> implements ProcessingContext<T> {
+    private static <T> T loggingExceptions(Supplier<T> block, String message, T fallback) {
+        try {
+            return block.get();
+        } catch (Exception e) {
+            log.error(message, e);
+            return fallback;
+        }
+    }
+
     private final String subscriptionId;
     private final TaskRequest request;
     private final DecatonTask<T> task;
@@ -99,13 +109,8 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
                 this.task.metadata(), taskData, this.task.taskDataBytes());
         DecatonProcessor<P> nextProcessor = downstreams.get(0);
         final TraceHandle parentTrace = request.trace();
-        TraceHandle tmpTraceHandle = NoopTrace.INSTANCE;
-        try {
-            tmpTraceHandle = parentTrace.childFor(nextProcessor);
-        } catch(Exception e) {
-            log.error("Exception from tracing", e);
-        }
-        final TraceHandle traceHandle = tmpTraceHandle;
+        final TraceHandle traceHandle = loggingExceptions(() -> parentTrace.childFor(nextProcessor),
+                                                          "Exception from tracing", NoopTrace.INSTANCE);
         CompletableFuture<Void> future = new CompletableFuture<>();
         DeferredCompletion nextCompletion = () -> {
             future.complete(null);
@@ -121,13 +126,13 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
 
         try {
             try {
-                tmpTraceHandle.processingStart();
+                traceHandle.processingStart();
             } catch (Exception e) {
                 log.error("Exception from tracing", e);
             }
             nextProcessor.process(nextContext, taskData);
             try {
-                tmpTraceHandle.processingReturn();
+                traceHandle.processingReturn();
             } catch (Exception e) {
                 log.error("Exception from tracing", e);
             }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -28,7 +28,7 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -26,7 +26,12 @@ import com.linecorp.decaton.processor.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
+import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
+import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class ProcessingContextImpl<T> implements ProcessingContext<T> {
     private final String subscriptionId;
     private final TaskRequest request;
@@ -90,18 +95,37 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
             return CompletableFuture.completedFuture(null);
         }
 
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        DeferredCompletion nextCompletion = () -> future.complete(null);
-
         DecatonTask<P> task = new DecatonTask<>(
                 this.task.metadata(), taskData, this.task.taskDataBytes());
         DecatonProcessor<P> nextProcessor = downstreams.get(0);
+        final TraceHandle parentTrace = request.trace();
+        final TraceHandle traceHandle = null == parentTrace ? NoopTrace.INSTANCE
+                                                            : parentTrace.childFor(nextProcessor);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        DeferredCompletion nextCompletion = () -> {
+            future.complete(null);
+            try {
+                traceHandle.processingCompletion();
+            } catch (Exception e) {
+                log.error("Exception from tracing", e);
+            }
+        };
         ProcessingContextImpl<P> nextContext = new ProcessingContextImpl<>(
                 subscriptionId, request, task, nextCompletion,
                 downstreams.subList(1, downstreams.size()), retryQueueingProcessor);
 
         try {
+            try {
+                traceHandle.processingStart();
+            } catch (Exception e) {
+                log.error("Exception from tracing", e);
+            }
             nextProcessor.process(nextContext, taskData);
+            try {
+                traceHandle.processingReturn();
+            } catch (Exception e) {
+                log.error("Exception from tracing", e);
+            }
         } finally {
             if (!nextContext.completionDeferred.get()) {
                 // If process didn't requested for deferred completion, we understand it as process

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -26,8 +26,9 @@ import com.linecorp.decaton.processor.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
+import com.linecorp.decaton.processor.TracingProvider.ProcessorTraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -98,9 +99,10 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
         DecatonTask<P> task = new DecatonTask<>(
                 this.task.metadata(), taskData, this.task.taskDataBytes());
         DecatonProcessor<P> nextProcessor = downstreams.get(0);
-        final TraceHandle parentTrace = request.trace();
-        final TraceHandle traceHandle = Utils.loggingExceptions(() -> parentTrace.childFor(nextProcessor),
-                                                                "Exception from tracing", NoopTrace.INSTANCE);
+        final RecordTraceHandle parentTrace = request.trace();
+        final ProcessorTraceHandle traceHandle = Utils.loggingExceptions(
+                () -> parentTrace.childFor(nextProcessor),
+                "Exception from tracing", NoopTrace.INSTANCE);
         CompletableFuture<Void> future = new CompletableFuture<>();
         DeferredCompletion nextCompletion = () -> {
             future.complete(null);

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -42,9 +42,10 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.Property;
 import com.linecorp.decaton.processor.SubscriptionStateListener;
+import com.linecorp.decaton.processor.TracingProvider;
 import com.linecorp.decaton.processor.metrics.Metrics;
 import com.linecorp.decaton.processor.metrics.Metrics.SubscriptionMetrics;
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 import com.linecorp.decaton.processor.runtime.Utils.Timer;
 
 import lombok.extern.slf4j.Slf4j;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -43,6 +43,7 @@ import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.Property;
 import com.linecorp.decaton.processor.SubscriptionStateListener;
 import com.linecorp.decaton.processor.TracingProvider;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 import com.linecorp.decaton.processor.metrics.Metrics;
 import com.linecorp.decaton.processor.metrics.Metrics.SubscriptionMetrics;
 import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
@@ -358,7 +359,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             PartitionContext context = contexts.get(tp);
             DeferredCompletion offsetCompletion = context.registerOffset(record.offset());
             TracingProvider provider = scope.tracingProvider();
-            TraceHandle trace = provider.traceFor(record, scope.subscriptionId());
+            RecordTraceHandle trace = provider.traceFor(record, scope.subscriptionId());
             final DeferredCompletion tracingCompletion = () -> {
                 try {
                     trace.processingCompletion();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
@@ -36,6 +36,7 @@ import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.PropertySupplier;
 import com.linecorp.decaton.processor.SubscriptionStateListener;
 import com.linecorp.decaton.processor.TaskMetadata;
+import com.linecorp.decaton.processor.TracingProvider;
 
 import lombok.AccessLevel;
 import lombok.Setter;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionScope.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionScope.java
@@ -19,6 +19,7 @@ package com.linecorp.decaton.processor.runtime;
 import java.util.Optional;
 
 import com.linecorp.decaton.processor.ProcessorProperties;
+import com.linecorp.decaton.processor.TracingProvider;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
@@ -19,7 +19,7 @@ package com.linecorp.decaton.processor.runtime;
 import org.apache.kafka.common.TopicPartition;
 
 import com.linecorp.decaton.processor.DeferredCompletion;
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -35,7 +35,7 @@ class TaskRequest {
     private final String key;
     private final String id;
     @ToString.Exclude
-    private final TraceHandle trace;
+    private final RecordTraceHandle trace;
     @ToString.Exclude
     private byte[] rawRequestBytes;
 
@@ -43,7 +43,7 @@ class TaskRequest {
                 long recordOffset,
                 DeferredCompletion completion,
                 String key,
-                TraceHandle trace,
+                RecordTraceHandle trace,
                 byte[] rawRequestBytes) {
         this.topicPartition = topicPartition;
         this.recordOffset = recordOffset;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
@@ -19,7 +19,7 @@ package com.linecorp.decaton.processor.runtime;
 import org.apache.kafka.common.TopicPartition;
 
 import com.linecorp.decaton.processor.DeferredCompletion;
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TracingProvider.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TracingProvider.java
@@ -58,6 +58,8 @@ public interface TracingProvider {
          * Otherwise, this will be invoked by the thread that calls {@link DeferredCompletion#complete()}.
          */
         void processingCompletion();
+
+        TraceHandle childFor(DecatonProcessor<?> processor);
     }
 
     /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/Utils.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/Utils.java
@@ -27,13 +27,17 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * A collection of utilities method which are used just internally.
  */
+@Slf4j
 final class Utils {
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
@@ -42,6 +46,15 @@ final class Utils {
             ThreadLocal.withInitial(() -> NumberFormat.getNumberInstance(Locale.US));
 
     private Utils() {}
+
+    static <T> T loggingExceptions(Supplier<T> block, String message, T fallback) {
+        try {
+            return block.get();
+        } catch (Exception e) {
+            log.error(message, e);
+            return fallback;
+        }
+    }
 
     static class Timer {
         private final long t0;

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
@@ -55,8 +55,8 @@ import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.TestTraceHandle;
 import com.linecorp.decaton.processor.TestTracingProvider;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 import com.linecorp.decaton.protocol.Sample.HelloTask;
@@ -110,7 +110,7 @@ public class ProcessingContextImplTest {
     }
 
     @SafeVarargs
-    private static ProcessingContextImpl<HelloTask> context(TraceHandle traceHandle,
+    private static ProcessingContextImpl<HelloTask> context(RecordTraceHandle traceHandle,
                                                             DecatonProcessor<HelloTask>... processors) {
         TaskRequest request = new TaskRequest(
                 new TopicPartition("topic", 1), 1, null, "TEST",
@@ -363,7 +363,7 @@ public class ProcessingContextImplTest {
 
     @Test(timeout = 5000)
     public void testTrace_Sync() throws InterruptedException {
-        TraceHandle handle = new TestTraceHandle("testTrace_Sync");
+        RecordTraceHandle handle = new TestTraceHandle("testTrace_Sync");
         final AtomicReference<String> traceDuringProcessing = new AtomicReference<>();
         try {
             ProcessingContextImpl<HelloTask> context = context(handle,
@@ -386,7 +386,7 @@ public class ProcessingContextImplTest {
     public void testTrace_Async() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        TraceHandle handle = new TestTraceHandle("testTrace_Async");
+        RecordTraceHandle handle = new TestTraceHandle("testTrace_Async");
         final AtomicReference<String> traceDuringSyncProcessing = new AtomicReference<>();
         final AtomicReference<String> traceDuringAsyncProcessing = new AtomicReference<>();
         try {

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
@@ -56,7 +56,7 @@ import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.TestTraceHandle;
 import com.linecorp.decaton.processor.TestTracingProvider;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 import com.linecorp.decaton.protocol.Sample.HelloTask;

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
@@ -16,9 +16,10 @@
 
 package com.linecorp.decaton.processor;
 
-import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.ProcessorTraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
 
-public class TestTraceHandle implements TraceHandle {
+public class TestTraceHandle implements RecordTraceHandle, ProcessorTraceHandle {
     private final String traceId;
     private String previousTraceId;
 
@@ -44,7 +45,7 @@ public class TestTraceHandle implements TraceHandle {
     }
 
     @Override
-    public TraceHandle childFor(DecatonProcessor<?> processor) {
+    public ProcessorTraceHandle childFor(DecatonProcessor<?> processor) {
         final String childTraceId = traceId + "-" + processor.name();
         return new TestTraceHandle(childTraceId);
     }

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
@@ -20,6 +20,7 @@ import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
 
 public class TestTraceHandle implements TraceHandle {
     private final String traceId;
+    private String previousTraceId;
 
     public TestTraceHandle(String traceId) {
         this.traceId = traceId;
@@ -28,12 +29,13 @@ public class TestTraceHandle implements TraceHandle {
 
     @Override
     public void processingStart() {
+        previousTraceId = TestTracingProvider.traceId.get();
         TestTracingProvider.traceId.set(traceId);
     }
 
     @Override
     public void processingReturn() {
-        TestTracingProvider.traceId.remove();
+        TestTracingProvider.traceId.set(previousTraceId);
     }
 
     @Override

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.decaton.processor;
 
-import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+import com.linecorp.decaton.processor.TracingProvider.TraceHandle;
 
 public class TestTraceHandle implements TraceHandle {
     private final String traceId;

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTraceHandle.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import com.linecorp.decaton.processor.runtime.TracingProvider.TraceHandle;
+
+public class TestTraceHandle implements TraceHandle {
+    private final String traceId;
+
+    public TestTraceHandle(String traceId) {
+        this.traceId = traceId;
+        TestTracingProvider.openTraces.add(traceId);
+    }
+
+    @Override
+    public void processingStart() {
+        TestTracingProvider.traceId.set(traceId);
+    }
+
+    @Override
+    public void processingReturn() {
+        TestTracingProvider.traceId.remove();
+    }
+
+    @Override
+    public void processingCompletion() {
+        TestTracingProvider.openTraces.remove(traceId);
+    }
+
+    @Override
+    public TraceHandle childFor(DecatonProcessor<?> processor) {
+        final String childTraceId = traceId + "-" + processor.name();
+        return new TestTraceHandle(childTraceId);
+    }
+}

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
-import com.linecorp.decaton.processor.runtime.TracingProvider;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
@@ -49,7 +49,7 @@ public class TestTracingProvider implements TracingProvider {
     }
 
     @Override
-    public TraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
+    public RecordTraceHandle traceFor(ConsumerRecord<?, ?> record, String subscriptionId) {
         final Header header = record.headers().lastHeader(TRACE_HEADER);
         if (null != header) {
             final String recordTraceId = new String(header.value(), StandardCharsets.UTF_8);

--- a/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
+++ b/processor/src/testFixtures/java/com/linecorp/decaton/processor/TestTracingProvider.java
@@ -14,18 +14,16 @@
  * under the License.
  */
 
-package com.linecorp.decaton.testing.processor;
-
-import static org.junit.Assert.assertEquals;
+package com.linecorp.decaton.processor;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 
-import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
 import com.linecorp.decaton.processor.runtime.TracingProvider;
 
@@ -34,11 +32,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TestTracingProvider implements TracingProvider {
     public static final String TRACE_HEADER = "test-trace-id";
-    private static final ThreadLocal<String> traceId = new ThreadLocal<>();
-    private static final Set<String> openTraces = ConcurrentHashMap.newKeySet();
+    static final ThreadLocal<String> traceId = new ThreadLocal<>();
+    static final Set<String> openTraces = ConcurrentHashMap.newKeySet();
 
     public static String getCurrentTraceId() {
         return traceId.get();
+    }
+
+    public static Set<String> getOpenTraces() {
+        return Collections.unmodifiableSet(openTraces);
     }
 
     public static void assertAllTracesWereClosed() {
@@ -53,31 +55,10 @@ public class TestTracingProvider implements TracingProvider {
         if (null != header) {
             final String recordTraceId = new String(header.value(), StandardCharsets.UTF_8);
             traceId.set(recordTraceId);
-            openTraces.add(recordTraceId);
-            return new TraceHandle() {
-                @Override
-                public void processingStart() {
-                    traceId.set(recordTraceId);
-                }
-
-                @Override
-                public void processingReturn() {
-                    assertEquals(recordTraceId, traceId.get());
-                    traceId.remove();
-                }
-
-                @Override
-                public void processingCompletion() {
-                    openTraces.remove(recordTraceId);
-                }
-
-                @Override
-                public TraceHandle childFor(DecatonProcessor<?> processor) {
-                    return NoopTrace.INSTANCE;
-                }
-            };
+            return new TestTraceHandle(recordTraceId);
         } else {
             return NoopTrace.INSTANCE;
         }
     }
+
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -18,7 +18,7 @@ ext {
     noPublish = true
 }
 dependencies {
-    implementation project(':processor')
+    implementation testFixtures(project(':processor'))
     implementation project(':protobuf')
 
     implementation "org.apache.kafka:kafka-clients:$kafkaVersion"

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -49,7 +49,7 @@ import com.linecorp.decaton.processor.SubscriptionStateListener;
 import com.linecorp.decaton.processor.TestTracingProvider;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
-import com.linecorp.decaton.processor.runtime.TracingProvider;
+import com.linecorp.decaton.processor.TracingProvider;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 import com.linecorp.decaton.testing.KafkaClusterRule;

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -46,6 +46,7 @@ import com.linecorp.decaton.processor.ProcessorProperties;
 import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.PropertySupplier;
 import com.linecorp.decaton.processor.SubscriptionStateListener;
+import com.linecorp.decaton.processor.TestTracingProvider;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.processor.runtime.TracingProvider;

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTracingProducer.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTracingProducer.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
+import com.linecorp.decaton.processor.TestTracingProvider;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 
 public class TestTracingProducer implements Producer<String, DecatonTaskRequest> {

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTracingProvider.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/TestTracingProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 
+import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.NoopTracingProvider.NoopTrace;
 import com.linecorp.decaton.processor.runtime.TracingProvider;
 
@@ -68,6 +69,11 @@ public class TestTracingProvider implements TracingProvider {
                 @Override
                 public void processingCompletion() {
                     openTraces.remove(recordTraceId);
+                }
+
+                @Override
+                public TraceHandle childFor(DecatonProcessor<?> processor) {
+                    return NoopTrace.INSTANCE;
                 }
             };
         } else {


### PR DESCRIPTION
To help understand performance in more detail, create a "child" `TraceHandle` around the individual processor.