### PR TITLE
Add interface to decatonClient for customizing delay

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.decaton.client;
 
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import com.linecorp.decaton.common.Serializer;
+
+import lombok.Builder;
+import lombok.Value;
 
 /**
  * Decaton client interface to use for putting tasks on decaton queue.
@@ -51,20 +53,10 @@ public interface DecatonClient<T> extends AutoCloseable {
      * Put a task onto associated decaton queue with specifying arbitrary delay duration.`
      * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
      * @param task an instance of task. Should never be null.
-     * @param delayDuration duration which is used to set delay of task metadata.
+     * @param overrideTaskMetadata taskMetaData which can be set by users and used for event publish.
      * @return a {@link CompletableFuture} which represents the result of task put.
      */
-    CompletableFuture<PutTaskResult> put(String key, T task, Duration delayDuration);
-
-    /**
-     * Put a task onto associated decaton queue with specifying arbitrary timestamp and arbitrary delay.
-     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
-     * @param task an instance of task. Should never be null.
-     * @param timestamp milliseconds precision timestamp which is to be used to set timestamp of task metadata.
-     * @param delayInMillis milliseconds which is used to set delay duration of task metadata.
-     * @return a {@link CompletableFuture} which represents the result of task put.
-     */
-    CompletableFuture<PutTaskResult> put(String key, T task, long timestamp, long delayInMillis);
+    CompletableFuture<PutTaskResult> put(String key, T task, TaskMetaData overrideTaskMetadata);
 
     /**
      * Put a task onto associated decaton queue.
@@ -131,5 +123,14 @@ public interface DecatonClient<T> extends AutoCloseable {
      */
     static <T> DecatonClientBuilder<T> producing(String topic, Serializer<T> serializer) {
         return new DecatonClientBuilder<>(topic, serializer);
+    }
+
+    @Builder
+    @Value
+    class TaskMetaData {
+        /** timestamp of task metadata */
+        Long timestamp;
+        /** scheduledTime for event processing, it should be (timestamp + delayDuration) in milliseconds */
+        Long scheduledTime;
     }
 }

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.client;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -45,6 +46,25 @@ public interface DecatonClient<T> extends AutoCloseable {
      * @return a {@link CompletableFuture} which represents the result of task put.
      */
     CompletableFuture<PutTaskResult> put(String key, T task, long timestamp);
+
+    /**
+     * Put a task onto associated decaton queue with specifying arbitrary delay duration.`
+     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
+     * @param task an instance of task. Should never be null.
+     * @param delayDuration duration which is used to set delay of task metadata.
+     * @return a {@link CompletableFuture} which represents the result of task put.
+     */
+    CompletableFuture<PutTaskResult> put(String key, T task, Duration delayDuration);
+
+    /**
+     * Put a task onto associated decaton queue with specifying arbitrary timestamp and arbitrary delay.
+     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
+     * @param task an instance of task. Should never be null.
+     * @param timestamp milliseconds precision timestamp which is to be used to set timestamp of task metadata.
+     * @param delayInMillis milliseconds which is used to set delay duration of task metadata.
+     * @return a {@link CompletableFuture} which represents the result of task put.
+     */
+    CompletableFuture<PutTaskResult> put(String key, T task, long timestamp, long delayInMillis);
 
     /**
      * Put a task onto associated decaton queue.

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -50,13 +50,13 @@ public interface DecatonClient<T> extends AutoCloseable {
     CompletableFuture<PutTaskResult> put(String key, T task, long timestamp);
 
     /**
-     * Put a task onto associated decaton queue with specifying arbitrary delay duration.`
+     * Put a task onto associated decaton queue with specifying some fields of task metadata.
      * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
      * @param task an instance of task. Should never be null.
      * @param overrideTaskMetadata taskMetaData which can be set by users and used for event publish.
      * @return a {@link CompletableFuture} which represents the result of task put.
      */
-    CompletableFuture<PutTaskResult> put(String key, T task, TaskMetaData overrideTaskMetadata);
+    CompletableFuture<PutTaskResult> put(String key, T task, TaskMetadata overrideTaskMetadata);
 
     /**
      * Put a task onto associated decaton queue.
@@ -127,10 +127,14 @@ public interface DecatonClient<T> extends AutoCloseable {
 
     @Builder
     @Value
-    class TaskMetaData {
-        /** timestamp of task metadata */
+    class TaskMetadata {
+        /**
+         * timestamp of task metadata
+         */
         Long timestamp;
-        /** scheduledTime for event processing, it should be (timestamp + delayDuration) in milliseconds */
+        /**
+         * scheduledTime for event processing, it should be (timestamp + delayDuration) in milliseconds
+         */
         Long scheduledTime;
     }
 }

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -56,13 +55,7 @@ public class DecatonClientTest {
         }
 
         @Override
-        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, Duration delayDuration) {
-            return null;
-        }
-
-        @Override
-        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, long timestamp,
-                                                    long delayInMillis) {
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, TaskMetaData overrideTaskMetaData) {
             return null;
         }
 

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -55,7 +55,7 @@ public class DecatonClientTest {
         }
 
         @Override
-        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, TaskMetaData overrideTaskMetaData) {
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, TaskMetadata overrideTaskMetadata) {
             return null;
         }
 

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +52,17 @@ public class DecatonClientTest {
 
         @Override
         public CompletableFuture<PutTaskResult> put(String key, HelloTask task, long timestamp) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, Duration delayDuration) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, long timestamp,
+                                                    long delayInMillis) {
             return null;
         }
 


### PR DESCRIPTION
Hello, decaton team.
We are using decaton in our application and for one topic, we’d like to use the delayed event feature of decaton.  We are using decatonClient to publish events and there is no put method which can be used to custom  scheduledTime  and it’s hard to extend the DecatonClientImpl class. So I added the put method with delay duration (by duration or milliseconds) as parameter. 
Please take a look at it.