### PR TITLE
Adopt poll(Duration) fixes #118

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
@@ -26,13 +26,35 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
+import com.linecorp.decaton.processor.runtime.SubscriptionBuilder;
+import com.linecorp.decaton.processor.runtime.SubscriptionStateListener;
 import com.linecorp.decaton.processor.runtime.SubscriptionStateListener.State;
+import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
+import com.linecorp.decaton.protocol.Decaton.DecatonTaskRequest;
+import com.linecorp.decaton.protocol.Sample.HelloTask;
 import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.TestUtils;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public class SubscriptionStateTest {
     @ClassRule
@@ -81,5 +103,113 @@ public class SubscriptionStateTest {
                 }
             }
         });
+    }
+
+    @Test(timeout = 30000)
+    public void testStuckProcessRecoverAfterRevoke() throws Exception {
+        Metrics.register(new SimpleMeterRegistry());
+        String topic = rule.admin().createRandomTopic(3, 3);
+
+        CountDownLatch processALatch = new CountDownLatch(1);
+        CountDownLatch processBLatch = new CountDownLatch(1);
+
+        try (Producer<String, DecatonTaskRequest> producer = TestUtils.producer(rule.bootstrapServers());
+             Subscription subA = new Subscription("A", topic, (ctx, task) -> processALatch.await());
+             Subscription subB = new Subscription("B", topic, (ctx, task) -> processBLatch.await());
+             Subscription subC = new Subscription("C", topic, (ctx, task) -> {})) {
+
+            // Starts 2 subscriptions first.
+            // The partition assignment will be subA[0,1], subB[2]
+            CountDownLatch subAStartLatch = new CountDownLatch(1);
+            CountDownLatch subBStartLatch = new CountDownLatch(1);
+            subA.listenerRef.set(state -> { if (state == State.RUNNING) subAStartLatch.countDown(); });
+            subB.listenerRef.set(state -> { if (state == State.RUNNING) subBStartLatch.countDown(); });
+            subA.subscription.start();
+            subB.subscription.start();
+
+            // Produce single task for partition 1 and 2 respectively.
+            // This will cause subA and subB's processing to be stuck, then partitions will be paused.
+            produceTask(producer, topic, 1);
+            produceTask(producer, topic, 2);
+            TestUtils.awaitCondition("Partitions should be paused since process is stuck",
+                                     () -> subA.partitionPaused(1) && subB.partitionPaused(2));
+
+            CountDownLatch rebalanceLatch = new CountDownLatch(1);
+            CountDownLatch runningLatch = new CountDownLatch(1);
+            subA.listenerRef.set(state -> {
+                switch (state) {
+                    case REBALANCING: rebalanceLatch.countDown(); break;
+                    case RUNNING: runningLatch.countDown(); break;
+                    default: break;
+                }
+            });
+
+            // Start one more instance subC
+            // This will cause another rebalance and partition assignment will be subA[0], subB[1], subC[2]
+            subC.subscription.start();
+
+            // Solve subA's processing stuck after waiting rebalance starts.
+            rebalanceLatch.await();
+            processALatch.countDown();
+
+            // Wait subA to transition to RUNNING state
+            runningLatch.await();
+        }
+    }
+
+    private static void produceTask(Producer<String, DecatonTaskRequest> producer, String topic, int partition) {
+        ProducerRecord<String, DecatonTaskRequest> record = new ProducerRecord<>(
+                topic, partition, null,
+                DecatonTaskRequest
+                        .newBuilder()
+                        .setSerializedTask(HelloTask.getDefaultInstance().toByteString())
+                        .build());
+        producer.send(record);
+    }
+
+    private static class Subscription implements AutoCloseable {
+        private final AtomicReference<SubscriptionStateListener> listenerRef = new AtomicReference<>();
+        private final String id;
+        private final String topic;
+        private final ProcessorSubscription subscription;
+
+        private Subscription(String id,
+                             String topic,
+                             DecatonProcessor<HelloTask> processor) {
+            this.id = id;
+            this.topic = topic;
+            listenerRef.set(state -> {});
+
+            Properties props = new Properties();
+            SubscriptionBuilder builder = new SubscriptionBuilder(id);
+            props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, rule.bootstrapServers());
+            props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "test-" + id);
+            props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+            props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+            builder.consumerConfig(props);
+            builder.properties(StaticPropertySupplier.of(
+                    Property.ofStatic(ProcessorProperties.CONFIG_MAX_PENDING_RECORDS, 1)));
+            builder.stateListener(state -> listenerRef.get().onChange(state));
+            builder.processorsBuilder(
+                    ProcessorsBuilder.consuming(topic, new ProtocolBuffersDeserializer<>(HelloTask.parser()))
+                                     .thenProcess(processor));
+            subscription = builder.build();
+        }
+
+        boolean partitionPaused(int partition) {
+            return Optional.ofNullable(
+                    Metrics.registry()
+                           .find("decaton.partition.paused")
+                           .tags("subscription", id,
+                                 "topic", topic,
+                                 "partition", String.valueOf(partition))
+                           .gauge()).map(Gauge::value).orElse(0.0) > 0;
+        }
+
+        @Override
+        public void close() throws Exception {
+            subscription.close();
+        }
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManager.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -38,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ConsumeManager implements AutoCloseable {
-    private static final long POLL_TIMEOUT_MILLIS = 100;
+    private static final Duration POLL_TIMEOUT = Duration.ofMillis(100L);
 
     /**
      * Interface to class storing partition's consumption state information.
@@ -151,7 +152,7 @@ public class ConsumeManager implements AutoCloseable {
     }
 
     /**
-     * Run a single {@link Consumer#poll(long)} to obtain records from subscribing topics.
+     * Run a single {@link Consumer#poll(Duration)} to obtain records from subscribing topics.
      * For each consumed record, {@link ConsumerHandler#receive(ConsumerRecord)} called.
      * After finish processing consumed records, {@link PartitionStates#updatePartitionsStatus()} called.
      * According to the values from {@link PartitionStates#partitionsNeedsPause()} and
@@ -162,7 +163,7 @@ public class ConsumeManager implements AutoCloseable {
      */
     public void poll() {
         Timer timer = Utils.timer();
-        ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT_MILLIS);
+        ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
         metrics.consumerPollTime.record(timer.duration());
 
         timer = Utils.timer();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -21,7 +21,9 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
@@ -164,7 +166,7 @@ public class ProcessorSubscriptionTest {
         doAnswer(invocation -> {
             listener.set(invocation.getArgument(1));
             return null;
-        }).when(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        }).when(consumer).subscribe(anyCollection(), any(ConsumerRebalanceListener.class));
 
         BlockingQueue<Long> feedOffsets = new ArrayBlockingQueue<>(4);
         feedOffsets.add(100L);
@@ -183,8 +185,8 @@ public class ProcessorSubscriptionTest {
             committedOffsets.putAll(invocation.getArgument(0));
             return null;
         };
-        doAnswer(storeCommitOffsets).when(consumer).commitSync(any(Map.class));
-        doAnswer(storeCommitOffsets).when(consumer).commitAsync(any(Map.class), any());
+        doAnswer(storeCommitOffsets).when(consumer).commitSync(anyMap());
+        doAnswer(storeCommitOffsets).when(consumer).commitAsync(anyMap(), any());
 
         AtomicBoolean first = new AtomicBoolean();
         doAnswer(invocation -> {
@@ -201,7 +203,7 @@ public class ProcessorSubscriptionTest {
                 Thread.sleep(invocation.getArgument(0));
                 return ConsumerRecords.empty();
             }
-        }).when(consumer).poll(anyLong());
+        }).when(consumer).poll(any());
 
         subscription.start();
         processLatch.await();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -86,7 +87,7 @@ public class ConsumeManagerTest {
         doAnswer(invocation -> {
             rebalanceListener = invocation.getArgument(1);
             return null;
-        }).when(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        }).when(consumer).subscribe(anyCollection(), any(ConsumerRebalanceListener.class));
         consumeManager.init(singletonList(TOPIC));
     }
 
