### PR TITLE
Stop setting record timestamp from meta fixes #101

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
@@ -18,7 +18,6 @@ package com.linecorp.decaton.client.internal;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
@@ -30,7 +29,6 @@ import com.linecorp.decaton.client.DecatonClient;
 import com.linecorp.decaton.client.KafkaProducerSupplier;
 import com.linecorp.decaton.client.PutTaskResult;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
-import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 
 /**
  * A raw interface to put a built {@link DecatonTaskRequest} directly.
@@ -64,9 +62,7 @@ public class DecatonTaskProducer implements AutoCloseable {
     }
 
     public CompletableFuture<PutTaskResult> sendRequest(String key, DecatonTaskRequest request) {
-        TaskMetadataProto taskMeta = Objects.requireNonNull(request.getMetadata(), "request.metadata");
-        ProducerRecord<String, DecatonTaskRequest> record =
-                new ProducerRecord<>(topic, null, null, key, request);
+        ProducerRecord<String, DecatonTaskRequest> record = new ProducerRecord<>(topic, key, request);
 
         CompletableFuture<PutTaskResult> result = new CompletableFuture<>();
         producer.send(record, (metadata, exception) -> {

--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
@@ -66,7 +66,7 @@ public class DecatonTaskProducer implements AutoCloseable {
     public CompletableFuture<PutTaskResult> sendRequest(String key, DecatonTaskRequest request) {
         TaskMetadataProto taskMeta = Objects.requireNonNull(request.getMetadata(), "request.metadata");
         ProducerRecord<String, DecatonTaskRequest> record =
-                new ProducerRecord<>(topic, null, taskMeta.getTimestampMillis(), key, request);
+                new ProducerRecord<>(topic, null, null, key, request);
 
         CompletableFuture<PutTaskResult> result = new CompletableFuture<>();
         producer.send(record, (metadata, exception) -> {

--- a/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
@@ -18,6 +18,7 @@ package com.linecorp.decaton.client.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -79,7 +80,7 @@ public class DecatonClientImplTest {
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<String, DecatonTaskRequest> record = captor.getValue();
-        assertEquals(1234, record.timestamp().longValue());
+        assertNull(record.timestamp());
         assertEquals(1234, record.value().getMetadata().getTimestampMillis());
     }
 
@@ -91,7 +92,7 @@ public class DecatonClientImplTest {
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<String, DecatonTaskRequest> record = captor.getValue();
-        assertEquals(1234, record.timestamp().longValue());
+        assertNull(record.timestamp());
         assertEquals(1234, record.value().getMetadata().getTimestampMillis());
     }
 
@@ -103,7 +104,7 @@ public class DecatonClientImplTest {
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<String, DecatonTaskRequest> record = captor.getValue();
-        assertEquals(5678, record.timestamp().longValue());
+        assertNull(record.timestamp());
         assertEquals(5678, record.value().getMetadata().getTimestampMillis());
     }
 
@@ -115,7 +116,7 @@ public class DecatonClientImplTest {
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<String, DecatonTaskRequest> record = captor.getValue();
-        assertEquals(5678, record.timestamp().longValue());
+        assertNull(record.timestamp());
         assertEquals(5678, record.value().getMetadata().getTimestampMillis());
     }
 
@@ -158,7 +159,7 @@ public class DecatonClientImplTest {
     private void verifyAndAssertTaskMetadata(long timestamp, long scheduledTime) {
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<String, DecatonTaskRequest> record = captor.getValue();
-        assertEquals(timestamp, record.timestamp().longValue());
+        assertNull(record.timestamp());
         assertEquals(timestamp, record.value().getMetadata().getTimestampMillis());
         assertEquals(scheduledTime, record.value().getMetadata().getScheduledTimeMillis());
         assertNotNull(record.value().getMetadata().getSourceApplicationId());

--- a/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
@@ -41,7 +41,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.linecorp.decaton.client.DecatonClient.TaskMetadata;
-import com.linecorp.decaton.client.internal.DecatonClientImpl;
 import com.linecorp.decaton.protobuf.ProtocolBuffersSerializer;
 import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Sample.HelloTask;

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.decaton.processor;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.After;
@@ -26,7 +29,13 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.linecorp.decaton.processor.runtime.DecatonTask;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.Property;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
+import com.linecorp.decaton.processor.runtime.TaskExtractor;
+import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
 import com.linecorp.decaton.testing.KafkaClusterRule;
 import com.linecorp.decaton.testing.TestUtils;
 import com.linecorp.decaton.testing.processor.ProcessedRecord;
@@ -34,12 +43,23 @@ import com.linecorp.decaton.testing.processor.ProcessingGuarantee;
 import com.linecorp.decaton.testing.processor.ProcessingGuarantee.GuaranteeType;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
 import com.linecorp.decaton.testing.processor.ProducedRecord;
+import com.linecorp.decaton.testing.processor.TestTask;
 
 public class RetryQueueingTest {
     @ClassRule
-    public static KafkaClusterRule rule = new KafkaClusterRule();
+    public static KafkaClusterRule rule = new KafkaClusterRule(brokerProperties());
 
     private String retryTopic;
+
+    private static Properties brokerProperties() {
+        Properties props = new Properties();
+        // We found that retry record's timestamp could be set to 0 unintentionally,
+        // which causes messages to be deleted by retention immediately.
+        // To reproduce it in integration test easily, we set shorter retention check interval.
+        // See https://github.com/line/decaton/issues/101 for the details.
+        props.setProperty("log.retention.check.interval.ms", "500");
+        return props;
+    }
 
     @Before
     public void setUp() {
@@ -74,6 +94,21 @@ public class RetryQueueingTest {
         }
     }
 
+    private static class TestTaskExtractor implements TaskExtractor<TestTask> {
+        @Override
+        public DecatonTask<TestTask> extract(byte[] bytes) {
+            try {
+                TaskMetadata meta = TaskMetadata.builder().build();
+                DecatonTaskRequest request = DecatonTaskRequest.parseFrom(bytes);
+                TestTask task = new TestTask.TestTaskDeserializer().deserialize(
+                        request.getSerializedTask().toByteArray());
+                return new DecatonTask<>(meta, task, bytes);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
     @Test(timeout = 30000)
     public void testRetryQueuing() throws Exception {
         // scenario:
@@ -96,6 +131,48 @@ public class RetryQueueingTest {
                         GuaranteeType.PROCESS_ORDERING,
                         GuaranteeType.SERIAL_PROCESSING)
                 .customSemantics(new ProcessRetriedTask())
+                .build()
+                .run();
+    }
+
+    /*
+     * This test tries to re-produce delivery-loss due to https://github.com/line/decaton/issues/101 by:
+     *   1. Retry all tasks once immediately
+     *   2. Process retried tasks in "slow" pace
+     *     - To simulate the situation like "Retry tasks spikes (e.g. due to downstream storage failure),
+     *       but processing throughput is not sufficient", which is typical situation that causes
+     *       message delivery loss due to decaton#101.
+     */
+    @Test(timeout = 60000)
+    public void testRetryQueuingExtractingWithDefaultMeta() throws Exception {
+        // LogManager waits to start clean-up process until InitialTaskDelayMs (30sec) elapses.
+        // https://github.com/apache/kafka/blob/2.4.0/core/src/main/scala/kafka/log/LogManager.scala#L70
+        Thread.sleep(30000L);
+
+        ProcessorTestSuite
+                .builder(rule)
+                .numTasks(10)
+                .propertySupplier(StaticPropertySupplier.of(
+                        // Configure max pending records to 1 to pause fetches easily
+                        Property.ofStatic(ProcessorProperties.CONFIG_MAX_PENDING_RECORDS, 1),
+                        Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 1)
+                ))
+                .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
+                    if (ctx.metadata().retryCount() == 0) {
+                        ctx.retry();
+                    } else {
+                        Thread.sleep(1000L);
+                    }
+                }))
+                .retryConfig(RetryConfig.builder()
+                                        .retryTopic(retryTopic)
+                                        .backoff(Duration.ofMillis(10))
+                                        .build())
+                .excludeSemantics(
+                        GuaranteeType.PROCESS_ORDERING,
+                        GuaranteeType.SERIAL_PROCESSING)
+                .customSemantics(new ProcessRetriedTask())
+                .customTaskExtractor(new TestTaskExtractor())
                 .build()
                 .run();
     }

