### PR TITLE
Correct outdated import paths in docs/example project

### DIFF
--- a/docs/example/src/main/java/example/CentralDogmaSupplierMain.java
+++ b/docs/example/src/main/java/example/CentralDogmaSupplierMain.java
@@ -24,8 +24,8 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.decaton.centraldogma.CentralDogmaPropertySupplier;
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 

--- a/docs/example/src/main/java/example/IgnoreKeysMain.java
+++ b/docs/example/src/main/java/example/IgnoreKeysMain.java
@@ -16,7 +16,8 @@
 
 package example;
 
-import static com.linecorp.decaton.processor.ProcessorProperties.CONFIG_IGNORE_KEYS;
+
+import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_IGNORE_KEYS;
 
 import java.util.Arrays;
 import java.util.Properties;
@@ -24,10 +25,10 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
-import com.linecorp.decaton.processor.Property;
-import com.linecorp.decaton.processor.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 

--- a/docs/example/src/main/java/example/JSONUserEventExtractor.java
+++ b/docs/example/src/main/java/example/JSONUserEventExtractor.java
@@ -21,10 +21,10 @@ import java.io.UncheckedIOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.linecorp.decaton.processor.DecatonTask;
-import com.linecorp.decaton.processor.TaskExtractor;
 import com.linecorp.decaton.processor.TaskMetadata;
 
+import com.linecorp.decaton.processor.runtime.DecatonTask;
+import com.linecorp.decaton.processor.runtime.TaskExtractor;
 import example.models.UserEvent;
 
 public class JSONUserEventExtractor implements TaskExtractor<UserEvent> {

--- a/docs/example/src/main/java/example/ProcessingRateMain.java
+++ b/docs/example/src/main/java/example/ProcessingRateMain.java
@@ -16,20 +16,19 @@
 
 package example;
 
-import static com.linecorp.decaton.processor.ProcessorProperties.CONFIG_PROCESSING_RATE;
-
-import java.util.Properties;
+import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_PROCESSING_RATE;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
+import java.util.Properties;
+
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
-import com.linecorp.decaton.processor.Property;
-import com.linecorp.decaton.processor.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
-
 import example.processors.PrintMessageTaskProcessor;
 
 public class ProcessingRateMain {

--- a/docs/example/src/main/java/example/ProcessorMain.java
+++ b/docs/example/src/main/java/example/ProcessorMain.java
@@ -21,8 +21,8 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 

--- a/docs/example/src/main/java/example/ProcessorMain2.java
+++ b/docs/example/src/main/java/example/ProcessorMain2.java
@@ -21,11 +21,11 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorProperties;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
-import com.linecorp.decaton.processor.Property;
-import com.linecorp.decaton.processor.StaticPropertySupplier;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 

--- a/docs/example/src/main/java/example/RetryQueuingMain.java
+++ b/docs/example/src/main/java/example/RetryQueuingMain.java
@@ -22,8 +22,8 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import com.linecorp.decaton.example.protocol.Mytasks.PrintMessageTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.RetryConfig;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;

--- a/docs/example/src/main/java/example/TaskCompactionMain.java
+++ b/docs/example/src/main/java/example/TaskCompactionMain.java
@@ -23,16 +23,16 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.linecorp.decaton.processor.DecatonTask;
-import com.linecorp.decaton.processor.ProcessorsBuilder;
-import com.linecorp.decaton.processor.TaskExtractor;
 import com.linecorp.decaton.processor.TaskMetadata;
-import com.linecorp.decaton.processor.runtime.CompactionProcessor;
-import com.linecorp.decaton.processor.runtime.CompactionProcessor.CompactChoice;
+import com.linecorp.decaton.processor.processors.CompactionProcessor;
+import com.linecorp.decaton.processor.processors.CompactionProcessor.CompactChoice;
+import com.linecorp.decaton.processor.runtime.DecatonTask;
 import com.linecorp.decaton.processor.runtime.ProcessorScope;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 
+import com.linecorp.decaton.processor.runtime.TaskExtractor;
 import example.models.LocationEvent;
 import example.processors.LocationEventProcessor;
 

--- a/docs/example/src/main/java/example/UserEventProcessorMain.java
+++ b/docs/example/src/main/java/example/UserEventProcessorMain.java
@@ -20,8 +20,8 @@ import java.util.Properties;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
-import com.linecorp.decaton.processor.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
 import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
 
 import example.processors.UserEventProcessor;


### PR DESCRIPTION
Should have been done at 2.0 release.