### PR TITLE
Use a single CentralDogma watcher per file

### DIFF
--- a/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
+++ b/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
@@ -16,11 +16,8 @@
 
 package com.linecorp.decaton.centraldogma;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -48,7 +45,7 @@ import com.linecorp.decaton.processor.runtime.PropertySupplier;
 /**
  * A {@link PropertySupplier} implementation with Central Dogma backend.
  *
- * This implementation maps property's {@link PropertyDefinition#name} as the absolute field name in the file
+ * This implementation maps property's {@link PropertyDefinition#name()} as the absolute field name in the file
  * on Central Dogma.
  *
  * An example JSON format would be look like:
@@ -69,16 +66,9 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
     private static final long INITIAL_VALUE_TIMEOUT_SECS = 30;
     private static final long PROPERTY_CREATION_TIMEOUT_MILLIS = 10000;
 
-    private final CentralDogma centralDogma;
-    private final String projectName;
-    private final String repositoryName;
-    private final String fileName;
-    private final List<Watcher<?>> watchers;
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    // FIXME: after CentralDogma supports API to query field's existence, those fields will no longer necessary.
-    private volatile Set<String> configuredKeys;
+    private final Watcher<JsonNode> rootWatcher;
 
     /**
      * Creates a new {@link CentralDogmaPropertySupplier}.
@@ -89,23 +79,7 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
      */
     public CentralDogmaPropertySupplier(CentralDogma centralDogma, String projectName,
                                         String repositoryName, String fileName) {
-        this.centralDogma = centralDogma;
-        this.projectName = projectName;
-        this.repositoryName = repositoryName;
-        this.fileName = fileName;
-        watchers = new ArrayList<>();
-
-        setupWatcherForConfiguredKeys();
-    }
-
-    // FIXME: dumb workaround to check field's existence, until CD client supports API for querying it.
-    @SuppressWarnings("unchecked")
-    private void setupWatcherForConfiguredKeys() {
-        Watcher<Map> rootWatcher = centralDogma.fileWatcher(
-                projectName, repositoryName, Query.ofJsonPath(fileName, "$"),
-                node -> objectMapper.convertValue(node, Map.class));
-        watchers.add(rootWatcher);
-        rootWatcher.watch(rootObject -> configuredKeys = (Set<String>) rootObject.keySet());
+        rootWatcher = centralDogma.fileWatcher(projectName, repositoryName, Query.ofJsonPath(fileName));
         try {
             rootWatcher.awaitInitialValue(INITIAL_VALUE_TIMEOUT_SECS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -129,18 +103,13 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
 
     @Override
     public <T> Optional<Property<T>> getProperty(PropertyDefinition<T> definition) {
-        // FIXME: dumb workaround to check field's existence, until CD client supports API for querying it.
-        if (!configuredKeys.contains(definition.name())) {
+        if (!rootWatcher.latestValue().has(definition.name())) {
             return Optional.empty();
         }
 
-        Watcher<JsonNode> watcher = centralDogma.fileWatcher(
-                projectName, repositoryName,
-                Query.ofJsonPath(fileName, String.format("$.['%s']", definition.name())));
-        watchers.add(watcher);
-
         DynamicProperty<T> prop = new DynamicProperty<>(definition);
-        watcher.watch(node -> {
+        Watcher<JsonNode> child = rootWatcher.newChild(jsonNode -> jsonNode.path(definition.name()));
+        child.watch(node -> {
             try {
                 setValue(prop, node);
             } catch (RuntimeException e) {
@@ -148,22 +117,18 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
             }
         });
         try {
-            watcher.awaitInitialValue(INITIAL_VALUE_TIMEOUT_SECS, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
+            JsonNode node = child.initialValueFuture().join().value(); //doesn't fail since it's a child watcher
+            setValue(prop, node);
+        }  catch (RuntimeException e) {
+            logger.warn("Failed to set initial value from CentralDogma for {}", definition.name(), e);
         }
 
         return Optional.of(prop);
     }
 
     @Override
-    public void close() throws Exception {
-        for (Watcher<?> watcher : watchers) {
-            watcher.close();
-        }
+    public void close() {
+        rootWatcher.close();
     }
 
     /**

--- a/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
+++ b/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
@@ -51,12 +51,12 @@ import com.linecorp.decaton.processor.runtime.PropertySupplier;
  * An example JSON format would be look like:
  * {@code
  * {
- *     "partition.threads": 10,
- *     "ignore.keys": [
+ *     "decaton.partition.concurrency": 10,
+ *     "decaton.ignore.keys": [
  *       "123456",
  *       "79797979"
  *     ],
- *     "partition.processing.rate": 50
+ *     "decaton.processing.rate.per.partition": 50
  * }
  * }
  */

--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.centraldogma;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.PropertyDefinition;
+
+public class CentralDogmaPropertySupplierIntegrationTest {
+
+    @Rule
+    public CentralDogmaRule centralDogmaRule = new CentralDogmaRule();
+
+    private static final String PROJECT_NAME = "unit-test";
+    private static final String REPOSITORY_NAME = "repo";
+    private static final String FILENAME = "/subscription.json";
+
+    private static final PropertyDefinition<Long> LONG_PROPERTY =
+            PropertyDefinition.define("num.property", Long.class, 0L,
+                                      v -> v instanceof Long && (Long) v >= 0L);
+
+    @Test(timeout = 50000)
+    public void testCDIntegration() throws InterruptedException {
+        CentralDogma client = centralDogmaRule.client();
+
+        final String ORIGINAL =
+                "{\n"
+                + "  \"num.property\": 10,\n"
+                + "  \"ignore.keys\": [\n"
+                + "    \"123456\",\n"
+                + "    \"79797979\"\n"
+                + "  ],\n"
+                + "  \"partition.processing.rate\": 50\n"
+                + "}\n";
+
+        client.createProject(PROJECT_NAME).join();
+        client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+        client.push(PROJECT_NAME, REPOSITORY_NAME, Revision.HEAD, "summary",
+                    Change.ofJsonUpsert(FILENAME, ORIGINAL)).join();
+
+        CentralDogmaPropertySupplier supplier = new CentralDogmaPropertySupplier(
+                client, PROJECT_NAME, REPOSITORY_NAME, FILENAME);
+
+        Property<Long> prop = supplier.getProperty(LONG_PROPERTY).get();
+
+        assertEquals(10L, prop.value().longValue());
+
+        final String UPDATED =
+                "{\n"
+                + "  \"num.property\": 20,\n"
+                + "  \"ignore.keys\": [\n"
+                + "    \"123456\",\n"
+                + "    \"79797979\"\n"
+                + "  ],\n"
+                + "  \"partition.processing.rate\": 50\n"
+                + "}\n";
+
+        CountDownLatch latch = new CountDownLatch(2);
+        prop.listen((o, n) -> latch.countDown());
+
+        client.push(PROJECT_NAME, REPOSITORY_NAME, Revision.HEAD, "summary",
+                    Change.ofJsonPatch(FILENAME, ORIGINAL, UPDATED)).join();
+
+        latch.await();
+        assertEquals(20L, prop.value().longValue());
+    }
+
+    @Test
+    public void testFileExist() {
+        CentralDogma client = centralDogmaRule.client();
+        client.createProject(PROJECT_NAME).join();
+        client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+        client.push(PROJECT_NAME, REPOSITORY_NAME, Revision.HEAD, "test",
+                    Change.ofJsonUpsert(FILENAME, "{}")).join();
+        assertTrue(CentralDogmaPropertySupplier
+                           .fileExists(client, PROJECT_NAME, REPOSITORY_NAME, FILENAME, Revision.HEAD));
+    }
+
+    @Test
+    public void testFileNonExistent() {
+        CentralDogma client = centralDogmaRule.client();
+        client.createProject(PROJECT_NAME).join();
+        client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+        assertFalse(CentralDogmaPropertySupplier
+                            .fileExists(client, PROJECT_NAME, REPOSITORY_NAME, FILENAME, Revision.HEAD));
+    }
+
+    @Test(timeout = 10000)
+    public void testCDRegisterSuccess() {
+        CentralDogma client = centralDogmaRule.client();
+        client.createProject(PROJECT_NAME).join();
+        client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+
+        CentralDogmaPropertySupplier.register(client, PROJECT_NAME, REPOSITORY_NAME, FILENAME);
+        Entry<JsonNode> prop = client.getFile(PROJECT_NAME, REPOSITORY_NAME,
+                                              Revision.HEAD, Query.ofJson(FILENAME)).join();
+
+        assertEquals(CentralDogmaPropertySupplier.defaultProperties().asText(),
+                     prop.content().asText());
+    }
+
+    @Test(timeout = 10000, expected = RuntimeException.class)
+    public void testCDRegisterNonExistentProject() {
+        CentralDogmaPropertySupplier.register(centralDogmaRule.client(),
+                                              "non-existent-project", REPOSITORY_NAME, FILENAME);
+    }
+
+    @Test(timeout = 15000, expected = RuntimeException.class)
+    public void testCDRegisterTimeout() {
+        CentralDogma client = spy(centralDogmaRule.client());
+        client.createProject(PROJECT_NAME).join();
+        client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+
+        doReturn(CompletableFuture.completedFuture(new Revision(1)))
+                .when(client)
+                .normalizeRevision(eq(PROJECT_NAME), eq(REPOSITORY_NAME), any());
+
+        CentralDogmaPropertySupplier.register(client, PROJECT_NAME, REPOSITORY_NAME, FILENAME);
+
+        CentralDogmaPropertySupplier.register(client, PROJECT_NAME, REPOSITORY_NAME, FILENAME);
+    }
+
+    @Test(timeout = 15000)
+    public void testCDRegisterConflict() throws Exception {
+        CountDownLatch userAIsRunning = new CountDownLatch(1);
+        CountDownLatch userBIsRunning = new CountDownLatch(1);
+
+        CentralDogma userA = spy(centralDogmaRule.client());
+        CentralDogma userB = centralDogmaRule.client();
+        JsonNode userBPush = Jackson.readTree("{\"foo\": \"bar\"}");
+
+        userA.createProject(PROJECT_NAME).join();
+        userA.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
+
+        doAnswer(i -> {
+            userAIsRunning.countDown();
+            userBIsRunning.await();
+            return i.callRealMethod();
+        }).when(userA)
+          .push(eq(PROJECT_NAME), eq(REPOSITORY_NAME), any(), any(),
+                eq(Change.ofJsonUpsert(FILENAME, CentralDogmaPropertySupplier.defaultProperties())));
+
+        ExecutorService service = Executors.newFixedThreadPool(2);
+        service.submit(() -> CentralDogmaPropertySupplier
+                .register(userA, PROJECT_NAME, REPOSITORY_NAME, FILENAME));
+        service.submit(() -> {
+            try {
+                userAIsRunning.await();
+                userB.push(PROJECT_NAME, REPOSITORY_NAME, Revision.HEAD, "test",
+                           Change.ofJsonUpsert(FILENAME, userBPush)).join();
+                userBIsRunning.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+        service.shutdown();
+        service.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+
+        Entry<JsonNode> prop = userA.getFile(PROJECT_NAME, REPOSITORY_NAME,
+                                             Revision.HEAD, Query.ofJson(FILENAME)).join();
+
+        assertEquals(userBPush, prop.content());
+    }
+}


### PR DESCRIPTION
Fixes the following issues

## Race condition in initialization (rare)

```
java.lang.NullPointerException: null
	at com.linecorp.decaton.centraldogma.CentralDogmaPropertySupplier.getProperty(CentralDogmaPropertySupplier.java:133)
	at com.linecorp.decaton.processor.runtime.internal.AbstractDecatonProperties$Builder.setBySupplier(AbstractDecatonProperties.java:55)
	at com.linecorp.decaton.processor.runtime.SubscriptionBuilder.properties(SubscriptionBuilder.java:103)
```

It happens because CD watchers don't notify synchronously and instead add a task to `watchScheduler`. So awaiting initial value does not guarantee that all watchers have been run. 

## Watchers multiplication

Each watcher polls CD, so with many processors / dynamic properties that's a lot of unnecessary load.
Note that child watchers do not react when a part of the file they are not watching is updated. https://github.com/line/centraldogma/blob/master/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java#L92