### PR TITLE
Increment error counter for synchronous failure

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
@@ -41,6 +41,12 @@ public class CompletionImpl implements Completion {
         return comp;
     }
 
+    static CompletionImpl failedCompletion(Throwable ex) {
+        CompletionImpl comp = new CompletionImpl();
+        comp.completeExceptionally(ex);
+        return comp;
+    }
+
     public CompletionImpl() {
         future = new CompletableFuture<>();
     }
@@ -91,5 +97,10 @@ public class CompletionImpl implements Completion {
     @Override
     public void complete() {
         future.complete(null);
+    }
+
+    // package private for now, since decaton ignores exception in almost every place.
+    void completeExceptionally(Throwable ex) {
+        future.completeExceptionally(ex);
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
@@ -43,7 +43,7 @@ public class CompletionImpl implements Completion {
 
     static CompletionImpl failedCompletion(Throwable ex) {
         CompletionImpl comp = new CompletionImpl();
-        comp.completeExceptionally(ex);
+        comp.future.completeExceptionally(ex);
         return comp;
     }
 
@@ -97,10 +97,5 @@ public class CompletionImpl implements Completion {
     @Override
     public void complete() {
         future.complete(null);
-    }
-
-    // package private for now, since decaton ignores exception in almost every place.
-    void completeExceptionally(Throwable ex) {
-        future.completeExceptionally(ex);
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -128,13 +128,9 @@ public class ProcessPipeline<T> implements AutoCloseable {
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
-            } else {
-                taskMetrics.tasksError.increment();
             }
-            processResult = CompletionImpl.completedCompletion();
+            processResult = CompletionImpl.failedCompletion(e);
 
-            log.error("Uncaught exception thrown by processor {} for task {}",
-                      scope, request, e);
         } finally {
             Duration elapsed = timer.duration();
             if (log.isTraceEnabled()) {
@@ -154,6 +150,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
             processMetrics.tasksCompleteDuration.record(completeDuration);
 
             if (e != null) {
+                log.error("Uncaught exception thrown by processor {} for task {}", scope, request, e);
                 taskMetrics.tasksError.increment();
             }
         });

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -128,6 +128,8 @@ public class ProcessPipeline<T> implements AutoCloseable {
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
+            } else {
+                taskMetrics.tasksError.increment();
             }
             processResult = CompletionImpl.completedCompletion();
 


### PR DESCRIPTION
After [this change](https://github.com/line/decaton/pull/99/files#diff-4df160cb6c95ec9c8815d2af1dda8a9ebe841c74c4e094bd3ef8e75074dd0af5L121) in  https://github.com/line/decaton/pull/99, decaton stopped incrementing `taskMetrics.tasksError` for synchronous failure.
This PR wants to fix `tasksError` to work again.

I applied quick patch as first PR, but implementing `completeExceptionally(Throwable)` in [DeferredCompletion](https://github.com/line/decaton/blob/d9543b907cb6af8090b4159eb7cd8fddb4cabac1/processor/src/main/java/com/linecorp/decaton/processor/DeferredCompletion.java) and complete it with exception sounds the right way.
How do you think?


