### PR TITLE
Support cooperative rebalancing fixes #98,#118

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
     ext {
         // Freezing this to 1.X until https://github.com/spring-projects/spring-boot/issues/12649 is resolved
         slf4jVersion = "1.7.36"
-        protobufVersion = "3.3.0"
+        protobufVersion = "3.21.7"
         kafkaVersion = "3.2.0"
         micrometerVersion = "1.7.5"
         lombokVersion = "1.18.22"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
     ext {
         // Freezing this to 1.X until https://github.com/spring-projects/spring-boot/issues/12649 is resolved
         slf4jVersion = "1.7.36"
-        protobufVersion = "3.21.7"
+        protobufVersion = "3.3.0"
         kafkaVersion = "3.2.0"
         micrometerVersion = "1.7.5"
         lombokVersion = "1.18.22"

--- a/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/SubscriptionStateTest.java
@@ -65,8 +65,13 @@ public class SubscriptionStateTest {
                 }
                 switch (state) {
                     case INITIALIZING:
-                    case REBALANCING:
                         validTransition = Arrays.asList(State.RUNNING);
+                        break;
+                    case REBALANCING:
+                        // It's possible to transition to SHUTTING_DOWN from REBALANCING
+                        // when onPartitionRevoked and onPartitionAssigned are not done in same poll() and
+                        // shutdown is initiated between them
+                        validTransition = Arrays.asList(State.RUNNING, State.SHUTTING_DOWN);
                         break;
                     case RUNNING:
                         validTransition = Arrays.asList(State.REBALANCING, State.SHUTTING_DOWN);

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -32,7 +32,6 @@ import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.TimeoutException;
 
 import com.linecorp.decaton.processor.metrics.Metrics;
@@ -266,13 +265,6 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             contexts.updateHighWatermarks();
             try {
                 commitManager.commitSync();
-            } catch (RebalanceInProgressException e) {
-                // At this point, Decaton already stopped processing though, from KafkaConsumer perspective,
-                // it's not closed yet (i.e. rebalance due to member-leave is not initiated), so another rebalance might be
-                // initiated (likely by other consumer instances), and then, this commitSync may fail due to
-                // RebalanceInProgressException.
-                // So, since it's not a fatal situation and kind of expected failure, we just log at WARN level.
-                log.warn("Offset commit failed because rebalance is ongoing when closing consumer", e);
             } catch (RuntimeException e) {
                 log.error("Offset commit failed before closing consumer", e);
             }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/AssignmentManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/AssignmentManager.java
@@ -52,9 +52,22 @@ public class AssignmentManager {
     interface AssignmentStore {
         /**
          * Return set of {@link TopicPartition}s that are currently assigned.
+         * Note that this have to include all partitions including revoking ones.
          * @return set of assigned topic-partitions.
          */
         Set<TopicPartition> assignedPartitions();
+
+        /**
+         * Mark the partitions as revoking
+         * @param partitions target partition to mark
+         */
+        void markRevoking(Collection<TopicPartition> partitions);
+
+        /**
+         * Set the partitions as not revoking
+         * @param partitions target partition to unmark
+         */
+        void unmarkRevoking(Collection<TopicPartition> partitions);
 
         /**
          * Add new topic-partitions with associated configurations.
@@ -90,6 +103,7 @@ public class AssignmentManager {
 
         partitionsRevoked(removed);
         partitionsAssigned(added);
+        store.unmarkRevoking(newSet);
     }
 
     /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/AssignmentManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/AssignmentManager.java
@@ -59,13 +59,13 @@ public class AssignmentManager {
 
         /**
          * Mark the partitions as revoking
-         * @param partitions target partition to mark
+         * @param partitions target partitions to mark
          */
         void markRevoking(Collection<TopicPartition> partitions);
 
         /**
          * Set the partitions as not revoking
-         * @param partitions target partition to unmark
+         * @param partitions target partitions to unmark
          */
         void unmarkRevoking(Collection<TopicPartition> partitions);
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -34,6 +34,7 @@ import lombok.experimental.Accessors;
 /**
  * Represents all states of one partition assigned to this subscription instance.
  */
+@Accessors(fluent = true)
 public class PartitionContext implements AutoCloseable {
     private final PartitionScope scope;
     private final PartitionProcessor partitionProcessor;
@@ -53,7 +54,6 @@ public class PartitionContext implements AutoCloseable {
      */
     @Getter
     @Setter
-    @Accessors(fluent = true)
     private boolean revoking;
 
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
@@ -139,13 +139,13 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
     @Override
     public Map<TopicPartition, OffsetAndMetadata> commitReadyOffsets() {
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
-        contexts.values()
-                .stream()
-                .filter(context -> !context.revoking()).forEach(context -> {
-                    context.offsetWaitingCommit().ifPresent(
-                            offset -> offsets.put(context.topicPartition(),
-                                                  new OffsetAndMetadata(offset + 1, null)));
-                });
+        for (PartitionContext context : contexts.values()) {
+            if (!context.revoking()) {
+                context.offsetWaitingCommit().ifPresent(
+                        offset -> offsets.put(context.topicPartition(),
+                                              new OffsetAndMetadata(offset + 1, null)));
+            }
+        }
         return offsets;
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
@@ -139,11 +139,13 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
     @Override
     public Map<TopicPartition, OffsetAndMetadata> commitReadyOffsets() {
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
-        for (PartitionContext context : contexts.values()) {
-            context.offsetWaitingCommit().ifPresent(
-                    offset -> offsets.put(context.topicPartition(),
-                                          new OffsetAndMetadata(offset + 1, null)));
-        }
+        contexts.values()
+                .stream()
+                .filter(context -> !context.revoking()).forEach(context -> {
+                    context.offsetWaitingCommit().ifPresent(
+                            offset -> offsets.put(context.topicPartition(),
+                                                  new OffsetAndMetadata(offset + 1, null)));
+                });
         return offsets;
     }
 
@@ -156,6 +158,24 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
             // which indicates the offset to "fetch next".
             contexts.get(tp).updateCommittedOffset(offset - 1);
         }
+    }
+
+    @Override
+    public void markRevoking(Collection<TopicPartition> partitions) {
+        contexts.forEach((tp, ctx) -> {
+            if (partitions.contains(tp)) {
+                ctx.revoking(true);
+            }
+        });
+    }
+
+    @Override
+    public void unmarkRevoking(Collection<TopicPartition> partitions) {
+        contexts.forEach((tp, ctx) -> {
+            if (partitions.contains(tp)) {
+                ctx.revoking(false);
+            }
+        });
     }
 
     public int totalPendingTasks() {
@@ -192,6 +212,7 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
     public List<TopicPartition> partitionsNeedsPause() {
         boolean pausingAll = pausingAllProcessing();
         return contexts.values().stream()
+                       .filter(c -> !c.revoking())
                        .filter(c -> !c.paused())
                        .filter(c -> pausingAll || shouldPartitionPaused(c.pendingTasksCount()))
                        .map(PartitionContext::topicPartition)
@@ -202,6 +223,7 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
     public List<TopicPartition> partitionsNeedsResume() {
         boolean pausingAll = pausingAllProcessing();
         return contexts.values().stream()
+                       .filter(c -> !c.revoking())
                        .filter(PartitionContext::paused)
                        .filter(c -> !pausingAll && !shouldPartitionPaused(c.pendingTasksCount()))
                        .map(PartitionContext::topicPartition)

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -21,8 +21,8 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
@@ -199,10 +199,12 @@ public class ProcessorSubscriptionTest {
                         new ConsumerRecord<>(tp.topic(), tp.partition(), offset, "abc".getBytes(StandardCharsets.UTF_8),
                                              String.valueOf(offset).getBytes()))));
             } else {
-                Thread.sleep(invocation.getArgument(0));
+                Duration timeout = invocation.getArgument(0);
+                Thread.sleep(timeout.toMillis());
                 return ConsumerRecords.empty();
             }
-        }).when(consumer).poll(anyLong());
+        }).when(consumer).poll(any());
+        doReturn(singleton(tp)).when(consumer).assignment();
 
         subscription.start();
         processLatch.await();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
@@ -22,7 +22,6 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
@@ -106,7 +105,7 @@ public class ConsumeManagerTest {
                 new ConsumerRecord<>(TOPIC, 1, 102, "key", new byte[0]));
         ConsumerRecords<String, byte[]> consumerRecords =
                 new ConsumerRecords<>(Collections.singletonMap(new TopicPartition(TOPIC, 1), records));
-        doReturn(consumerRecords).when(consumer).poll(anyLong());
+        doReturn(consumerRecords).when(consumer).poll(any());
 
         List<TopicPartition> partitionsNeedsPause = new ArrayList<>(Arrays.asList(tp(1)));
         List<TopicPartition> partitionsNeedsResume = new ArrayList<>(Arrays.asList(tp(2)));
@@ -150,7 +149,7 @@ public class ConsumeManagerTest {
             rebalanceListener.onPartitionsRevoked(singletonList(tp(2)));
             rebalanceListener.onPartitionsAssigned(Arrays.asList(tp(1), tp(3)));
             return ConsumerRecords.empty();
-        }).when(consumer).poll(anyLong());
+        }).when(consumer).poll(any());
 
         Set<TopicPartition> pausedPartitions = new HashSet<>();
         doAnswer(invocation -> {
@@ -158,6 +157,7 @@ public class ConsumeManagerTest {
             pausedPartitions.addAll(invocation.getArgument(0));
             return null;
         }).when(consumer).pause(any());
+        doReturn(new HashSet<>(Arrays.asList(tp(1), tp(3)))).when(consumer).assignment();
 
         consumeManager.poll();
         // Do not call pause for the revoked partition "2".

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
@@ -320,6 +320,13 @@ public class PartitionContextsTest {
         doReturn(false).when(contexts).pausingAllProcessing();
         partitions = contexts.partitionsNeedsResume();
         assertEquals(new HashSet<>(asList(tp(1), tp(2))), new HashSet<>(partitions));
+
+        // unmark revoking
+        doReturn(false).when(cts.get(0)).revoking();
+
+        // unmarked partition should be included
+        partitions = contexts.partitionsNeedsResume();
+        assertEquals(new HashSet<>(asList(tp(0), tp(1), tp(2))), new HashSet<>(partitions));
     }
 
     @Test

--- a/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/TestUtils.java
@@ -146,7 +146,8 @@ public class TestUtils {
             throws InterruptedException, TimeoutException {
         return subscription("subscription-" + sequence(),
                             bootstrapServers,
-                            builderConfigurer);
+                            builderConfigurer,
+                            null);
     }
 
     /**
@@ -156,11 +157,13 @@ public class TestUtils {
      * @param subscriptionId subscription id of the instance
      * @param bootstrapServers bootstrap servers to connect
      * @param builderConfigurer configure subscription builder to fit test requirements
+     * @param additionalConsumerConfig additional configs to be passed when instantiating consumer
      * @return {@link ProcessorSubscription} instance which is already running
      */
     public static ProcessorSubscription subscription(String subscriptionId,
                                                      String bootstrapServers,
-                                                     Consumer<SubscriptionBuilder> builderConfigurer)
+                                                     Consumer<SubscriptionBuilder> builderConfigurer,
+                                                     Properties additionalConsumerConfig)
             throws InterruptedException, TimeoutException {
         AtomicReference<SubscriptionStateListener> stateListenerRef = new AtomicReference<>();
         CountDownLatch initializationLatch = new CountDownLatch(1);
@@ -185,6 +188,10 @@ public class TestUtils {
         props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "test-" + subscriptionId);
         props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, DEFAULT_GROUP_ID);
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        if (additionalConsumerConfig != null) {
+            props.putAll(additionalConsumerConfig);
+        }
 
         builderConfigurer.accept(builder);
         builder.consumerConfig(props)

