### PR TITLE
DocChecker: Fail validation only if base_version differs to the release version by major version

### DIFF
--- a/docs/src/main/java/com/linecorp/decaton/DocumentChecker.java
+++ b/docs/src/main/java/com/linecorp/decaton/DocumentChecker.java
@@ -60,19 +60,8 @@ public final class DocumentChecker {
                                matcher.group(4) != null);
         }
 
-        boolean isHigherThanOrEqualsTo(Version other) {
-            int[] a = { major, minor, patch, snapshot ? 0 : 1 };
-            int[] b = { other.major, other.minor, other.patch, other.snapshot ? 0 : 1 };
-
-            for (int i = 0; i < a.length; i++) {
-                if (a[i] > b[i]) {
-                    return true;
-                }
-                if (a[i] < b[i]) {
-                    return false;
-                }
-            }
-            return true;
+        boolean hasHigherOrEqualMajorVersion(Version other) {
+            return major >= other.major;
         }
 
         @Override
@@ -142,7 +131,7 @@ public final class DocumentChecker {
                                   baseVersion, version));
             return errors;
         }
-        if (baseVersion.isHigherThanOrEqualsTo(version)) {
+        if (baseVersion.hasHigherOrEqualMajorVersion(version)) {
             return errors;
         }
 


### PR DESCRIPTION
Background:
* We have started semantic versioning
* DocChecker always makes a release build to fail because most of the docs depends on `processor` module which gets updated almost 100% on each release.

Let's change DocChecker to fail only if `:base_version:` has lower major version than the version being released. 
This should be okay because:
* The objective of DocChecker is to avoid a document being outdated by forgotten to be updated
* A document gets outdated mainly by Public API changes. Otherwise, the content in doc is almost guaranteed to keep working.