### PR TITLE
Reduce some object allocations that are identified as expensive by allocation profiling

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/LoggingContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/LoggingContext.java
@@ -38,22 +38,29 @@ public class LoggingContext implements AutoCloseable {
     public static final String SUBSCRIPTION_ID_KEY = "dt_subscription_id";
     public static final String TASK_KEY = "dt_task_key";
 
-    public LoggingContext(String subscriptionId, TaskRequest request, TaskMetadata metadata) {
-        MDC.put(METADATA_KEY, metadata.toString());
-        MDC.put(TASK_KEY, String.valueOf(request.key()));
-        MDC.put(SUBSCRIPTION_ID_KEY, subscriptionId);
-        MDC.put(OFFSET_KEY, String.valueOf(request.recordOffset()));
-        MDC.put(TOPIC_KEY, request.topicPartition().topic());
-        MDC.put(PARTITION_KEY, String.valueOf(request.topicPartition().partition()));
+    private final boolean enabled;
+
+    public LoggingContext(boolean enabled, String subscriptionId, TaskRequest request, TaskMetadata metadata) {
+        this.enabled = enabled;
+        if (enabled) {
+            MDC.put(METADATA_KEY, metadata.toString());
+            MDC.put(TASK_KEY, String.valueOf(request.key()));
+            MDC.put(SUBSCRIPTION_ID_KEY, subscriptionId);
+            MDC.put(OFFSET_KEY, String.valueOf(request.recordOffset()));
+            MDC.put(TOPIC_KEY, request.topicPartition().topic());
+            MDC.put(PARTITION_KEY, String.valueOf(request.topicPartition().partition()));
+        }
     }
 
     @Override
     public void close() {
-        MDC.remove(OFFSET_KEY);
-        MDC.remove(TOPIC_KEY);
-        MDC.remove(TASK_KEY);
-        MDC.remove(PARTITION_KEY);
-        MDC.remove(METADATA_KEY);
-        MDC.remove(SUBSCRIPTION_ID_KEY);
+        if (enabled) {
+            MDC.remove(OFFSET_KEY);
+            MDC.remove(TOPIC_KEY);
+            MDC.remove(TASK_KEY);
+            MDC.remove(PARTITION_KEY);
+            MDC.remove(METADATA_KEY);
+            MDC.remove(SUBSCRIPTION_ID_KEY);
+        }
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/LoggingContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/LoggingContext.java
@@ -52,6 +52,10 @@ public class LoggingContext implements AutoCloseable {
         }
     }
 
+    public LoggingContext(String subscriptionId, TaskRequest request, TaskMetadata metadata) {
+        this(true, subscriptionId, request, metadata);
+    }
+
     @Override
     public void close() {
         if (enabled) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.MDC;
+
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.internal.AbstractDecatonProperties;
 import com.linecorp.decaton.processor.runtime.internal.OutOfOrderCommitControl;
@@ -123,6 +125,18 @@ public class ProcessorProperties extends AbstractDecatonProperties {
             PropertyDefinition.define("decaton.processing.shutdown.timeout.ms", Long.class, 0L,
                                       v -> v instanceof Long && (Long) v >= 0);
 
+    /**
+     * Control whether to enable or disable decaton specific information store in slf4j's {@link MDC}.
+     * This option is enabled by default, but it is known to cause some object allocations which could become
+     * a problem in massive scale traffic. This option intend to provide an option for users to disable MDC
+     * properties where not necessary to reduce GC pressure.
+     *
+     * Reloadable: yes
+     */
+    public static final PropertyDefinition<Boolean> CONFIG_LOGGING_MDC_ENABLED =
+            PropertyDefinition.define("decaton.logging.mdc.enabled", Boolean.class, true,
+                                      v -> v instanceof Boolean);
+
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
             Collections.unmodifiableList(Arrays.asList(
                     CONFIG_IGNORE_KEYS,
@@ -131,7 +145,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_MAX_PENDING_RECORDS,
                     CONFIG_COMMIT_INTERVAL_MS,
                     CONFIG_GROUP_REBALANCE_TIMEOUT_MS,
-                    CONFIG_SHUTDOWN_TIMEOUT_MS));
+                    CONFIG_SHUTDOWN_TIMEOUT_MS,
+                    CONFIG_LOGGING_MDC_ENABLED));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -25,6 +25,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.runtime.TaskExtractor;
 import com.linecorp.decaton.processor.metrics.Metrics;
 import com.linecorp.decaton.processor.metrics.Metrics.ProcessMetrics;
@@ -105,7 +106,8 @@ public class ProcessPipeline<T> implements AutoCloseable {
     // visible for testing
     CompletableFuture<Void> process(TaskRequest request, DecatonTask<T> task) throws InterruptedException {
         ProcessingContext<T> context =
-                new ProcessingContextImpl<>(scope.subscriptionId(), request, task, processors, retryProcessor);
+                new ProcessingContextImpl<>(scope.subscriptionId(), request, task, processors, retryProcessor,
+                                            scope.props());
 
         Timer timer = Utils.timer();
         CompletableFuture<Void> processResult;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
@@ -34,7 +34,6 @@ public class TaskRequest {
     private final long recordOffset;
     private final DeferredCompletion completion;
     private final String key;
-    private final String id;
     @ToString.Exclude
     private final Headers headers;
     @ToString.Exclude
@@ -56,12 +55,15 @@ public class TaskRequest {
         this.headers = headers;
         this.trace = trace;
         this.rawRequestBytes = rawRequestBytes;
+    }
 
-        StringBuilder idBuilder = new StringBuilder();
-        idBuilder.append("topic=").append(topicPartition.topic());
-        idBuilder.append(" partition=").append(topicPartition.partition());
-        idBuilder.append(" offset=").append(recordOffset);
-        id = idBuilder.toString();
+    public String id() {
+        // TaskRequest object is held alive through associated ProcessingContext's lifetime, hence holding
+        // any value as its field makes memory occupation worse. Since this ID field is rarely used (typically
+        // when trace level logging is enabled), it is better to take short lived object allocation and cpu cost
+        // rather than building it once and cache as an object field.
+        return "topic=" + topicPartition.topic() + " partition=" + topicPartition.partition() +
+               " offset=" + recordOffset;
     }
 
     /**

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
@@ -38,18 +38,18 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
-import com.linecorp.decaton.processor.runtime.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.processors.CompactionProcessor.CompactChoice;
 import com.linecorp.decaton.processor.processors.CompactionProcessor.CompactingTask;
+import com.linecorp.decaton.processor.runtime.DecatonTask;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.runtime.internal.ProcessingContextImpl;
 import com.linecorp.decaton.processor.runtime.internal.TaskRequest;
 import com.linecorp.decaton.protocol.Sample.HelloTask;
@@ -109,9 +109,9 @@ public class CompactionProcessorTest {
         TaskRequest request = new TaskRequest(
                 new TopicPartition("topic", 1), 1, null, name, null, null, null);
         ProcessingContext<HelloTask> context =
-                Mockito.spy(new ProcessingContextImpl<>("subscription", request, task, completion,
-                                                        Collections.singletonList(downstream),
-                                                        null));
+                spy(new ProcessingContextImpl<>("subscription", request, task,
+                                                Collections.singletonList(downstream), null,
+                                                ProcessorProperties.builder().build(), completion));
 
         TaskInput input = new TaskInput(taskData, completion, context);
         if (beforeProcess != null) {

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
@@ -53,6 +53,7 @@ import com.linecorp.decaton.processor.runtime.DecatonTask;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.TaskMetadata;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.tracing.TestTraceHandle;
 import com.linecorp.decaton.processor.tracing.TestTracingProvider;
 import com.linecorp.decaton.processor.tracing.TracingProvider.RecordTraceHandle;
@@ -117,7 +118,8 @@ public class ProcessingContextImplTest {
                 null, traceHandle, REQUEST.toByteArray());
         DecatonTask<HelloTask> task = new DecatonTask<>(
                 TaskMetadata.fromProto(REQUEST.getMetadata()), TASK, TASK.toByteArray());
-        return new ProcessingContextImpl<>("subscription", request, task, Arrays.asList(processors), null);
+        return new ProcessingContextImpl<>("subscription", request, task, Arrays.asList(processors),
+                                           null, ProcessorProperties.builder().build());
     }
 
     private static void safeAwait(CountDownLatch latch) {
@@ -345,8 +347,10 @@ public class ProcessingContextImplTest {
                 TaskMetadata.fromProto(REQUEST.getMetadata()), TASK.toByteArray(), TASK.toByteArray());
 
         ProcessingContextImpl<byte[]> context =
-                spy(new ProcessingContextImpl<>("subscription", request, task, completion,
-                                                Collections.emptyList(), retryProcessor));
+                spy(new ProcessingContextImpl<>("subscription", request, task,
+                                                Collections.emptyList(), retryProcessor,
+                                                ProcessorProperties.builder().build(),
+                                                completion));
 
         CompletableFuture<Void> produceFuture = context.retry();
 


### PR DESCRIPTION
I found some code in decaton core causes massive object allocations (in proportional to consumed records) that causes high GC pressure.

The most significant ones are String allocation in `LoggingContext` (`TaskMetadata.toString()`) but `TaskRequest#id` too. (which is used only if trace level logging is enabled)

In this PR I saved those expensive object allocations by making it lazy or by adding a new flag to opt-out `LoggingContext` when its not necessary. 

* Adds new config `decaton.logging.mdc.enabled`