--- a/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
+++ b/testing/src/main/java/com/linecorp/decaton/testing/processor/ProcessorTestSuite.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -92,6 +94,7 @@ public class ProcessorTestSuite {
     private final int numTasks;
     private final Function<ProcessorsBuilder<TestTask>, ProcessorsBuilder<TestTask>> configureProcessorsBuilder;
     private final RetryConfig retryConfig;
+    private final Properties consumerConfig;
     private final PropertySupplier propertySuppliers;
     private final Set<ProcessingGuarantee> semantics;
     private final SubscriptionStatesListener statesListener;
@@ -141,6 +144,10 @@ public class ProcessorTestSuite {
          * Supply additional {@link ProcessorProperties} through {@link PropertySupplier}
          */
         private PropertySupplier propertySupplier;
+        /**
+         * Supply additional {@link Properties} to be passed to instantiate {@link KafkaConsumer}
+         */
+        private Properties consumerConfig;
         /**
          * Listen every subscription's state changes
          */
@@ -198,6 +205,7 @@ public class ProcessorTestSuite {
                                           numTasks,
                                           configureProcessorsBuilder,
                                           retryConfig,
+                                          consumerConfig,
                                           propertySupplier,
                                           semantics,
                                           statesListener,
@@ -307,7 +315,8 @@ public class ProcessorTestSuite {
                         builder.enableTracing(tracingProvider);
                     }
                     builder.stateListener(state -> statesListener.onChange(id, state));
-                });
+                },
+                consumerConfig);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
## Summary
- Kafka 2.4 added [cooperative rebalancing](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429%3A+Kafka+Consumer+Incremental+Rebalance+Protocol), which aims to minimize well-known "stop-the-world" effect upon consumer rebalance
  * Essentially, what cooperative rebalancing achieves is to revoke/assign only necessary partitions on rebalance and allows to fetch on still-owned partitions even during rebalance.
  * We can opt-in cooperative rebalancing protocol by specifying `ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG` property
