### PR TITLE
Fix flaky and broken offsetRegression test

### DIFF
--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -191,7 +191,7 @@ public class ProcessorSubscriptionTest {
         subscription.close();
 
         OffsetAndMetadata offset = committedOffsets.get(tp);
-        // 101 + 1 is committed when offset=100 is completed.
+        // 101 + 1 is committed when offset=101 is completed.
         assertEquals(102L, offset.offset());
     }
 }


### PR DESCRIPTION
I was trying to address flaky test caused https://github.com/line/decaton/actions/runs/573915623 to fail, but while I'm working I realized that the current test implementation isn't reflecting my intention correctly.

The renewed version of test intends to check that a ProcessorSubscription continue working even after an offset regression.