### PR TITLE
Add batching processor

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
@@ -64,32 +64,4 @@ public class BatchingProcessorTest {
             .build()
             .run();
     }
-
-    // TODO: Fix test or test's target. This test does not succeed.
-//    @Test(timeout = 30000)
-//    public void testBatchingProcessor_capacity() throws Exception {
-//        Random rand = randomRule.random();
-//        ProcessorTestSuite
-//            .builder(rule)
-//            .configureProcessorsBuilder(builder -> builder.thenProcess(
-//                new BatchingProcessor<TestTask>(Long.MAX_VALUE, 100) {
-//                    @Override
-//                    protected void processBatchingTasks(List<BatchingTask<TestTask>> batchingTasks) {
-//                        // adding some random delay to simulate realistic usage
-//                        try {
-//                            Thread.sleep(rand.nextInt(10));
-//                        } catch (InterruptedException e) {
-//                            Thread.currentThread().interrupt();
-//                            throw new RuntimeException(e);
-//                        }
-//                        batchingTasks.forEach(batchingTask -> batchingTask.completion().complete());
-//                    }
-//                }
-//            ))
-//            .propertySupplier(StaticPropertySupplier.of(
-//                Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
-//            ))
-//            .build()
-//            .run();
-//    }
 }

--- a/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
@@ -39,12 +39,12 @@ public class BatchingProcessorTest {
     public RandomRule randomRule = new RandomRule();
 
     @Test(timeout = 30000)
-    public void testBatchingProcessor_lingerMillis() throws Exception {
+    public void testBatchingProcessor() throws Exception {
         Random rand = randomRule.random();
         ProcessorTestSuite
             .builder(rule)
             .configureProcessorsBuilder(builder -> builder.thenProcess(
-                new BatchingProcessor<TestTask>(1000, Integer.MAX_VALUE) {
+                new BatchingProcessor<TestTask>(1000, 100) {
                     @Override
                     protected void processBatchingTasks(List<BatchingTask<TestTask>> batchingTasks) {
                         // adding some random delay to simulate realistic usage

--- a/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import java.util.List;
+import java.util.Random;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.decaton.processor.processors.BatchingProcessor;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.Property;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.RandomRule;
+import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
+import com.linecorp.decaton.testing.processor.TestTask;
+
+public class BatchingProcessorTest {
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+    @Rule
+    public RandomRule randomRule = new RandomRule();
+
+    @Test(timeout = 30000)
+    public void testBatchingProcessor_lingerMillis() {
+        Random rand = randomRule.random();
+        ProcessorTestSuite
+            .builder(rule)
+            .configureProcessorsBuilder(builder -> builder.thenProcess(
+                new BatchingProcessor<TestTask>(1000, Integer.MAX_VALUE) {
+                    @Override
+                    protected void processBatchingTasks(List<BatchingTask<TestTask>> batchingTasks) {
+                        // adding some random delay to simulate realistic usage
+                        try {
+                            Thread.sleep(rand.nextInt(10));
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(e);
+                        }
+                        batchingTasks.forEach(batchingTask -> batchingTask.completion().complete());
+                    }
+                }
+            ))
+            .propertySupplier(StaticPropertySupplier.of(
+                Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
+            ))
+            .build()
+            .run();
+    }
+
+    // TODO: Fix test or test's target. This test does not succeed.
+//    @Test(timeout = 30000)
+//    public void testBatchingProcessor_capacity() {
+//        Random rand = randomRule.random();
+//        ProcessorTestSuite
+//            .builder(rule)
+//            .configureProcessorsBuilder(builder -> builder.thenProcess(
+//                new BatchingProcessor<TestTask>(Long.MAX_VALUE, 100) {
+//                    @Override
+//                    protected void processBatchingTasks(List<BatchingTask<TestTask>> batchingTasks) {
+//                        // adding some random delay to simulate realistic usage
+//                        try {
+//                            Thread.sleep(rand.nextInt(10));
+//                        } catch (InterruptedException e) {
+//                            Thread.currentThread().interrupt();
+//                            throw new RuntimeException(e);
+//                        }
+//                        batchingTasks.forEach(batchingTask -> batchingTask.completion().complete());
+//                    }
+//                }
+//            ))
+//            .propertySupplier(StaticPropertySupplier.of(
+//                Property.ofStatic(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY, 16)
+//            ))
+//            .build()
+//            .run();
+//    }
+}

--- a/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/BatchingProcessorTest.java
@@ -39,7 +39,7 @@ public class BatchingProcessorTest {
     public RandomRule randomRule = new RandomRule();
 
     @Test(timeout = 30000)
-    public void testBatchingProcessor_lingerMillis() {
+    public void testBatchingProcessor_lingerMillis() throws Exception {
         Random rand = randomRule.random();
         ProcessorTestSuite
             .builder(rule)
@@ -67,7 +67,7 @@ public class BatchingProcessorTest {
 
     // TODO: Fix test or test's target. This test does not succeed.
 //    @Test(timeout = 30000)
-//    public void testBatchingProcessor_capacity() {
+//    public void testBatchingProcessor_capacity() throws Exception {
 //        Random rand = randomRule.random();
 //        ProcessorTestSuite
 //            .builder(rule)

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -68,7 +68,7 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
      * @param capacity size limit for this processor. Every time tasks’size reaches capacity,
      * tasks in past before reaching capacity are pushed to {@link BatchingTask#processBatchingTasks(List)}.
      */
-    public BatchingProcessor(long lingerMillis, int capacity) {
+    protected BatchingProcessor(long lingerMillis, int capacity) {
         this.lingerMillis = lingerMillis;
         this.capacity = capacity;
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -27,6 +27,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.Completion;
+import com.linecorp.decaton.processor.runtime.internal.Utils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -66,12 +67,12 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
         this.lingerMillis = lingerMillis;
         this.capacity = capacity;
 
-        ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1, r -> {
-            Thread th = new Thread(r);
-            th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
-                       + '/' + System.identityHashCode(this));
-            return th;
-        });
+        ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(
+            1,
+            Utils.namedThreadFactory(
+                "Decaton" + BatchingProcessor.class.getSimpleName() + '/' + System.identityHashCode(this)
+            )
+        );
 
         // For faster shutdown cancel all pending flush on executor shutdown.
         // In fact for this purpose we have two options here:

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.processors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.ProcessingContext;
+
+import lombok.ToString;
+
+public class BatchingProcessor<T> implements DecatonProcessor<T> {
+    private static final Logger logger = LoggerFactory.getLogger(CompactionProcessor.class);
+
+    BiConsumer<String, List<BufferedTask<T>>> processor;
+    long lingerMillis;
+    int capacity;
+    long maxRetryCount;
+
+    private final ConcurrentMap<String, BufferedTaskGroup> windowedTasks = new ConcurrentHashMap<>(64, 0.75f,
+                                                                                                   2);
+    final ScheduledExecutorService scheduler = initScheduler();
+
+    protected ScheduledExecutorService initScheduler() {
+        return new ScheduledThreadPoolExecutor(1, r -> {
+            Thread th = new Thread(r);
+            th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
+                       + "-Flusher/" + System.identityHashCode(this));
+            return th;
+        });
+    }
+
+    @ToString
+    static class BufferedTask<T> {
+        final T task;
+        final ProcessingContext<T> context;
+
+        BufferedTask(T task, ProcessingContext<T> context) {
+            this.task = task;
+            this.context = context;
+            context.deferCompletion();
+        }
+    }
+
+    class BufferedTaskGroup {
+        private final String key;
+        private final int capacity;
+        private final List<BufferedTask<T>> bufferedTasks = new ArrayList<>();
+        private final Future<?> scheduledFlush;
+        private final AtomicBoolean flushed = new AtomicBoolean();
+
+        // Run in Processor thread for this partition
+        BufferedTaskGroup(String key, int capacity) {
+            this.key = key;
+            this.capacity = capacity;
+            scheduledFlush = scheduleFlush();
+        }
+
+        // Run from Processor thread for this partition
+
+        /**
+         * Will reject new tasks is flush has already happened or is ongoing.
+         * @return whether the task was actually added.
+         */
+        boolean addBufferedTask(ProcessingContext<T> context, T task) {
+            if (!context.key().equals(key)) {
+                throw new RuntimeException("");
+            }
+            synchronized (bufferedTasks) {
+                if (isFull() || flushed.get()) {
+                    return false;
+                }
+                bufferedTasks.add(new BufferedTask<>(task, context));
+            }
+            return true;
+        }
+
+        private boolean isFull() {
+            return bufferedTasks.size() >= capacity;
+        }
+
+        private Future<?> scheduleFlush() {
+            Runnable flushTask = () -> {
+                try {
+                    flush();
+                } catch (InterruptedException e) {
+                    logger.error("interrupted while flushing task group {}", this, e);
+                    Thread.currentThread().interrupt();
+                }
+            };
+            return scheduler.schedule(flushTask, lingerMillis, TimeUnit.MILLISECONDS);
+        }
+
+        void flush() throws InterruptedException {
+            BufferedTaskGroup expected;
+            synchronized (bufferedTasks) {
+                if (flushed.getAndSet(true)) {
+                    logger.info("Already flushed: {}", this);
+                    return;
+                }
+                logger.debug("Flushing task group: {}", this);
+                expected = windowedTasks.remove(key);
+
+                if (!bufferedTasks.isEmpty()) {
+                    process();
+                }
+            }
+
+            // Prevent concurrent update from missing tasks.
+            // Since there is no synchronization on `windowedTasks`
+            // then during scheduled flush another task can be inserted instead
+            if (expected != null && expected != this && !expected.flushed.get()) {
+                synchronized (expected.bufferedTasks) {
+                    if (!expected.flushed.getAndSet(true) && !expected.bufferedTasks.isEmpty()) {
+                        logger.warn("Flushing other task group: {}", expected);
+                        expected.process();
+                    }
+                }
+            }
+        }
+
+        // Run in Processor thread for this partition
+        void flushNow() throws InterruptedException {
+            if (!scheduledFlush.isDone()) {
+                boolean cancelled = scheduledFlush.cancel(false);
+                logger.debug("{} previously scheduled flush for user {}", key,
+                             cancelled ? "Cancelled" : "Already cancelled");
+                flush();
+            }
+        }
+
+        private void process() throws InterruptedException {
+            try {
+                processor.accept(key, bufferedTasks);
+            } catch (RuntimeException e) {
+                // Only retryable tasks are retried.
+                for (BufferedTask<T> t : bufferedTasks) {
+                    handleTaskFailure(e, t.context, t.task);
+                }
+            } finally {
+                // complete successful and abandoned tasks
+                // for retried tasks, this does nothing (deferredCompletion is already complete)
+                bufferedTasks.forEach(t -> t.context.deferCompletion().complete());
+            }
+        }
+
+        private void handleTaskFailure(RuntimeException e, ProcessingContext<T> context, T task)
+            throws InterruptedException {
+            long currentRetryCount = context.metadata().retryCount();
+            if (maxRetryCount > currentRetryCount) {
+                logger.warn("Failed to process task<{}>, retrying ({}/{})",
+                            task, currentRetryCount, maxRetryCount, e);
+                context.retry();
+            } else {
+                logger.error("Failed to process task<{}>, retries exhausted ({})",
+                             task, currentRetryCount, e);
+            }
+        }
+
+    }
+
+    BatchingProcessor(
+        BiConsumer<String, List<BufferedTask<T>>> processor,
+        long lingerMillis,
+        int capacity
+    ) {
+        this.lingerMillis = lingerMillis;
+        this.capacity = capacity;
+        this.processor = processor;
+    }
+
+    @Override
+    public void process(ProcessingContext<T> context, T task) throws InterruptedException {
+        String key = context.key();
+        BufferedTaskGroup taskGroup = windowedTasks.get(key);
+        if (taskGroup != null) {
+            if (taskGroup.addBufferedTask(context, task)) {
+                logger.debug("Joined existing task group {}", taskGroup);
+                return;
+            }
+        }
+        if (taskGroup == null) {
+            logger.debug("Creating new task group for key {}", key);
+        } else {
+            logger.debug("Cannot reuse task group {}", taskGroup);
+            taskGroup.flushNow(); // removes `taskGroup` from `windowedTasks`
+        }
+        while (true) {
+            BufferedTaskGroup freshTaskGroup = new BufferedTaskGroup(key, capacity);
+            if (freshTaskGroup.addBufferedTask(context, task)) {
+                BufferedTaskGroup replacedTaskGroup = windowedTasks.put(key, freshTaskGroup);
+                if (replacedTaskGroup != null) {
+                    logger.warn("Previous taskGroup should have been removed already, was: {}",
+                                replacedTaskGroup);
+                    replacedTaskGroup.flushNow();
+                }
+                break;
+            }
+            logger.warn("Could not add task to a fresh buffer for key {}", key);
+        }
+    }
+
+    @Override
+    public String name() {
+        return DecatonProcessor.super.name();
+    }
+
+    @Override
+    public void close() throws Exception {
+        DecatonProcessor.super.close();
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -17,221 +17,121 @@
 package com.linecorp.decaton.processor.processors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
+import com.linecorp.decaton.processor.Completion;
 
-import lombok.ToString;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
-public class BatchingProcessor<T> implements DecatonProcessor<T> {
-    private static final Logger logger = LoggerFactory.getLogger(CompactionProcessor.class);
+abstract public class BatchingProcessor<T> implements DecatonProcessor<T> {
 
-    BiConsumer<String, List<BufferedTask<T>>> processor;
-    long lingerMillis;
-    int capacity;
-    long maxRetryCount;
+    private final ScheduledExecutorService executor;
+    private final List<BatchingTask<T>> windowedTasks = Collections.synchronizedList(new ArrayList<>());
+    private final long lingerMillis;
+    private final int capacity;
 
-    private final ConcurrentMap<String, BufferedTaskGroup> windowedTasks = new ConcurrentHashMap<>();
-    final ScheduledExecutorService scheduler = initScheduler();
+    @Getter
+    @Accessors(fluent = true)
+    public static class BatchingTask<T> {
+        @Getter(AccessLevel.NONE)
+        public final Completion completion;
+        public final ProcessingContext<T> context;
+        public final T task;
 
-    protected ScheduledExecutorService initScheduler() {
-        return new ScheduledThreadPoolExecutor(1, r -> {
-            Thread th = new Thread(r);
-            th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
-                       + "-Flusher/" + System.identityHashCode(this));
-            return th;
-        });
-    }
-
-    @ToString
-    static class BufferedTask<T> {
-        final T task;
-        final ProcessingContext<T> context;
-
-        BufferedTask(T task, ProcessingContext<T> context) {
-            this.task = task;
+        private BatchingTask(Completion completion, ProcessingContext<T> context, T task) {
+            this.completion = completion;
             this.context = context;
-            context.deferCompletion();
+            this.task = task;
         }
     }
 
-    class BufferedTaskGroup {
-        private final String key;
-        private final int capacity;
-        private final List<BufferedTask<T>> bufferedTasks = new ArrayList<>();
-        private final Future<?> scheduledFlush;
-        private final AtomicBoolean flushed = new AtomicBoolean();
-
-        // Run in Processor thread for this partition
-        BufferedTaskGroup(String key, int capacity) {
-            this.key = key;
-            this.capacity = capacity;
-            scheduledFlush = scheduleFlush();
-        }
-
-        // Run from Processor thread for this partition
-
-        /**
-         * Will reject new tasks is flush has already happened or is ongoing.
-         * @return whether the task was actually added.
-         */
-        boolean addBufferedTask(ProcessingContext<T> context, T task) {
-            if (!context.key().equals(key)) {
-                throw new RuntimeException("");
-            }
-            synchronized (bufferedTasks) {
-                if (isFull() || flushed.get()) {
-                    return false;
-                }
-                bufferedTasks.add(new BufferedTask<>(task, context));
-            }
-            return true;
-        }
-
-        private boolean isFull() {
-            return bufferedTasks.size() >= capacity;
-        }
-
-        private Future<?> scheduleFlush() {
-            Runnable flushTask = () -> {
-                try {
-                    flush();
-                } catch (InterruptedException e) {
-                    logger.error("interrupted while flushing task group {}", this, e);
-                    Thread.currentThread().interrupt();
-                }
-            };
-            return scheduler.schedule(flushTask, lingerMillis, TimeUnit.MILLISECONDS);
-        }
-
-        void flush() throws InterruptedException {
-            BufferedTaskGroup expected;
-            synchronized (bufferedTasks) {
-                if (flushed.getAndSet(true)) {
-                    logger.info("Already flushed: {}", this);
-                    return;
-                }
-                logger.debug("Flushing task group: {}", this);
-                expected = windowedTasks.remove(key);
-
-                if (!bufferedTasks.isEmpty()) {
-                    process();
-                }
-            }
-
-            // Prevent concurrent update from missing tasks.
-            // Since there is no synchronization on `windowedTasks`
-            // then during scheduled flush another task can be inserted instead
-            if (expected != null && expected != this && !expected.flushed.get()) {
-                synchronized (expected.bufferedTasks) {
-                    if (!expected.flushed.getAndSet(true) && !expected.bufferedTasks.isEmpty()) {
-                        logger.warn("Flushing other task group: {}", expected);
-                        expected.process();
-                    }
-                }
-            }
-        }
-
-        // Run in Processor thread for this partition
-        void flushNow() throws InterruptedException {
-            if (!scheduledFlush.isDone()) {
-                boolean cancelled = scheduledFlush.cancel(false);
-                logger.debug("{} previously scheduled flush for user {}", key,
-                             cancelled ? "Cancelled" : "Already cancelled");
-                flush();
-            }
-        }
-
-        private void process() throws InterruptedException {
-            try {
-                processor.accept(key, bufferedTasks);
-            } catch (RuntimeException e) {
-                // Only retryable tasks are retried.
-                for (BufferedTask<T> t : bufferedTasks) {
-                    handleTaskFailure(e, t.context, t.task);
-                }
-            } finally {
-                // complete successful and abandoned tasks
-                // for retried tasks, this does nothing (deferredCompletion is already complete)
-                bufferedTasks.forEach(t -> t.context.deferCompletion().complete());
-            }
-        }
-
-        private void handleTaskFailure(RuntimeException e, ProcessingContext<T> context, T task)
-            throws InterruptedException {
-            long currentRetryCount = context.metadata().retryCount();
-            if (maxRetryCount > currentRetryCount) {
-                logger.warn("Failed to process task<{}>, retrying ({}/{})",
-                            task, currentRetryCount, maxRetryCount, e);
-                context.retry();
-            } else {
-                logger.error("Failed to process task<{}>, retries exhausted ({})",
-                             task, currentRetryCount, e);
-            }
-        }
-
-    }
-
+    // visible for testing
     BatchingProcessor(
-        BiConsumer<String, List<BufferedTask<T>>> processor,
         long lingerMillis,
-        int capacity
+        int capacity,
+        ScheduledThreadPoolExecutor scheduledExecutor
     ) {
         this.lingerMillis = lingerMillis;
         this.capacity = capacity;
-        this.processor = processor;
+
+        if (scheduledExecutor == null) {
+            scheduledExecutor = new ScheduledThreadPoolExecutor(1, r -> {
+                Thread th = new Thread(r);
+                th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
+                           + '/' + System.identityHashCode(this));
+                return th;
+            });
+        }
+        // For faster shutdown cancel all pending flush on executor shutdown.
+        // In fact for this purpose we have two options here:
+        // A. Cancel all pending flush
+        // B. Run all pending flush immediately, regardless remaining time until flush
+        // A has a downside that it forces consumer to re-process some amount of tasks.
+        // B has a downside that it may causes flush bursting and then on spike for storage/API access in
+        // downstream processor.
+        // Given that this feature is expected to be used mainly for reducing workload for storage/APIs,
+        // we think taking A is much desirable behavior in most cases.
+        scheduledExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        executor = scheduledExecutor;
+    }
+
+    public BatchingProcessor(long lingerMillis) {
+        this(lingerMillis, Integer.MAX_VALUE, null);
+    }
+
+    public BatchingProcessor(long lingerMillis, int capacity) {
+        this(lingerMillis, capacity, null);
+    }
+
+    private void flush() {
+        if (!windowedTasks.isEmpty()) {
+            return;
+        }
+        synchronized (windowedTasks) {
+            processBatchingTasks(windowedTasks);
+        }
+    }
+
+    // visible for testing
+    Runnable flushTask() {
+        return this::flush;
+    }
+
+    private void scheduleFlush() {
+        executor.schedule(flushTask(), lingerMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public void process(ProcessingContext<T> context, T task) throws InterruptedException {
-        String key = context.key();
-        BufferedTaskGroup taskGroup = windowedTasks.get(key);
-        if (taskGroup != null) {
-            if (taskGroup.addBufferedTask(context, task)) {
-                logger.debug("Joined existing task group {}", taskGroup);
-                return;
-            }
+        BatchingTask<T> newTask = new BatchingTask<>(context.deferCompletion(), context, task);
+        boolean isInitialTask = windowedTasks.isEmpty();
+        windowedTasks.add(newTask);
+        if (isInitialTask) {
+            scheduleFlush();
         }
-        if (taskGroup == null) {
-            logger.debug("Creating new task group for key {}", key);
-        } else {
-            logger.debug("Cannot reuse task group {}", taskGroup);
-            taskGroup.flushNow(); // removes `taskGroup` from `windowedTasks`
+        if (windowedTasks.size() >= this.capacity) {
+            flush();
         }
-        while (true) {
-            BufferedTaskGroup freshTaskGroup = new BufferedTaskGroup(key, capacity);
-            if (freshTaskGroup.addBufferedTask(context, task)) {
-                BufferedTaskGroup replacedTaskGroup = windowedTasks.put(key, freshTaskGroup);
-                if (replacedTaskGroup != null) {
-                    logger.warn("Previous taskGroup should have been removed already, was: {}",
-                                replacedTaskGroup);
-                    replacedTaskGroup.flushNow();
-                }
-                break;
-            }
-            logger.warn("Could not add task to a fresh buffer for key {}", key);
-        }
-    }
-
-    @Override
-    public String name() {
-        return DecatonProcessor.super.name();
     }
 
     @Override
     public void close() throws Exception {
-        DecatonProcessor.super.close();
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
     }
+
+    /**
+     * *MUST* call {@link BatchingTask#completion}'s {@link DeferredCompletion#complete()} or
+     * {@link BatchingTask#context}'s {@link ProcessingContext#retry()} method.
+     */
+    abstract void processBatchingTasks(List<BatchingTask<T>> batchingTasks);
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -17,6 +17,7 @@
 package com.linecorp.decaton.processor.processors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -40,7 +41,7 @@ import lombok.experimental.Accessors;
 public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
 
     private final ScheduledExecutorService executor;
-    private List<BatchingTask<T>> currentBatch = new ArrayList<>();
+    private List<BatchingTask<T>> currentBatch = Collections.synchronizedList(new ArrayList<>());
     private final long lingerMillis;
     private final int capacity;
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -54,7 +54,6 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
 
     /**
      * Instantiate {@link BatchingProcessor}.
-     * If you only need one limit, please set large enough value to another.
      * @param lingerMillis time limit for this processor. On every lingerMillis milliseconds,
      * tasks in past lingerMillis milliseconds are pushed to {@link BatchingTask#processBatchingTasks(List)}.
      * @param capacity size limit for this processor. Every time tasks’size reaches capacity,

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -27,7 +27,8 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.Completion;
 
-import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.experimental.Accessors;
 
 /**
@@ -43,21 +44,13 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
     private final long lingerMillis;
     private final int capacity;
 
-    @Getter
+    @Value
     @Accessors(fluent = true)
+    @RequiredArgsConstructor
     public static class BatchingTask<T> {
-        @Getter
-        private final Completion completion;
-        @Getter
-        private final ProcessingContext<T> context;
-        @Getter
-        private final T task;
-
-        private BatchingTask(Completion completion, ProcessingContext<T> context, T task) {
-            this.completion = completion;
-            this.context = context;
-            this.task = task;
-        }
+        Completion completion;
+        ProcessingContext<T> context;
+        T task;
     }
 
     /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -38,7 +38,7 @@ import lombok.experimental.Accessors;
  * Batch-flushing should be done in time-based and size-based.
  * @param <T> type of task to batch
  */
-abstract public class BatchingProcessor<T> implements DecatonProcessor<T> {
+public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
 
     private final ScheduledExecutorService executor;
     private final List<BatchingTask<T>> windowedTasks = Collections.synchronizedList(new ArrayList<>());

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -33,8 +33,8 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 
 /**
- * An Abstract {@link DecatonProcessor} to Batch several tasks of type T to List<T> and process them at once.
- * e.g. when downstream-DB supports batching I/O (which often very efficient).
+ * An Abstract {@link DecatonProcessor} to Batch several tasks of type {@code T} to {@code List<T>}
+ * and process them at once. e.g. when downstream-DB supports batching I/O (which often very efficient).
  * Batch-flushing should be done in time-based and size-based.
  * @param <T> type of task to batch
  */

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -93,7 +93,7 @@ abstract public class BatchingProcessor<T> implements DecatonProcessor<T> {
     }
 
     private void flush() {
-        if (!windowedTasks.isEmpty()) {
+        if (windowedTasks.isEmpty()) {
             return;
         }
         synchronized (windowedTasks) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -135,8 +135,7 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
      * so design it so that they are called finally by yourself. Otherwise, consumption will stick.
      * BatchingProcessor realizes its function by using {@link ProcessingContext#deferCompletion()}.
      * Reading {@link ProcessingContext#deferCompletion()}'s description will help you.
-     * This method runs in different thread
-     * from the {@link BatchingProcessor#process(ProcessingContext, Object) thread.
+     * This method runs in different thread from the {@link #process} thread.
      */
     protected abstract void processBatchingTasks(List<BatchingTask<T>> batchingTasks);
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -74,11 +74,11 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
         this.capacity = capacity;
 
         ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1, r -> {
-                Thread th = new Thread(r);
-                th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
-                           + '/' + System.identityHashCode(this));
-                return th;
-            });
+            Thread th = new Thread(r);
+            th.setName("Decaton" + BatchingProcessor.class.getSimpleName()
+                       + '/' + System.identityHashCode(this));
+            return th;
+        });
 
         // For faster shutdown cancel all pending flush on executor shutdown.
         // In fact for this purpose we have two options here:

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -35,7 +35,7 @@ import lombok.experimental.Accessors;
 /**
  * An Abstract {@link DecatonProcessor} to Batch several tasks of type {@code T} to {@code List<T>}
  * and process them at once. e.g. when downstream-DB supports batching I/O (which often very efficient).
- * Batch-flushing should be done in time-based and size-based.
+ * Batch-flushing is done in time-based and size-based.
  * @param <T> type of task to batch
  */
 public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
@@ -128,8 +128,15 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
     }
 
     /**
+     * After complete processing batch of tasks,
      * *MUST* call {@link BatchingTask#completion}'s {@link DeferredCompletion#complete()} or
-     * {@link BatchingTask#context}'s {@link ProcessingContext#retry()} method.
+     * {@link BatchingTask#context}'s {@link ProcessingContext#retry()} method for each {@link BatchingTask}.
+     * The above methods is not called automatically even when an error occurs in this method,
+     * so design it so that they are called finally by yourself. Otherwise, consumption will stick.
+     * BatchingProcessor realizes its function by using {@link ProcessingContext#deferCompletion()}.
+     * Reading {@link ProcessingContext#deferCompletion()}'s description will help you.
+     * This method runs in different thread
+     * from the {@link BatchingProcessor#process(ProcessingContext, Object) thread.
      */
     protected abstract void processBatchingTasks(List<BatchingTask<T>> batchingTasks);
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -112,7 +112,8 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
         };
     }
 
-    private void scheduleFlush() {
+    // visible for testing
+    protected void scheduleFlush() {
         executor.schedule(periodicallyFlushTask(), lingerMillis, TimeUnit.MILLISECONDS);
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -97,7 +97,8 @@ abstract public class BatchingProcessor<T> implements DecatonProcessor<T> {
             return;
         }
         synchronized (windowedTasks) {
-            processBatchingTasks(windowedTasks);
+            processBatchingTasks(new ArrayList<>(windowedTasks));
+            windowedTasks.clear();
         }
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -140,5 +140,5 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
      * *MUST* call {@link BatchingTask#completion}'s {@link DeferredCompletion#complete()} or
      * {@link BatchingTask#context}'s {@link ProcessingContext#retry()} method.
      */
-    abstract void processBatchingTasks(List<BatchingTask<T>> batchingTasks);
+    protected abstract void processBatchingTasks(List<BatchingTask<T>> batchingTasks);
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -17,7 +17,6 @@
 package com.linecorp.decaton.processor.processors;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -42,7 +41,7 @@ import lombok.experimental.Accessors;
 public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
 
     private final ScheduledExecutorService executor;
-    private List<BatchingTask<T>> currentBatch = Collections.synchronizedList(new ArrayList<>());
+    private List<BatchingTask<T>> currentBatch = new ArrayList<>();
     private final long lingerMillis;
     private final int capacity;
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -28,7 +28,6 @@ import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.Completion;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
@@ -48,10 +47,12 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
     @Getter
     @Accessors(fluent = true)
     public static class BatchingTask<T> {
-        @Getter(AccessLevel.NONE)
-        public final Completion completion;
-        public final ProcessingContext<T> context;
-        public final T task;
+        @Getter
+        private final Completion completion;
+        @Getter
+        private final ProcessingContext<T> context;
+        @Getter
+        private final T task;
 
         private BatchingTask(Completion completion, ProcessingContext<T> context, T task) {
             this.completion = completion;

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -43,8 +43,7 @@ public class BatchingProcessor<T> implements DecatonProcessor<T> {
     int capacity;
     long maxRetryCount;
 
-    private final ConcurrentMap<String, BufferedTaskGroup> windowedTasks = new ConcurrentHashMap<>(64, 0.75f,
-                                                                                                   2);
+    private final ConcurrentMap<String, BufferedTaskGroup> windowedTasks = new ConcurrentHashMap<>();
     final ScheduledExecutorService scheduler = initScheduler();
 
     protected ScheduledExecutorService initScheduler() {

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -28,7 +28,6 @@ import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.Completion;
 import com.linecorp.decaton.processor.runtime.internal.Utils;
 
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -47,7 +46,6 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
 
     @Value
     @Accessors(fluent = true)
-    @RequiredArgsConstructor
     public static class BatchingTask<T> {
         Completion completion;
         ProcessingContext<T> context;

--- a/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/processors/BatchingProcessor.java
@@ -112,8 +112,7 @@ public abstract class BatchingProcessor<T> implements DecatonProcessor<T> {
         };
     }
 
-    // visible for testing
-    protected void scheduleFlush() {
+    private void scheduleFlush() {
         executor.schedule(periodicallyFlushTask(), lingerMillis, TimeUnit.MILLISECONDS);
     }
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
@@ -63,8 +63,8 @@ public class BatchingProcessorTest {
             @Override
             void processBatchingTasks(List<BatchingTask<HelloTask>> batchingTasks) {
                 batchingTasks.forEach(batchingTask -> {
-                    processedTasks.add(batchingTask.task);
-                    batchingTask.completion.complete();
+                    processedTasks.add(batchingTask.task());
+                    batchingTask.completion().complete();
                 });
             }
         };

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor.processors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.decaton.processor.Completion;
+import com.linecorp.decaton.processor.ProcessingContext;
+import com.linecorp.decaton.protocol.Sample.HelloTask;
+
+public class BatchingProcessorTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private ProcessingContext<HelloTask> context;
+
+    @Mock
+    private Completion completion;
+
+    private final List<HelloTask> processedTasks = new ArrayList<>();
+
+    @Before
+    public void before() {
+        doReturn(completion).when(context).deferCompletion();
+        processedTasks.clear();
+    }
+
+    private HelloTask buildHelloTask(String name, int age) {
+        return HelloTask.newBuilder().setName(name).setAge(age).build();
+    }
+
+    private BatchingProcessor<HelloTask> buildProcessor(long lingerMs, int capacity) {
+        return new BatchingProcessor<HelloTask>(lingerMs, capacity) {
+            @Override
+            void processBatchingTasks(List<BatchingTask<HelloTask>> batchingTasks) {
+                batchingTasks.forEach(batchingTask -> {
+                    processedTasks.add(batchingTask.task);
+                    batchingTask.completion.complete();
+                });
+            }
+        };
+    }
+
+    @Test(timeout = 5000)
+    public void testLingerLimit() throws InterruptedException {
+        long lingerMs = 500;
+        BatchingProcessor<HelloTask> processor = buildProcessor(lingerMs, Integer.MAX_VALUE);
+
+        HelloTask task1 = buildHelloTask("one", 1);
+        HelloTask task2 = buildHelloTask("two", 2);
+        HelloTask task3 = buildHelloTask("three", 3);
+        HelloTask task4 = buildHelloTask("four", 4);
+
+        processor.process(context, task1);
+        processor.process(context, task2);
+        Thread.sleep(lingerMs * 2); // doubling just to make sure flush completed in background
+        processor.process(context, task3);
+        assertEquals(Arrays.asList(task1, task2), processedTasks);
+        Thread.sleep(lingerMs * 2); // doubling just to make sure flush completed in background
+        processor.process(context, task4);
+        assertEquals(Arrays.asList(task1, task2, task3), processedTasks);
+
+        verify(context, times(4)).deferCompletion();
+        verify(completion, times(processedTasks.size())).complete();
+    }
+
+    @Test(timeout = 5000)
+    public void testCapacityLimit() throws InterruptedException {
+        BatchingProcessor<HelloTask> processor = buildProcessor(Long.MAX_VALUE, 2);
+
+        HelloTask task1 = buildHelloTask("one", 1);
+        HelloTask task2 = buildHelloTask("two", 2);
+        HelloTask task3 = buildHelloTask("three", 3);
+        HelloTask task4 = buildHelloTask("four", 4);
+        HelloTask task5 = buildHelloTask("five", 5);
+
+        processor.process(context, task1);
+        processor.process(context, task2);
+        processor.process(context, task3);
+        assertEquals(Arrays.asList(task1, task2), processedTasks);
+        processor.process(context, task4);
+        processor.process(context, task5);
+        assertEquals(Arrays.asList(task1, task2, task3, task4), processedTasks);
+
+        verify(context, times(5)).deferCompletion();
+        verify(completion, times(processedTasks.size())).complete();
+    }
+}

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
@@ -61,7 +61,7 @@ public class BatchingProcessorTest {
     private BatchingProcessor<HelloTask> buildProcessor(long lingerMs, int capacity) {
         return new BatchingProcessor<HelloTask>(lingerMs, capacity) {
             @Override
-            void processBatchingTasks(List<BatchingTask<HelloTask>> batchingTasks) {
+            protected void processBatchingTasks(List<BatchingTask<HelloTask>> batchingTasks) {
                 batchingTasks.forEach(batchingTask -> {
                     processedTasks.add(batchingTask.task());
                     batchingTask.completion().complete();

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/BatchingProcessorTest.java
@@ -48,7 +48,7 @@ public class BatchingProcessorTest {
     @Mock
     private Completion completion;
 
-    private final List<HelloTask> processedTasks = new ArrayList<>();
+    private final List<HelloTask> processedTasks = Collections.synchronizedList(new ArrayList<>());
 
     @Before
     public void before() {


### PR DESCRIPTION
# Motivation
- Task batching is a common-pattern that many Decaton users often implement by their own.
   - i.e. Batching several tasks of type T to List<T> and process them at once. e.g. when downstream-DB supports batching I/O (which often very efficient)
   - Batch-flushing should be done in time-based and size-based.
- So it's better to provide BatchingProcessor built-in to meet the common needs
 
Related Issue: https://github.com/line/decaton/issues/128