### PR TITLE
Update release script to follow the new versioning scheme

### DIFF
--- a/developer-docs/making-release.md
+++ b/developer-docs/making-release.md
@@ -20,16 +20,10 @@ sonatypeUsername=// OSS Sonatype username that you created at step 1
 sonatypePassword=// OSS Sonatype password that you created at step 1
 ```
 
-## Releasing SNAPSHOT version
-
-Run `./scripts/publish.sh`.
-
-NOTE: It takes some moment (~1h) until the published version becomes visible to users.
-
-## Releasing release version
+## Releasing a new version
 
 1. Check `:base_version:` of every documents under `./docs` to see if there's any article referring SNAPSHOT version. If any, strip SNAPSHOT suffix with carefully checking if the document is up-to-date with the version you're going to release. Then make a single commit to bump the document version and push it directly to the master branch.
-2. Run `./script/publish.sh --release`.
+2. Run `./script/publish.sh $RELEASE_VERSION`.
 3. Upon successful exit, login to https://oss.sonatype.org and click "Staging Repositories" in the left panel. ![staging-repo](staging-repositories.png)
 4. Confirm you see an entry for decaton in staging repositories list. Check the box and press the "Close" button. ![staging-list](staging-list.png)
 5. It will take some time to complete. Keep polling the screen until the "Release" button becomes clickable. ![release-ready](./release-ready.png)


### PR DESCRIPTION
As we're going to manage versions following semver we're gonna need to specify the release version by ourselves.
Also deprecating stuff related to SNAPSHOT versions as we very rarely make a publish with a SNAPSHOT version.