### PR TITLE
Add missing url on docs

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6,6 +6,7 @@ Decaton Documents
 - link:./why-decaton.adoc[Why Decaton]
 - link:./getting-started.adoc[Getting Started]
 - link:./spring-integration.adoc[Spring Integration]
+- link:./tracing.adoc[Tracing]
 - link:./consuming-any-data.adoc[Use Decaton for consuming topics of non-Decaton tasks]
 - link:./dynamic-property-configuration.adoc[Dynamic property configuration for the processor]
 - link:./monitoring.adoc[Monitoring Decaton]


### PR DESCRIPTION
https://github.com/line/decaton/pull/69 added the distributed tracing feature and its document but an index page doesn't have its url. This pull request just adds the url in the index page.