@@ -106,7 +107,7 @@ public class ConsumeManagerTest {
                 new ConsumerRecord<>(TOPIC, 1, 102, "key", new byte[0]));
         ConsumerRecords<String, byte[]> consumerRecords =
                 new ConsumerRecords<>(Collections.singletonMap(new TopicPartition(TOPIC, 1), records));
-        doReturn(consumerRecords).when(consumer).poll(anyLong());
+        doReturn(consumerRecords).when(consumer).poll(any());
 
         List<TopicPartition> partitionsNeedsPause = new ArrayList<>(Arrays.asList(tp(1)));
         List<TopicPartition> partitionsNeedsResume = new ArrayList<>(Arrays.asList(tp(2)));
@@ -150,7 +151,7 @@ public class ConsumeManagerTest {
             rebalanceListener.onPartitionsRevoked(singletonList(tp(2)));
             rebalanceListener.onPartitionsAssigned(Arrays.asList(tp(1), tp(3)));
             return ConsumerRecords.empty();
-        }).when(consumer).poll(anyLong());
+        }).when(consumer).poll(any());
 
         Set<TopicPartition> pausedPartitions = new HashSet<>();
         doAnswer(invocation -> {


### PR DESCRIPTION
## Summary
- Currently, Decaton uses `KafkaConsumer#poll(long)` which is deprecated and could be removed in future Kafka release