### PR TITLE
MetricsTest should clear metrics in advance to make test result stable fixes #94

### DIFF
--- a/processor/src/test/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/metrics/MetricsTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.linecorp.decaton.processor.metrics.Metrics.SchedulerMetrics;
@@ -38,6 +39,11 @@ public class MetricsTest {
 
     private static Set<Meter.Id> idSet(Meter.Id... ids) {
         return new HashSet<>(Arrays.asList(ids));
+    }
+
+    @Before
+    public void setUp() {
+        Metrics.registry().clear();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Currently, `MetricsTest.testMetricsLifecycleManagement` fails if `CompactionProcessorTest` is executed first (depending on test execution order), because metrics for `CompactionProcessor` isn't cleaned up in any place
  * https://github.com/line/decaton/blob/master/processor/src/main/java/com/linecorp/decaton/processor/processors/CompactionProcessor.java#L58
- One possible fix might be creating enclosing class for `CompactionProcessor` metrics and extends AbstractMetrics and close it upon processor close
- But rather, I fixed by clearing metrics in `@Before` to make testMetricsLifecycleManagement stable even we forget closing metrics in other classes