### PR TITLE
Bugfix: Exception from consumer.pause() in rebalance due to passing already revoked partition

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManager.java
@@ -16,9 +16,10 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -117,7 +118,7 @@ public class ConsumeManager implements AutoCloseable {
      * @param subscribeTopics list of topics to fetch records from.
      */
     public void init(Collection<String> subscribeTopics) {
-        List<TopicPartition> pausedPartitions = new ArrayList<>();
+        Set<TopicPartition> pausedPartitions = new HashSet<>();
         consumer.subscribe(subscribeTopics, new ConsumerRebalanceListener() {
             @Override
             public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
@@ -139,6 +140,7 @@ public class ConsumeManager implements AutoCloseable {
                 // Consumer rebalance resets all pause states of assigned partitions even though they
                 // haven't moved over from/to different consumer instance.
                 // Need to re-call pause with originally paused partitions to bring state back consistent.
+                pausedPartitions.retainAll(partitions);
                 try {
                     consumer.pause(pausedPartitions);
                 } finally {


### PR DESCRIPTION
In current implementation the `consumer.pause()` may throw `IllegalStateException: No current assignment for partition ...`. 

When rebalance occurs, we save the list of partitions and restore the pause state later. However, since the rebalance might have taken over some partitions off from this instance, we have to filter these partitions from the argument of consumer.pause().
So this happens when all the following 3 conditions are met:
* There’s a paused partition
* Trigger rebalance (instance failure, restart)
* Rebalance taken over a partition from the current instance