### PR TITLE
Embed task metadata in record header

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClientBuilder.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClientBuilder.java
@@ -24,12 +24,11 @@ import java.util.Properties;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 
 import com.linecorp.decaton.client.internal.DecatonClientImpl;
 import com.linecorp.decaton.client.kafka.PrintableAsciiStringSerializer;
-import com.linecorp.decaton.client.kafka.ProtocolBuffersKafkaSerializer;
 import com.linecorp.decaton.common.Serializer;
-import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -54,10 +53,10 @@ public class DecatonClientBuilder<T> {
 
     public static class DefaultKafkaProducerSupplier implements KafkaProducerSupplier {
         @Override
-        public Producer<String, DecatonTaskRequest> getProducer(Properties config) {
+        public Producer<String, byte[]> getProducer(Properties config) {
             return new KafkaProducer<>(config,
                                        new PrintableAsciiStringSerializer(),
-                                       new ProtocolBuffersKafkaSerializer<>());
+                                       new ByteArraySerializer());
         }
     }
 

--- a/client/src/main/java/com/linecorp/decaton/client/KafkaProducerSupplier.java
+++ b/client/src/main/java/com/linecorp/decaton/client/KafkaProducerSupplier.java
@@ -39,5 +39,5 @@ public interface KafkaProducerSupplier {
      * @return an Kafka producer instance which implements {@link Producer}. The returned instance will be
      * closed along with {@link DecatonClient#close} being called.
      */
-    Producer<String, DecatonTaskRequest> getProducer(Properties config);
+    Producer<String, byte[]> getProducer(Properties config);
 }

--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonClientImpl.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonClientImpl.java
@@ -21,13 +21,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import com.google.protobuf.ByteString;
-
 import com.linecorp.decaton.client.DecatonClient;
 import com.linecorp.decaton.client.KafkaProducerSupplier;
 import com.linecorp.decaton.client.PutTaskResult;
 import com.linecorp.decaton.common.Serializer;
-import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 
 public class DecatonClientImpl<T> implements DecatonClient<T> {
@@ -93,15 +90,7 @@ public class DecatonClientImpl<T> implements DecatonClient<T> {
     }
 
     private CompletableFuture<PutTaskResult> put(String key, T task, TaskMetadataProto taskMetadataProto) {
-        byte[] serializedTask = serializer.serialize(task);
-
-        DecatonTaskRequest request =
-                DecatonTaskRequest.newBuilder()
-                                  .setMetadata(taskMetadataProto)
-                                  .setSerializedTask(ByteString.copyFrom(serializedTask))
-                                  .build();
-
-        return producer.sendRequest(key, request);
+        return producer.sendRequest(key, taskMetadataProto, serializer.serialize(task));
     }
 
     private TaskMetadataProto convertToTaskMetadataProto(TaskMetadata overrideTaskMetadata) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -36,6 +36,15 @@ import com.linecorp.decaton.processor.runtime.internal.RateLimiter;
  */
 public class ProcessorProperties extends AbstractDecatonProperties {
     /**
+     * Major version that the processor is upgraded from.
+     */
+    public enum UpgradeFrom {
+        V0,
+        V1,
+        COMPATIBLE_WITH_CURRENT,
+    }
+
+    /**
      * List of keys of task to skip processing.
      *
      * Reloadable: yes
@@ -123,6 +132,17 @@ public class ProcessorProperties extends AbstractDecatonProperties {
             PropertyDefinition.define("decaton.processing.shutdown.timeout.ms", Long.class, 0L,
                                       v -> v instanceof Long && (Long) v >= 0);
 
+    /**
+     * Version that the Decaton processor is upgraded from.
+     * This will be used to provide a graceful way to upgrade processor
+     * when Decaton introduces backward-incompatible change.
+     *
+     * Reloadable: no
+     */
+    public static final PropertyDefinition<UpgradeFrom> CONFIG_UPGRADE_FROM =
+            PropertyDefinition.define("decaton.upgrade.from", UpgradeFrom.class, UpgradeFrom.COMPATIBLE_WITH_CURRENT,
+                                      v -> v instanceof UpgradeFrom);
+
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
             Collections.unmodifiableList(Arrays.asList(
                     CONFIG_IGNORE_KEYS,
@@ -131,7 +151,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_MAX_PENDING_RECORDS,
                     CONFIG_COMMIT_INTERVAL_MS,
                     CONFIG_GROUP_REBALANCE_TIMEOUT_MS,
-                    CONFIG_SHUTDOWN_TIMEOUT_MS));
+                    CONFIG_SHUTDOWN_TIMEOUT_MS,
+                    CONFIG_UPGRADE_FROM));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -110,9 +110,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             DeferredCompletion completion = wrapForTracing(offsetCompletion, trace);
 
             if (blacklistedKeysFilter.shouldTake(record)) {
-                TaskRequest taskRequest =
-                        new TaskRequest(tp, record.offset(), completion, record.key(),
-                                        record.headers(), trace, record.value());
+                TaskRequest taskRequest = new TaskRequest(record, completion, trace);
                 context.addRequest(taskRequest);
             } else {
                 completion.complete();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskExtractor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/TaskExtractor.java
@@ -16,17 +16,19 @@
 
 package com.linecorp.decaton.processor.runtime;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
 /**
- * An interface for classes extracting {@link DecatonTask} from given bytes.
+ * An interface for classes extracting {@link DecatonTask} from given {@link ConsumerRecord}.
  * @param <T> type of task.
  */
 public interface TaskExtractor<T> {
     /**
-     * Extract object of type {@link DecatonTask} from given bytes.
-     * @param bytes raw message bytes.
+     * Extract object of type {@link DecatonTask} from given {@link ConsumerRecord}.
+     * @param record raw {@link ConsumerRecord}.
      * @return object of type {@link DecatonTask}.
-     * @throws RuntimeException this method can throw arbitrary {@link RuntimeException} if given bytes is invalid.
+     * @throws RuntimeException this method can throw arbitrary {@link RuntimeException} if given record is invalid.
      * If the method throws an exception, the task will be discarded and processor continues to process subsequent tasks.
      */
-    DecatonTask<T> extract(byte[] bytes);
+    DecatonTask<T> extract(ConsumerRecord<String, byte[]> record);
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -93,11 +93,10 @@ public class ProcessPipeline<T> implements AutoCloseable {
     // visible for testing
     DecatonTask<T> extract(TaskRequest request) {
         final DecatonTask<T> extracted;
-        extracted = taskExtractor.extract(request.rawRequestBytes());
+        extracted = taskExtractor.extract(request.record());
         if (!validateTask(extracted)) {
             throw new RuntimeException("Invalid task");
         }
-        request.purgeRawRequestBytes();
 
         return extracted;
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 
@@ -23,52 +24,52 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.tracing.TracingProvider.RecordTraceHandle;
 
 import lombok.Getter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 
-@ToString
 @Getter
 @Accessors(fluent = true)
 public class TaskRequest {
-    private final TopicPartition topicPartition;
-    private final long recordOffset;
+    private final ConsumerRecord<String, byte[]> record;
     private final DeferredCompletion completion;
-    private final String key;
     private final String id;
-    @ToString.Exclude
-    private final Headers headers;
-    @ToString.Exclude
     private final RecordTraceHandle trace;
-    @ToString.Exclude
-    private byte[] rawRequestBytes;
 
-    public TaskRequest(TopicPartition topicPartition,
-                       long recordOffset,
+    public TaskRequest(ConsumerRecord<String, byte[]> record,
                        DeferredCompletion completion,
-                       String key,
-                       Headers headers,
-                       RecordTraceHandle trace,
-                       byte[] rawRequestBytes) {
-        this.topicPartition = topicPartition;
-        this.recordOffset = recordOffset;
+                       RecordTraceHandle trace) {
+        this.record = record;
         this.completion = completion;
-        this.key = key;
-        this.headers = headers;
         this.trace = trace;
-        this.rawRequestBytes = rawRequestBytes;
 
         StringBuilder idBuilder = new StringBuilder();
-        idBuilder.append("topic=").append(topicPartition.topic());
-        idBuilder.append(" partition=").append(topicPartition.partition());
-        idBuilder.append(" offset=").append(recordOffset);
+        idBuilder.append("topic=").append(record.topic());
+        idBuilder.append(" partition=").append(record.partition());
+        idBuilder.append(" offset=").append(record.offset());
         id = idBuilder.toString();
     }
 
-    /**
-     * This class will live until the task process has been completed.
-     * To lessen heap pressure, rawRequestBytes should be purged by calling this once the task is extracted.
-     */
-    public void purgeRawRequestBytes() {
-        rawRequestBytes = null;
+    public TopicPartition topicPartition() {
+        return new TopicPartition(record.topic(), record.partition());
+    }
+
+    public String key() {
+        return record.key();
+    }
+
+    public long recordOffset() {
+        return record.offset();
+    }
+
+    public Headers headers() {
+        return record.headers();
+    }
+
+    @Override
+    public String toString() {
+        return "TaskRequest(" +
+               topicPartition() + ", " +
+               recordOffset() + ", " +
+               key() + ", " +
+               id();
     }
 }

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 apply plugin: 'com.google.protobuf'
 
 dependencies {
+    compile "org.apache.kafka:kafka-clients:$kafkaVersion"
     shade "com.google.protobuf:protobuf-java:$protobufVersion"
 }
 

--- a/protocol/src/main/java/com/linecorp/decaton/protocol/TaskMetadataUtil.java
+++ b/protocol/src/main/java/com/linecorp/decaton/protocol/TaskMetadataUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.protocol;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
+
+public class TaskMetadataUtil {
+    // leave a room to change key when it contended with other keys
+    private static final String METADATA_KEY_PROPERTY = "decaton.metadata.header.key";
+    private static final String METADATA_HEADER_KEY;
+    static {
+        METADATA_HEADER_KEY = System.getProperty(METADATA_KEY_PROPERTY, "dt_meta");
+    }
+
+    /**
+     * Write metadata to {@link Headers}
+     * @param metadata task metadata to be written
+     * @param headers record header to write to
+     */
+    public static void writeAsHeader(TaskMetadataProto metadata, Headers headers) {
+        headers.add(METADATA_HEADER_KEY, metadata.toByteArray());
+    }
+
+    /**
+     * Read metadata from given {@link Headers}
+     * @param headers record header to read from
+     * @return parsed {@link TaskMetadataProto} or null if header is absent
+     * @throws IllegalStateException if metadata bytes is invalid
+     */
+    public static TaskMetadataProto readFromHeader(Headers headers) {
+        Header header = headers.lastHeader(METADATA_HEADER_KEY);
+        if (header == null) {
+            return null;
+        }
+        try {
+            return TaskMetadataProto.parseFrom(header.value());
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/protocol/src/main/proto/decaton.proto
+++ b/protocol/src/main/proto/decaton.proto
@@ -22,7 +22,15 @@ message TaskMetadataProto {
 }
 
 // The topic level message struct of the message to request Decaton for processing a task.
+//
+// When Decaton had started, Kafka didn't have record headers yet so we needed to wrap tasks
+// in a protocol to propagate task metadata.
+// As we can use headers now, decaton client has started to support propagating metadata
+// through headers and sending tasks as record value directly.
+// This protocol could be removed in the future release.
 message DecatonTaskRequest {
+    option deprecated = true;
+
     TaskMetadataProto metadata = 1;
     bytes serialized_task = 2;
 }


### PR DESCRIPTION
## Motivation
- Currently, DecatonClient serializes tasks in `DecatonTaskRequest` protobuf format because when Decaton had started, Kafka didn't have record header yet
  * As Kafka started record header support quite long ago, it's natural to use it to embed task metadata

## Summary of changes
### protocol
- Rename `DecatonTaskRequest` protobuf message to `LegacyDecatonTaskRequest` and marked it as `@Deprecated`
- Add `TaskMetadataHeaders` which is responsible for read/write TaskMetadata from/to Headers

### client
- Add new `DecatonClient` which produces tasks as record value directly and embed metadata in headers and make it default
- Add new method `DecatonClientBuilder#buildLegacyClient`, that instantiates old decaton client impl which produces tasks in `DecatonTaskRequest` format
  * for backward compatibility

### processor
- Change the signature of `TaskExtractor#extract` to receive `ConsumerRecord` instead of `byte[]`, to allow users to access record header when extracting a task
- Make `DefaultTaskExtractor` to be able to parse both formats of tasks, `DecatonTaskRequest` protobuf and header-based tasks
  * for compatibility when rolling-upgrading decaton client application
- Introduce `CONFIG_UPGRADE_FROM` processor property, which denotes the previous version when upgrading decaton processor (analogous to Kafka Streams's `upgrade.from` property [ref](https://github.com/apache/kafka/blob/2.4.1/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java#L482))
- `DecatonTaskRetryQueueingProcessor` switches decaton task request format based on `CONFIG_UPGRADED_FROM`
  * If it is `V0_X_X` => produce in `DecatonTaskRequest` format same as current
  * otherwise => produce in header-based format
  * This switch is necessary to prevent producing retry tasks in new header-based format when rolling-upgrading decaton processor application, which is unparseable by old decaton processor version (0.x.x)
- Thus, upgrading process will be like below:
  * upgrade decaton processor by setting `CONFIG_UPGRADE_FROM` to `V0_X_X`
  * one more restart by unsetting `CONFIG_UPGRADE_FROM`
      - decaton processor starts producing retry tasks in header-based format
  * upgrade decaton client

## Want discussion

- As you noticed, current design enforces users to restart processor twice, and pay attention not to upgrade decaton-client first which could produce unparseable tasks
  * Besides, introducing `CONFIG_UPGRADE_FROM` looks bit awkward
- Isn't the upgrade procedure too complicated and error-prone?

This PR is still WIP. I'd like to complete it after we agreed about overall design.