### PR TITLE
Make record header accessible from DecatonProcessor fixes #73

### DIFF
--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -1,6 +1,6 @@
 Dynamic Property Configuration
 =============================
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: centraldogma,processor
 
 == Property Supplier

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,6 +1,6 @@
 Getting Started Decaton
 =======================
-:base_version: 0.0.44
+:base_version: 0.0.45-SNAPSHOT
 :modules: common,client,processor,protobuf
 
 Let's start from the most basic usage of Decaton client/processor.

--- a/docs/key-blocking.adoc
+++ b/docs/key-blocking.adoc
@@ -1,5 +1,5 @@
 = Key Blocking
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/monitoring.adoc
+++ b/docs/monitoring.adoc
@@ -1,6 +1,6 @@
 Monitoring Decaton
 ==================
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 This document guides you how to monitor your Decaton processor applications.

--- a/docs/rate-limiting.adoc
+++ b/docs/rate-limiting.adoc
@@ -1,5 +1,5 @@
 = Rate Limiting
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/retry-queueing.adoc
+++ b/docs/retry-queueing.adoc
@@ -1,5 +1,5 @@
 = Retry Queuing
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/task-compaction.adoc
+++ b/docs/task-compaction.adoc
@@ -1,5 +1,5 @@
 = Task Compaction
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 == Introduction

--- a/docs/tracing.adoc
+++ b/docs/tracing.adoc
@@ -1,5 +1,5 @@
 = Tracing
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: brave,processor
 
 Decaton can integrate with distributed tracing frameworks so that you can associate the processing of a message

--- a/docs/why-decaton.adoc
+++ b/docs/why-decaton.adoc
@@ -1,6 +1,6 @@
 Why Decaton
 ===========
-:base_version: 0.0.43
+:base_version: 0.0.45-SNAPSHOT
 :modules: processor
 
 This document explains why we have decided to create a new consumer framework.

