### PR TITLE
Upgrade micrometer to 1.6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,7 @@ allprojects {
     ext {
         protobufVersion = "3.3.0"
         kafkaVersion = "2.4.0"
-        prometheusVersion = "0.6.0"
-        micrometerVersion = "1.5.1"
+        micrometerVersion = "1.6.6"
         lombokVersion = "1.18.4"
         junitVersion = "4.13.2"
         hamcrestVersion = "2.2"


### PR DESCRIPTION
**Motivation:** Micrometer 1.7 is out and we shouldn't stay 2 minor versions behind

I refrained from jumping right to 1.7 because
- it's still quite recent
- it introduces a breaking change by requiring prometheus simpleclient 0.10.0, which has a small change in metrics name convention. https://github.com/prometheus/client_java/releases/tag/parent-0.10.0