### PR TITLE
Use toBuilder = true on config classes

### DIFF
--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/BenchmarkConfig.java
@@ -26,7 +26,7 @@ import lombok.experimental.Accessors;
 
 @Value
 @Accessors(fluent = true)
-@Builder
+@Builder(toBuilder = true)
 public class BenchmarkConfig {
     /**
      * Title of this benchmark.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/RetryConfig.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/RetryConfig.java
@@ -31,7 +31,7 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 @Accessors(fluent = true)
 public class RetryConfig {
     public static final String DEFAULT_RETRY_TOPIC_SUFFIX = "-retry";


### PR DESCRIPTION
Small change to make it easer to reuse configs while changing some properties. (Specifically, this is useful for the case where we want to populate a `RetryConfig` automatically from Spring properties, but then set some fields programmatically)