--- a/processor/src/main/java/com/linecorp/decaton/processor/ProcessingContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/ProcessingContext.java
@@ -18,6 +18,9 @@ package com.linecorp.decaton.processor;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+
 import com.linecorp.decaton.processor.runtime.LoggingContext;
 
 public interface ProcessingContext<T> {
@@ -34,6 +37,12 @@ public interface ProcessingContext<T> {
      * task.
      */
     String key();
+
+    /**
+     * Returns the {@link Headers} which is associated to the source {@link ConsumerRecord} of the task.
+     * @return an instance of {@link Headers}
+     */
+    Headers headers();
 
     /**
      * Returns the subscriptionId of the current processing context.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -39,7 +39,6 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
     private final String subscriptionId;
     private final TaskRequest request;
     private final DecatonTask<T> task;
-    private final Headers headers;
     private final DeferredCompletion completion;
     private final List<DecatonProcessor<T>> downstreams;
     private final DecatonProcessor<byte[]> retryQueueingProcessor;
@@ -58,7 +57,6 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
         this.downstreams = Collections.unmodifiableList(downstreams);
         this.retryQueueingProcessor = retryQueueingProcessor;
         completionDeferred = new AtomicBoolean();
-        headers = request.headers();
     }
 
     public ProcessingContextImpl(String subscriptionId, TaskRequest request, DecatonTask<T> task,
@@ -79,7 +77,7 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
 
     @Override
     public Headers headers() {
-        return headers;
+        return request.headers();
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessingContextImpl.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.kafka.common.header.Headers;
+
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
@@ -37,6 +39,7 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
     private final String subscriptionId;
     private final TaskRequest request;
     private final DecatonTask<T> task;
+    private final Headers headers;
     private final DeferredCompletion completion;
     private final List<DecatonProcessor<T>> downstreams;
     private final DecatonProcessor<byte[]> retryQueueingProcessor;
@@ -55,6 +58,7 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
         this.downstreams = Collections.unmodifiableList(downstreams);
         this.retryQueueingProcessor = retryQueueingProcessor;
         completionDeferred = new AtomicBoolean();
+        headers = request.headers();
     }
 
     public ProcessingContextImpl(String subscriptionId, TaskRequest request, DecatonTask<T> task,
@@ -71,6 +75,11 @@ public class ProcessingContextImpl<T> implements ProcessingContext<T> {
     @Override
     public String key() {
         return request.key();
+    }
+
+    @Override
+    public Headers headers() {
+        return headers;
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -372,7 +372,8 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
 
             if (blacklistedKeysFilter.shouldTake(record)) {
                 TaskRequest taskRequest =
-                        new TaskRequest(tp, record.offset(), completion, record.key(), trace, record.value());
+                        new TaskRequest(tp, record.offset(), completion, record.key(),
+                                        record.headers(), trace, record.value());
                 context.addRequest(taskRequest);
             } else {
                 completion.complete();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskRequest.java
@@ -17,6 +17,7 @@
 package com.linecorp.decaton.processor.runtime;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
 
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.TracingProvider.RecordTraceHandle;
@@ -35,6 +36,8 @@ class TaskRequest {
     private final String key;
     private final String id;
     @ToString.Exclude
+    private final Headers headers;
+    @ToString.Exclude
     private final RecordTraceHandle trace;
     @ToString.Exclude
     private byte[] rawRequestBytes;
@@ -43,12 +46,14 @@ class TaskRequest {
                 long recordOffset,
                 DeferredCompletion completion,
                 String key,
+                Headers headers,
                 RecordTraceHandle trace,
                 byte[] rawRequestBytes) {
         this.topicPartition = topicPartition;
         this.recordOffset = recordOffset;
         this.completion = completion;
         this.key = key;
+        this.headers = headers;
         this.trace = trace;
         this.rawRequestBytes = rawRequestBytes;
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/CompactionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/CompactionProcessorTest.java
@@ -104,7 +104,7 @@ public class CompactionProcessorTest {
                 taskData,
                 taskData.toByteArray());
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, name, null, null);
+                new TopicPartition("topic", 1), 1, null, name, null, null, null);
         ProcessingContext<HelloTask> context =
                 spy(new ProcessingContextImpl<>("subscription", request, task, completion,
                                                 Collections.singletonList(downstream),

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessPipelineTest.java
@@ -81,7 +81,7 @@ public class ProcessPipelineTest {
 
     private static TaskRequest taskRequest() {
         return new TaskRequest(
-                new TopicPartition("topic", 1), 1, mock(DeferredCompletion.class), "TEST", NoopTrace.INSTANCE, REQUEST.toByteArray());
+                new TopicPartition("topic", 1), 1, mock(DeferredCompletion.class), "TEST", null, NoopTrace.INSTANCE, REQUEST.toByteArray());
     }
 
     @Rule

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
@@ -114,7 +114,7 @@ public class ProcessingContextImplTest {
                                                             DecatonProcessor<HelloTask>... processors) {
         TaskRequest request = new TaskRequest(
                 new TopicPartition("topic", 1), 1, null, "TEST",
-                traceHandle, REQUEST.toByteArray());
+                null, traceHandle, REQUEST.toByteArray());
         DecatonTask<HelloTask> task = new DecatonTask<>(
                 TaskMetadata.fromProto(REQUEST.getMetadata()), TASK, TASK.toByteArray());
         return new ProcessingContextImpl<>("subscription", request, task, Arrays.asList(processors), null);
@@ -340,7 +340,8 @@ public class ProcessingContextImplTest {
         DeferredCompletion completion = spy(new MockCompletion());
 
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, "TEST", null, REQUEST.toByteArray());
+                new TopicPartition("topic", 1), 1, null, "TEST",
+                null, null, REQUEST.toByteArray());
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.fromProto(REQUEST.getMetadata()), TASK.toByteArray(), TASK.toByteArray());
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessingContextImplTest.java
@@ -340,8 +340,7 @@ public class ProcessingContextImplTest {
         DeferredCompletion completion = spy(new MockCompletion());
 
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, "TEST",
-                null, null, REQUEST.toByteArray());
+                new TopicPartition("topic", 1), 1, null, "TEST", null, null, REQUEST.toByteArray());
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.fromProto(REQUEST.getMetadata()), TASK.toByteArray(), TASK.toByteArray());
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorUnitTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorUnitTest.java
@@ -73,7 +73,7 @@ public class ProcessorUnitTest {
                                   .setSerializedTask(HelloTask.getDefaultInstance().toByteString())
                                   .build();
 
-        taskRequest = new TaskRequest(topicPartition, 1, completion, null, null, request.toByteArray());
+        taskRequest = new TaskRequest(topicPartition, 1, completion, null, null, null, request.toByteArray());
     }
 
     @Test(timeout = 1000)


### PR DESCRIPTION
## Motivation
- Currently there's no way to refer Kafka's RecordHeader from DecatonProcessor
- Sometimes it's necessary to access metadata in the headers and propagate it from DecatonProcessor
  * e.g. Spring-Kafka's request/reply semantics uses KafkaHeader to control message routing

## Changes
- This PR makes DecatonProcessor to access Headers through `ProcessingContext`