### PR TITLE
Fix regression handling

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -130,6 +130,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             } catch (OffsetRegressionException e) {
                 log.warn("Offset regression at partition {}", tp);
                 assignManager.repair(tp);
+                context = contexts.get(tp);
                 // If it fails even at 2nd attempt... no idea let it die.
                 offsetCompletion = context.registerOffset(record.offset());
             }


### PR DESCRIPTION
Fix a bug introduced by #60 .

Handling of `OffsetRegressionException` calls `assignManager.repair` which internally replaces the `PartitionContext` corresponding to the topic-partition, but it later still uses an old, previously grabbed `Context` causing subsequent `registerOffset` to never succeeds.