### PR TITLE
Upgrade kafka-clients dependency to 3.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
     ext {
         slf4jVersion = "1.7.32"
         protobufVersion = "3.3.0"
-        kafkaVersion = "2.4.0"
+        kafkaVersion = "3.2.0"
         micrometerVersion = "1.7.5"
         lombokVersion = "1.18.22"
         junitVersion = "4.13.2"

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
     api "io.micrometer:micrometer-core:$micrometerVersion"
 
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+
     testImplementation project(":protobuf")
     testRuntimeOnly "ch.qos.logback:logback-classic:1.2.6"
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -95,7 +95,7 @@ public class ProcessorSubscriptionTest {
         }
 
         @Override
-        public synchronized void close(long timeout, TimeUnit unit) {}
+        public void close(Duration timeout) {}
     }
 
     private static SubscriptionScope scope(String topic, long waitForProcessingOnClose) {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -16,6 +16,7 @@
 
 ext {
     noPublish = true
+    jacksonVersion = "2.12.3"
 }
 dependencies {
     implementation testFixtures(project(':processor'))
@@ -27,6 +28,8 @@ dependencies {
     implementation "org.apache.kafka:kafka_2.12:$kafkaVersion:test"
 
     implementation "com.google.protobuf:protobuf-java:$protobufVersion"
+    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 
     implementation('org.apache.zookeeper:zookeeper:3.5.6') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducerAdaptor.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProducerAdaptor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -52,6 +53,12 @@ abstract class ProducerAdaptor<K, V> implements Producer<K, V> {
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId)
             throws ProducerFencedException {
         delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+                                         ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+        delegate.sendOffsetsToTransaction(offsets, groupMetadata);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Upgrade kafka-clients dependency to the latest version
- But should still work with kafka 2.x
- After https://github.com/apache/kafka/pull/10203, several transitive dependencies that decaton currently depend on are moved from compile-classpath to runtime-classpath (`implementation` gradle config), we need to explicitly add dependencies for them
- Concern:
  * Should this change marked as "breaking change" and bump major version?