--- a/testing/src/main/java/com/linecorp/decaton/testing/EmbeddedKafkaCluster.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/EmbeddedKafkaCluster.java
@@ -48,11 +48,18 @@ public class EmbeddedKafkaCluster implements AutoCloseable {
     private final String bootstrapServers;
 
     public EmbeddedKafkaCluster(int numBrokers, String zkConnect) {
+        this(numBrokers, zkConnect, new Properties());
+    }
+
+    public EmbeddedKafkaCluster(int numBrokers,
+                                String zkConnect,
+                                Properties brokerProperties) {
         servers = new ArrayList<>(numBrokers);
         List<String> listeners = new ArrayList<>(numBrokers);
 
         for (int i = 0; i < numBrokers; i++) {
             Properties prop = createBrokerConfig(i, zkConnect);
+            prop.putAll(brokerProperties);
             KafkaServer server = TestUtils.createServer(KafkaConfig.fromProps(prop), Time.SYSTEM);
             int port = TestUtils.boundPort(server, SecurityProtocol.PLAINTEXT);
             String listener = "127.0.0.1:" + port;

--- a/testing/src/main/java/com/linecorp/decaton/testing/KafkaClusterRule.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/KafkaClusterRule.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.decaton.testing;
 
+import java.util.Properties;
+
 import org.junit.Rule;
 import org.junit.rules.ExternalResource;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
  * JUnit {@link Rule} that starts an embedded Kafka cluster.
  */
 @Slf4j
+@RequiredArgsConstructor
 public class KafkaClusterRule extends ExternalResource {
     private static final int KAFKA_CLUSTER_SIZE = 3;
 
@@ -35,6 +39,11 @@ public class KafkaClusterRule extends ExternalResource {
     @Getter
     @Accessors(fluent = true)
     private KafkaAdmin admin;
+    private final Properties brokerProperties;
+
+    public KafkaClusterRule() {
+        this(new Properties());
+    }
 
     public String bootstrapServers() {
         return kafkaCluster.bootstrapServers();
@@ -46,7 +55,8 @@ public class KafkaClusterRule extends ExternalResource {
 
         zooKeeper = new EmbeddedZooKeeper();
         kafkaCluster = new EmbeddedKafkaCluster(KAFKA_CLUSTER_SIZE,
-                                                zooKeeper.zkConnectAsString());
+                                                zooKeeper.zkConnectAsString(),
+                                                brokerProperties);
         admin = new KafkaAdmin(kafkaCluster.bootstrapServers());
     }
 


### PR DESCRIPTION
## Summary
- As described in #101, when we don't set `TaskMetadata#timestampMillis` explicitly on `TaskExtractor`, retry record's timestamp could be set to 0, which cause records to be deleted on broker side by retention immediately
- As retention-based log deletion takes record's timestamp into account, we should supply it independently of task's metadata timestamp (i.e. which is expected to be not related to Kafka's internal)

## Changes
- Stop setting record's timestamp from task metadata in DecatonTaskProducer.
  * We leave record's timestamp as null, so that KafkaProducer fills `System.currentTimeMillis`
  * NOTE: This could be considered as "backward-incompatible change", so we should bump major version when releasing this fix
- Add an integration test to reproduce the phenomenon (i.e. retry tasks are produces with timestamp=0 unintentionally, then deleted by retention immediately)
