### PR TITLE
Upgrade protobuf to support apple silicon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
     ext {
         // Freezing this to 1.X until https://github.com/spring-projects/spring-boot/issues/12649 is resolved
         slf4jVersion = "1.7.36"
-        protobufVersion = "3.3.0"
+        protobufVersion = "3.21.7"
         kafkaVersion = "3.2.0"
         micrometerVersion = "1.7.5"
         lombokVersion = "1.18.22"


### PR DESCRIPTION
- My bad, I removed workaround for apple silicon build in https://github.com/line/decaton/pull/148 but forgot to upgrade the plugin, so now still failing on apple silicon