- However, currently, Decaton doesn't work with cooperative rebalancing for some reasons. This PR gonna fix them

## Problems of current Decaton implementation to support cooperative rebalancing
- Deprecated `Consumer#poll(long)` is used
  * It's already deprecated and should be replaced with `Consumer#poll(Duration)`
  * There are several behavior changes in `Consumer#poll(Duration)` though, ~from cooperative rebalancing-support perspective~, the most notable one is `poll(Duration)` doesn't block for entire rebalancing procedure unlike `poll(long)`
      - i.e. When rebalance is initiated, after `onPartitionRevoked` is called, `poll()` may return without waiting `onPartitionAssigned` invocation in same poll. (It will be eventually invoked in later `poll()` though)
  * Currently, Decaton is relying on the behavior that `onPartitionRevoked` and `onPartitionAssigned` are executed in same `poll()`
      - Once `onPartitionRevoked` returns, revoked partitions are no longer owned by KafkaConsumer so any `pause/resume/offset commit` may cause RuntimeException and kills subscription thread
      - However, since Decaton postpones destroying `PartitionContext`s to at `onPartitionAssigned` (this was to minimize context-recreation as much as possible. In short, Decaton itself did similar thing to cooperative-rebalancing from eager-rebalancing era)
      - Hence, we need some mechanism to remember which partitions are already revoked, until we actually destroy contexts in subsequent `onPartitionAssigned`
- Decaton relies on the eager-rebalancing's behavior that "all assigned partitions are revoked in `onPartitionsRevoked` => new assignment is added  in `onPartitionsAssigned`".
  * With cooperative-rebalancing, `onPartitionsAssigned` will be called only on newly-added partitions

## Summary of changes
- Store `revoking` status in `PartitionContext`, which is used to prevent calling `pause/resume/offset commit` for revoked partitions during rebalance
- Fix `ConsumeManager` to work even if subset of partitions (i.e. not full assignment) are passed in `ConsumerRebalanceListener`'s callbacks
- `SubscriptionStateListener` state transition may change
  * Because `poll()` may return after `onPartitionsRevoked` before `onPartitionsAssigned`, the transition `REBALANCING` -> `SHUTTING_DOWN` is now possible.
  * This should be considered as **breaking change**

## Appendix
- Since the behavior change that "`onPartitionsRevoked` and `onPartitionsAssigned` may be called in different `poll()` introduces certain complexity, I wrote small `TLA+` spec to get a confidence about the design
  * https://gist.github.com/ocadaruma/226c2f4e65cb97aba3610341903955b0
