### PR TITLE
Add a workaround to build on arm64 mac

### DIFF
--- a/docs/consuming-any-data.adoc
+++ b/docs/consuming-any-data.adoc
@@ -1,6 +1,6 @@
 Consuming Arbitrary Topic
 =========================
-:base_version: 0.0.45
+:base_version: 0.0.46-SNAPSHOT
 :modules: common,protocol,processor
 
 This document guides you how to consume and process topics containing records not consists of Decaton's protocol (not produced by DecatonClient) using Decaton processors.

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -13,8 +13,18 @@ dependencies {
     shade "com.google.protobuf:protobuf-java:$protobufVersion"
 }
 
+// As of Dec 2020, protoc binary for Apple silicon hasn't been published yet.
+// (refs: https://github.com/protocolbuffers/protobuf/issues/8062)
+// To workaround that, override the classifier to x86_64 explicitly on arm64 mac.
+// (Should work thanks to Rosetta 2)
+def classifier = ''
+if ('osx-aarch_64'.equals(osdetector.classifier)) {
+    classifier = 'osx-x86_64'
+}
+
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$protobufVersion"
+        artifact = "com.google.protobuf:protoc:$protobufVersion:$classifier"
     }
 }
+


### PR DESCRIPTION
## Summary
- Decaton doesn't compile on arm64 mac
  * because protoc binary hasn't been published yet

```
% ./gradlew :processor:check
> Task :common:compileJava UP-TO-DATE
> Task :common:processResources NO-SOURCE
> Task :common:classes UP-TO-DATE
> Task :common:jar UP-TO-DATE
> Task :protocol:extractIncludeProto UP-TO-DATE
> Task :protocol:extractProto UP-TO-DATE
> Task :protocol:generateProto FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':protocol:generateProto'.
> Could not resolve all files for configuration ':protocol:protobufToolsLocator_protoc'.
   > Could not find protoc-osx-aarch_64.exe (com.google.protobuf:protoc:3.3.0).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.3.0/protoc-3.3.0-osx-aarch_64.exe
```