### PR TITLE
Log error trace when scheduleThenProcess fails

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
@@ -66,11 +66,13 @@ public class ProcessorUnit implements AsyncShutdownable {
         Timer timer = Utils.timer();
         try {
             pipeline.scheduleThenProcess(request);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Scheduling and/or processing interrupted. Shutdown initiated={}, request: {}",
+                     terminated, request);
         } catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            log.error("Error while processing request {}. Offset of this will left uncommitted", request);
+            log.error("Error while processing request {}. Corresponding offset will be left uncommitted.",
+                      request, e);
         } finally {
             // This metric measures the total amount of time the processors were processing tasks including time
             // for scheduling those tasks and is used to refer processor threads utilization, so it needs to measure

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
@@ -70,7 +70,8 @@ public class ProcessorUnit implements AsyncShutdownable {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            log.error("Error while processing request {}. Offset of this will left uncommitted", request);
+            log.error("Error while processing request {}. Corresponding offset will be left uncommitted.",
+                      request, e);
         } finally {
             // This metric measures the total amount of time the processors were processing tasks including time
             // for scheduling those tasks and is used to refer processor threads utilization, so it needs to measure

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorUnit.java
@@ -66,13 +66,11 @@ public class ProcessorUnit implements AsyncShutdownable {
         Timer timer = Utils.timer();
         try {
             pipeline.scheduleThenProcess(request);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("Scheduling and/or processing interrupted. Shutdown initiated={}, request: {}",
-                     terminated, request);
         } catch (Exception e) {
-            log.error("Error while processing request {}. Corresponding offset will be left uncommitted.",
-                      request, e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.error("Error while processing request {}. Offset of this will left uncommitted", request);
         } finally {
             // This metric measures the total amount of time the processors were processing tasks including time
             // for scheduling those tasks and is used to refer processor threads utilization, so it needs to measure


### PR DESCRIPTION
We found this cryptic error in our project (".. Offset of this will left uncommitted") but could not tell the cause since there is no stacktrace and no other log.

In this PR, I separate exception handling into
- InterruptedException : more or less expectable on shutdown; log at warn level
- the rest : really unexpected since `ProcessPipeline` also does its share of error handling