### PR TITLE
Add tests for deferred completion

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/CoreFunctionalityTest.java
@@ -101,7 +101,7 @@ public class CoreFunctionalityTest {
         ProcessorTestSuite
                 .builder(rule)
                 .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
-                    DeferredCompletion completion = ctx.deferCompletion();
+                    ctx.deferCompletion();
                     executorService.execute(() -> {
                         try {
                             Thread.sleep(rand.nextInt(10));
@@ -109,7 +109,7 @@ public class CoreFunctionalityTest {
                             Thread.currentThread().interrupt();
                             throw new RuntimeException(e);
                         } finally {
-                            completion.complete();
+                            ctx.deferCompletion().complete();
                         }
                     });
                 }))

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducerAdaptor.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducerAdaptor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.testing.processor;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+
+abstract class ProducerAdaptor<K, V> implements Producer<K, V> {
+    protected final Producer<K, V> delegate;
+    protected ProducerAdaptor(Producer<K, V> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void initTransactions() {
+        delegate.initTransactions();
+    }
+
+    @Override
+    public void beginTransaction() throws ProducerFencedException {
+        delegate.beginTransaction();
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId)
+            throws ProducerFencedException {
+        delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+    }
+
+    @Override
+    public void commitTransaction() throws ProducerFencedException {
+        delegate.commitTransaction();
+    }
+
+    @Override
+    public void abortTransaction() throws ProducerFencedException {
+        delegate.abortTransaction();
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+        return delegate.send(record);
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+        return delegate.send(record, callback);
+    }
+
+    @Override
+    public void flush() {
+        delegate.flush();
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic) {
+        return delegate.partitionsFor(topic);
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
+        return delegate.metrics();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public void close(Duration timeout) {
+        delegate.close(timeout);
+    }
+}


### PR DESCRIPTION
## Motivation

- In https://github.com/line/decaton/pull/99, we made some spec change about `ProcessingContext#deferCompletion()` that:
  * It requires to re-use `Completion` instance returned from `deferCompletion()` if we want to refer it later, otherwise completion will be leaked
  * However we realized that this change could cause a lot of migration cost for Decaton <= 2.x users
      - Decaton doc's example code was also outdated
  * So we concluded to make keep existing deferCompletion-usage to work by adding fix (https://github.com/line/decaton/pull/124)
  * => We should add integration test cases to ensure it works
- Besides, I fixed `ProcessorTestSuite` to await retried-produced tasks to be committed
