### PR TITLE
Upgrade shadow which has newer log4j2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id "me.champeau.jmh" version "0.6.6" apply false
-    id 'com.github.johnrengelman.shadow' version '7.1.0' apply false
+    id 'com.github.johnrengelman.shadow' version '7.1.1' apply false
     id 'io.franzbecker.gradle-lombok' version '5.0.0' apply false
 }
 

--- a/docs/example/build.gradle
+++ b/docs/example/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'com.google.protobuf' version '0.8.18'
-    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.1'
 }
 
 ext {

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -20,7 +20,7 @@ We also apply link:https://github.com/johnrengelman/shadow[gradle plugin for mak
 plugins {
     id 'idea'
     id 'com.google.protobuf' version '0.8.18'
-    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.1'
 }
 
 dependencies {


### PR DESCRIPTION
## Motivation
- Upgrade shadow plugin which has newer log4j2 dependency that is patched for recent RCE vulnerability
    * https://github.com/johnrengelman/shadow/releases/tag/7.1.1
- Note that this does **NOT** mean Decaton has log4j2 as the dependency