### PR TITLE
After protobuf plugin upgrade, workaround is no longer necessary

### DIFF
--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -6,18 +6,9 @@ dependencies {
     shade "com.google.protobuf:protobuf-java:$protobufVersion"
 }
 
-// As of Dec 2020, protoc binary for Apple silicon hasn't been published yet.
-// (refs: https://github.com/protocolbuffers/protobuf/issues/8062)
-// To workaround that, override the classifier to x86_64 explicitly on arm64 mac.
-// (Should work thanks to Rosetta 2)
-def classifier = ''
-if ('osx-aarch_64'.equals(osdetector.classifier)) {
-    classifier = 'osx-x86_64'
-}
-
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$protobufVersion:$classifier"
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
     }
 }
 


### PR DESCRIPTION
## Summary

- We added a workaround for Apple M1 in this PR https://github.com/line/decaton/pull/76
- However, I found that it's no longer necessary as already addressed in protobuf-plugin side
  * https://github.com/protocolbuffers/protobuf/pull/8557
- Forgot to remove this workaround after the plugin dep was upgraded