### PR TITLE
Add retry count metric

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -263,8 +263,8 @@ public class Metrics {
                                    .tags(availableTags.subscriptionScope())
                                    .register(registry));
 
-        public final DistributionSummary retryCount =
-                meter(() -> DistributionSummary.builder("retry.count")
+        public final DistributionSummary retryTaskRetries =
+                meter(() -> DistributionSummary.builder("retry.task.retries")
                                                .description("The number of times a task was retried")
                                                .tags(availableTags.subscriptionScope())
                                                .register(registry));

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import com.linecorp.decaton.processor.metrics.internal.AvailableTags;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Id;
@@ -261,6 +262,12 @@ public class Metrics {
                                    .description("The number of tasks failed to enqueue in retry topic")
                                    .tags(availableTags.subscriptionScope())
                                    .register(registry));
+
+        public final DistributionSummary retryCount =
+                meter(() -> DistributionSummary.builder("retry.count")
+                                               .description("The number of times a task was retried")
+                                               .tags(availableTags.subscriptionScope())
+                                               .register(registry));
     }
 
     public static Metrics withTags(String... keyValues) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -72,7 +72,7 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
             } else {
                 metrics.retryQueueingFailed.increment();
             }
-            metrics.retryCount.record(nextRetryCount);
+            metrics.retryTaskRetries.record(nextRetryCount);
         });
         context.deferCompletion().completeWith(future);
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -64,6 +64,7 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                                   .setMetadata(taskMetadata)
                                   .setSerializedTask(ByteString.copyFrom(serializedTask))
                                   .build();
+        metrics.retryTaskRetries.record(nextRetryCount);
 
         CompletableFuture<PutTaskResult> future = producer.sendRequest(context.key(), request);
         future.whenComplete((r, e) -> {
@@ -72,7 +73,6 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
             } else {
                 metrics.retryQueueingFailed.increment();
             }
-            metrics.retryTaskRetries.record(nextRetryCount);
         });
         context.deferCompletion().completeWith(future);
     }


### PR DESCRIPTION
# Motivation

In our use cases, we try to detect repeated failures of task processing by logging when tasks are retried.
However, frequent repeated logs tend to be ignored, so we may not notice repeated processing failures for a long time.
Instead, this PR introduces a retry count metric, which can be used for alerting based on thresholds.