### PR TITLE
Make max.poll.records customizable through consumer properties

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
@@ -143,6 +143,14 @@ public class SubscriptionBuilder {
         return this;
     }
 
+    private int consumerMaxPollRecords() {
+        if (consumerConfig.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG) != null) {
+            return Integer.parseInt(consumerConfig.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+        } else {
+            return ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS;
+        }
+    }
+
     public ProcessorSubscription build() {
         ProcessorProperties props = propertiesBuilder.build();
         String topic = processorsBuilder.topic();
@@ -150,7 +158,8 @@ public class SubscriptionBuilder {
                                                         topic,
                                                         Optional.ofNullable(retryConfig),
                                                         props,
-                                                        tracingProvider);
+                                                        tracingProvider,
+                                                        consumerMaxPollRecords());
 
         Properties consumerConfig = Objects.requireNonNull(this.consumerConfig, "consumerConfig");
         ConsumerSupplier consumerSupplier = new ConsumerSupplier(consumerConfig);

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumerSupplier.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumerSupplier.java
@@ -19,7 +19,6 @@ package com.linecorp.decaton.processor.runtime.internal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -30,7 +29,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
-    public static final int MAX_MAX_POLL_RECORDS = 100;
+    public static final int DEFAULT_MAX_POLL_RECORDS = 100;
 
     private static final Map<String, String> configOverwrites = new HashMap<String, String>() {{
         put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
@@ -57,10 +56,9 @@ public class ConsumerSupplier implements Supplier<Consumer<String, byte[]>> {
         }
 
         // max.poll.records handling to avoid memory overused
-        int maxPollRecords = Optional.ofNullable(props.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))
-                                     .map(Integer::parseInt).orElse(Integer.MAX_VALUE);
-        if (maxPollRecords > MAX_MAX_POLL_RECORDS) {
-            props.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(MAX_MAX_POLL_RECORDS));
+        if (props.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG) == null) {
+            props.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+                              String.valueOf(DEFAULT_MAX_POLL_RECORDS));
         }
 
         return props;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -45,7 +45,7 @@ public class PartitionContext {
         this.processors = processors;
         partitionProcessor = new PartitionProcessor(scope, processors);
 
-        int capacity = maxPendingRecords + ConsumerSupplier.MAX_MAX_POLL_RECORDS;
+        int capacity = maxPendingRecords + scope.maxPollRecords();
         commitControl = new OutOfOrderCommitControl(scope.topicPartition(), capacity);
 
         TopicPartition tp = scope.topicPartition();

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionScope.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionScope.java
@@ -30,7 +30,7 @@ public class PartitionScope extends SubscriptionScope {
 
     PartitionScope(SubscriptionScope parent, TopicPartition topicPartition) {
         super(parent.subscriptionId(), parent.topic(), parent.retryConfig(), parent.props(),
-              parent.tracingProvider());
+              parent.tracingProvider(), parent.maxPollRecords());
         this.topicPartition = topicPartition;
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/SubscriptionScope.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/SubscriptionScope.java
@@ -37,6 +37,7 @@ public class SubscriptionScope {
     private final Optional<RetryConfig> retryConfig;
     private final ProcessorProperties props;
     private final TracingProvider tracingProvider;
+    private final int maxPollRecords;
 
     public Optional<String> retryTopic() {
         return retryConfig.map(conf -> conf.retryTopicOrDefault(topic));

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -62,6 +62,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.SubscriptionStateListener.State;
+import com.linecorp.decaton.processor.runtime.internal.ConsumerSupplier;
 import com.linecorp.decaton.processor.runtime.internal.SubscriptionScope;
 import com.linecorp.decaton.processor.tracing.internal.NoopTracingProvider;
 
@@ -102,7 +103,8 @@ public class ProcessorSubscriptionTest {
                 Optional.empty(),
                 ProcessorProperties.builder().set(Property.ofStatic(
                         ProcessorProperties.CONFIG_SHUTDOWN_TIMEOUT_MS, waitForProcessingOnClose)).build(),
-                NoopTracingProvider.INSTANCE);
+                NoopTracingProvider.INSTANCE,
+                ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS);
     }
 
     private static ProcessorSubscription subscription(Consumer<String, byte[]> consumer,

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
@@ -60,7 +60,8 @@ public class DecatonTaskRetryQueueingProcessorTest {
     private static final SubscriptionScope scope = new SubscriptionScope(
             "subscription", "topic",
             Optional.of(RetryConfig.builder().backoff(RETRY_BACKOFF).build()),
-            ProcessorProperties.builder().build(), NoopTracingProvider.INSTANCE);
+            ProcessorProperties.builder().build(), NoopTracingProvider.INSTANCE,
+            ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS);
 
     @Mock
     private ProcessingContext<byte[]> context;

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ExecutionSchedulerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ExecutionSchedulerTest.java
@@ -51,7 +51,8 @@ public class ExecutionSchedulerTest {
             new PartitionScope(
                     new SubscriptionScope("subscription", "topic",
                                           Optional.empty(), ProcessorProperties.builder().build(),
-                                          NoopTracingProvider.INSTANCE),
+                                          NoopTracingProvider.INSTANCE,
+                                          ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
                     new TopicPartition("topic", 0)),
             0);
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextTest.java
@@ -41,7 +41,8 @@ public class PartitionContextTest {
     private final PartitionScope scope = new PartitionScope(
             new SubscriptionScope("subscription", "topic",
                                   Optional.empty(), ProcessorProperties.builder().build(),
-                                  NoopTracingProvider.INSTANCE),
+                                  NoopTracingProvider.INSTANCE,
+                                  ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
             new TopicPartition("topic", 0));
 
     @Mock

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
@@ -76,7 +76,8 @@ public class PartitionContextsTest {
 
     private final PartitionScope scope = new PartitionScope(
             new SubscriptionScope("subscription", "topic",
-                                  Optional.empty(), props, NoopTracingProvider.INSTANCE),
+                                  Optional.empty(), props, NoopTracingProvider.INSTANCE,
+                                  ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
             new TopicPartition("topic", 0));
 
     @Mock

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessorTest.java
@@ -50,7 +50,8 @@ public class PartitionProcessorTest {
                                   Optional.empty(),
                                   ProcessorProperties.builder().set(Property.ofStatic(
                                           ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 4)).build(),
-                                  NoopTracingProvider.INSTANCE),
+                                  NoopTracingProvider.INSTANCE,
+                                  ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
             new TopicPartition("topic", 0));
 
     @Mock

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
@@ -72,7 +72,8 @@ public class ProcessPipelineTest {
                     new SubscriptionScope("subscription", "topic",
                                           Optional.empty(),
                                           ProcessorProperties.builder().build(),
-                                          NoopTracingProvider.INSTANCE),
+                                          NoopTracingProvider.INSTANCE,
+                                          ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
                     new TopicPartition("topic", 0)),
             0);
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
@@ -63,7 +63,8 @@ public class ProcessorUnitTest {
                 new PartitionScope(
                         new SubscriptionScope("subscription", "topic",
                                               Optional.empty(), ProcessorProperties.builder().build(),
-                                              NoopTracingProvider.INSTANCE),
+                                              NoopTracingProvider.INSTANCE,
+                                              ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
                         new TopicPartition("topic", 0)),
                 0);
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorsTest.java
@@ -52,7 +52,8 @@ public class ProcessorsTest {
             new PartitionScope(
                     new SubscriptionScope(SUBSC_ID, topicPartition.topic(),
                                           Optional.empty(), ProcessorProperties.builder().build(),
-                                          NoopTracingProvider.INSTANCE),
+                                          NoopTracingProvider.INSTANCE,
+                                          ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS),
                     topicPartition),
             0);
 


### PR DESCRIPTION
In recent performance tuning experience, I found that the current default max.poll.records cap could be an issue.
As Decaton expects I/O intensive workload, which typically takes long to process a task, often the cost of work in Consumer#poll is negligible so we added hard limit for max.poll.records to size OOOCC easily.

However, in processor that does large batching of tasks, the processing time of a task could be few microseconds and in case `Consumer#poll` becomes an bottleneck. For such case, increasing max.poll.records contributes to better performance by eliminating some works repeated on every call of `Consumer#poll.`


This PR makes it to regard user-supplied max.poll.records in consumer config and discard hard limit, by using user-supplied max.poll.records to compute the size of OOOCC, when it's supplied.


This could be potentially a breaking change, but I would say no because the expected beaviour change has no critical consequence.