### PR TITLE
Bump dependencies : micrometer, centraldgoma, brave..

### DIFF
--- a/brave/build.gradle
+++ b/brave/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(":processor")
 
-    compile "io.zipkin.brave:brave-instrumentation-kafka-clients:5.12.6"
+    compile "io.zipkin.brave:brave-instrumentation-kafka-clients:5.13.3"
 
     itCompile "junit:junit:$junitVersion"
     itCompile project(":testing")

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ allprojects {
     ext {
         protobufVersion = "3.3.0"
         kafkaVersion = "2.4.0"
-        micrometerVersion = "1.6.6"
-        lombokVersion = "1.18.4"
+        micrometerVersion = "1.7.5"
+        lombokVersion = "1.18.22"
         junitVersion = "4.13.2"
         hamcrestVersion = "2.2"
 
@@ -64,8 +64,8 @@ subprojects {
 
         // Likely be used for most modules
         testImplementation "junit:junit:$junitVersion"
-        testImplementation "org.mockito:mockito-core:3.7.7"
-        testImplementation "org.mockito:mockito-inline:3.7.7"
+        testImplementation "org.mockito:mockito-core:3.9.0"
+        testImplementation "org.mockito:mockito-inline:3.9.0"
     }
 
     configurations {

--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -3,7 +3,7 @@ repositories {
 }
 
 ext {
-    centralDogmaVersion = "0.49.1"
+    centralDogmaVersion = "0.52.5"
     jacksonVersion = "2.12.5"
 }
 

--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -4,7 +4,7 @@ repositories {
 
 ext {
     centralDogmaVersion = "0.49.1"
-    jacksonVersion = "2.12.3"
+    jacksonVersion = "2.12.5"
 }
 
 dependencies {

--- a/docs/example/build.gradle
+++ b/docs/example/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 ext {
     DECATON_VERSION = getProperty("version") + (getProperty("snapshot").toBoolean() ? "-SNAPSHOT" : "")
     PROTOBUF_VERSION = "3.3.0"
-    CENTRALDOGMA_VERSION = "0.49.1"
+    CENTRALDOGMA_VERSION = "0.52.5"
 }
 
 repositories {

--- a/docs/example/build.gradle
+++ b/docs/example/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
     }
 }

--- a/docs/example/build.gradle
+++ b/docs/example/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "com.linecorp.decaton:decaton-processor:$DECATON_VERSION"
 
     // for "Consuming Arbitrary Topic" section
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
 
     //  for "Property Supplier" section
     implementation "com.linecorp.decaton:decaton-centraldogma:$DECATON_VERSION"

--- a/processor/README.md
+++ b/processor/README.md
@@ -9,7 +9,7 @@ A Decaton module containing core classes for processor.
 To maintain good performance for core implementations that impacts processor performance significantly, some micro benchmarks are maintained.
 See [jmh-gradle-plugin](https://github.com/melix/jmh-gradle-plugin) for added build targets.
 
-To run benchmark, it's highly recommended to run without Gradle daemon to get consistent result (saw it runs with old impl/settings several times).
+To run benchmark, it's highly recommended running without Gradle daemon to get consistent result (saw it runs with old impl/settings several times).
 
 ```sh
 ./gradlew --no-daemon clean processor:jmh

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2"
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.5.3"
     }
 }
 

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile "io.micrometer:micrometer-core:$micrometerVersion"
 
     testCompile project(":protobuf")
-    testRuntimeOnly "ch.qos.logback:logback-classic:1.2.3"
+    testRuntimeOnly "ch.qos.logback:logback-classic:1.2.6"
 
     testFixturesCompile "junit:junit:$junitVersion"
     testFixturesCompileOnly "org.projectlombok:lombok:$lombokVersion"

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
     }
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -33,5 +33,5 @@ dependencies {
     implementation "junit:junit:$junitVersion"
     implementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
-    runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
+    runtimeOnly "ch.qos.logback:logback-classic:1.2.6"
 }


### PR DESCRIPTION
## Motivation

Match dependencies set with the recently upgraded spring-boot version and generally keep the build up-to-date

## Transitive changes
- Micrometer 1.6.6 -> 1.7.5
    - Breaking changes (https://github.com/micrometer-metrics/micrometer/releases/tag/v1.7.0) : support for prometheus-simpleclient < 0.10 is dropped.
    - See other release notes for minor changes
- Brave 5.12.6 -> 5.13.3 ( bitter release notes: https://github.com/openzipkin/brave/releases/tag/5.13.2 )
- Centraldogma 0.49 -> 0.52 ( nothing major for our use case : https://github.com/line/centraldogma/releases )