### PR TITLE
Provide a way of specifying a partition when producing a task 

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -19,6 +19,9 @@ package com.linecorp.decaton.client;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+
 import com.linecorp.decaton.common.Serializer;
 
 import lombok.Builder;
@@ -78,6 +81,19 @@ public interface DecatonClient<T> extends AutoCloseable {
      * @return a {@link CompletableFuture} which represents the result of task put.
      */
     CompletableFuture<PutTaskResult> put(String key, T task, Consumer<Throwable> errorCallback);
+
+    /**
+     * Put a task onto a specified kafka partition.
+     * Note that the specified partition here is prioritised over the result of
+     * {@link Partitioner#partition(String, Object, byte[], Object, byte[], Cluster)}.
+     *
+     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
+     * @param task an instance of task. Should never be null.
+     * @param partition the id of the partition
+     *
+     * @return a {@link CompletableFuture} which represents the result of task put.
+     */
+    CompletableFuture<PutTaskResult> put(String key, T task, int partition);
 
     /**
      * Put a task onto associated decaton queue with specifying arbitrary timestamp.

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -63,9 +63,11 @@ public interface DecatonClient<T> extends AutoCloseable {
 
     /**
      * Put a task onto a specified kafka partition with specifying some fields of task metadata.
-     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
+     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matter.
      * @param task an instance of task. Should never be null.
-     * @param partition the id of the partition
+     * @param overrideTaskMetadata taskMetaData which can be set by users and used for event publish.
+     * null can be specified if it doesn't matter.
+     * @param partition the id of the partition. null can be specified if it doesn't matter.
      *
      * @return a {@link CompletableFuture} which represents the result of task put.
      */

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -62,6 +62,17 @@ public interface DecatonClient<T> extends AutoCloseable {
     CompletableFuture<PutTaskResult> put(String key, T task, TaskMetadata overrideTaskMetadata);
 
     /**
+     * Put a task onto a specified kafka partition with specifying some fields of task metadata.
+     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
+     * @param task an instance of task. Should never be null.
+     * @param partition the id of the partition
+     *
+     * @return a {@link CompletableFuture} which represents the result of task put.
+     */
+    CompletableFuture<PutTaskResult> put(String key, T task, TaskMetadata overrideTaskMetadata,
+                                         Integer partition);
+
+    /**
      * Put a task onto associated decaton queue.
      * This is just a helper method for typical use cases - put task asynchronously and observe result just for telling
      * whether the message production succeeded:
@@ -81,19 +92,6 @@ public interface DecatonClient<T> extends AutoCloseable {
      * @return a {@link CompletableFuture} which represents the result of task put.
      */
     CompletableFuture<PutTaskResult> put(String key, T task, Consumer<Throwable> errorCallback);
-
-    /**
-     * Put a task onto a specified kafka partition.
-     * Note that the specified partition here is prioritised over the result of
-     * {@link Partitioner#partition(String, Object, byte[], Object, byte[], Cluster)}.
-     *
-     * @param key the criteria to shuffle and order tasks. null can be specified if it doesn't matters.
-     * @param task an instance of task. Should never be null.
-     * @param partition the id of the partition
-     *
-     * @return a {@link CompletableFuture} which represents the result of task put.
-     */
-    CompletableFuture<PutTaskResult> put(String key, T task, int partition);
 
     /**
      * Put a task onto associated decaton queue with specifying arbitrary timestamp.

--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonClientImpl.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonClientImpl.java
@@ -124,12 +124,11 @@ public class DecatonClientImpl<T> implements DecatonClient<T> {
                                                             .setSourceApplicationId(applicationId)
                                                             .setSourceInstanceId(instanceId)
                                                             .setTimestampMillis(timestampSupplier.get());
-
-        final Long timestamp = overrideTaskMetadata.getTimestamp();
-        final Long scheduledTime = overrideTaskMetadata.getScheduledTime();
         if (overrideTaskMetadata == null) {
             return taskMetadataProtoBuilder.build();
         }
+        final Long timestamp = overrideTaskMetadata.getTimestamp();
+        final Long scheduledTime = overrideTaskMetadata.getScheduledTime();
         if (timestamp != null) {
             taskMetadataProtoBuilder.setTimestampMillis(timestamp);
         }

--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
@@ -61,12 +61,8 @@ public class DecatonTaskProducer implements AutoCloseable {
         this.topic = topic;
     }
 
-    public CompletableFuture<PutTaskResult> sendRequest(byte[] key, DecatonTaskRequest request) {
-        ProducerRecord<byte[], DecatonTaskRequest> record = new ProducerRecord<>(topic, key, request);
-        return sendRequest(record);
-    }
-
-    public CompletableFuture<PutTaskResult> sendRequest(byte[] key, DecatonTaskRequest request, int partition) {
+    public CompletableFuture<PutTaskResult> sendRequest(byte[] key, DecatonTaskRequest request,
+                                                        Integer partition) {
         ProducerRecord<byte[], DecatonTaskRequest> record = new ProducerRecord<>(topic, partition, key, request);
         return sendRequest(record);
     }

--- a/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/DecatonTaskProducer.java
@@ -63,7 +63,15 @@ public class DecatonTaskProducer implements AutoCloseable {
 
     public CompletableFuture<PutTaskResult> sendRequest(byte[] key, DecatonTaskRequest request) {
         ProducerRecord<byte[], DecatonTaskRequest> record = new ProducerRecord<>(topic, key, request);
+        return sendRequest(record);
+    }
 
+    public CompletableFuture<PutTaskResult> sendRequest(byte[] key, DecatonTaskRequest request, int partition) {
+        ProducerRecord<byte[], DecatonTaskRequest> record = new ProducerRecord<>(topic, partition, key, request);
+        return sendRequest(record);
+    }
+
+    private CompletableFuture<PutTaskResult> sendRequest(ProducerRecord<byte[], DecatonTaskRequest> record) {
         CompletableFuture<PutTaskResult> result = new CompletableFuture<>();
         producer.send(record, (metadata, exception) -> {
             if (exception == null) {
@@ -73,7 +81,6 @@ public class DecatonTaskProducer implements AutoCloseable {
                 result.completeExceptionally(exception);
             }
         });
-
         return result;
     }
 

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -66,6 +66,11 @@ public class DecatonClientTest {
         }
 
         @Override
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, int partition) {
+            return null;
+        }
+
+        @Override
         public void close() throws Exception {
             // noop
         }

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -55,18 +55,20 @@ public class DecatonClientTest {
         }
 
         @Override
-        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, TaskMetadata overrideTaskMetadata) {
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task,
+                                                    TaskMetadata overrideTaskMetadata) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<PutTaskResult> put(String key, HelloTask task,
+                                                    TaskMetadata overrideTaskMetadata, Integer partition) {
             return null;
         }
 
         @Override
         public CompletableFuture<PutTaskResult> put(String key, HelloTask task,
                                                     Consumer<Throwable> errorCallback) {
-            return null;
-        }
-
-        @Override
-        public CompletableFuture<PutTaskResult> put(String key, HelloTask task, int partition) {
             return null;
         }
 

--- a/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
@@ -179,7 +179,7 @@ public class DecatonClientImplTest {
     public void testSpecifyingPartitionWithoutMetadata() {
         doReturn(1234L).when(timestampSupplier).get();
 
-        client.put("key", HelloTask.getDefaultInstance(), TaskMetadata.builder().build(), 4);
+        client.put("key", HelloTask.getDefaultInstance(), null, 4);
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<byte[], DecatonTaskRequest> record = captor.getValue();

--- a/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/internal/DecatonClientImplTest.java
@@ -99,12 +99,12 @@ public class DecatonClientImplTest {
     public void testTimestampFieldSetExternally() {
         doReturn(1234L).when(timestampSupplier).get();
 
-        client.put("key", HelloTask.getDefaultInstance(), 5678);
+        client.put("key", HelloTask.getDefaultInstance(), 5678L);
 
         verify(producer, times(1)).send(captor.capture(), any(Callback.class));
         ProducerRecord<byte[], DecatonTaskRequest> record = captor.getValue();
         assertNull(record.timestamp());
-        assertEquals(5678, record.value().getMetadata().getTimestampMillis());
+        assertEquals(5678L, record.value().getMetadata().getTimestampMillis());
     }
 
     @Test
@@ -153,6 +153,18 @@ public class DecatonClientImplTest {
         assertTrue(record.value().getMetadata().getTimestampMillis() > 0);
         assertNotNull(record.value().getMetadata().getSourceApplicationId());
         assertNotNull(record.value().getMetadata().getSourceInstanceId());
+    }
+
+    @Test
+    public void testSpecifyingPartition() {
+        doReturn(1234L).when(timestampSupplier).get();
+
+        client.put("key", HelloTask.getDefaultInstance(), 4);
+
+        verify(producer, times(1)).send(captor.capture(), any(Callback.class));
+        ProducerRecord<byte[], DecatonTaskRequest> record = captor.getValue();
+        assertNotNull(record.partition());
+        assertEquals(4, record.partition().intValue());
     }
 
     private void verifyAndAssertTaskMetadata(long timestamp, long scheduledTime) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -66,7 +66,7 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                                   .build();
         metrics.retryTaskRetries.record(nextRetryCount);
 
-        CompletableFuture<PutTaskResult> future = producer.sendRequest(context.key(), request);
+        CompletableFuture<PutTaskResult> future = producer.sendRequest(context.key(), request, null);
         future.whenComplete((r, e) -> {
             if (e == null) {
                 metrics.retryQueuedTasks.increment();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
@@ -75,7 +75,7 @@ public class DecatonTaskRetryQueueingProcessorTest {
     @Before
     public void setUp() {
         processor = new DecatonTaskRetryQueueingProcessor(scope, producer);
-        doReturn(CompletableFuture.completedFuture(null)).when(producer).sendRequest(any(), any());
+        doReturn(CompletableFuture.completedFuture(null)).when(producer).sendRequest(any(), any(), any());
         doReturn(new CompletionImpl()).when(context).deferCompletion();
         doReturn("key".getBytes(StandardCharsets.UTF_8)).when(context).key();
         doReturn(TaskMetadata.builder().build()).when(context).metadata();
@@ -101,7 +101,7 @@ public class DecatonTaskRetryQueueingProcessorTest {
         processor.process(context, task.toByteArray());
 
         ArgumentCaptor<DecatonTaskRequest> captor = ArgumentCaptor.forClass(DecatonTaskRequest.class);
-        verify(producer, times(1)).sendRequest(eq(key), captor.capture());
+        verify(producer, times(1)).sendRequest(eq(key), captor.capture(), eq(null));
 
         DecatonTaskRequest request = captor.getValue();
         assertEquals(task.toByteString(), request.getSerializedTask());
@@ -120,7 +120,7 @@ public class DecatonTaskRetryQueueingProcessorTest {
         CompletionImpl comp = new CompletionImpl();
 
         doReturn(comp).when(context).deferCompletion();
-        doReturn(future).when(producer).sendRequest(any(), any());
+        doReturn(future).when(producer).sendRequest(any(), any(), any());
 
         processor.process(context, HelloTask.getDefaultInstance().toByteArray());
 
@@ -133,7 +133,7 @@ public class DecatonTaskRetryQueueingProcessorTest {
 
     @Test
     public void testDeferCompletion_EXCEPTION() throws InterruptedException {
-        doThrow(new KafkaException("kafka")).when(producer).sendRequest(any(), any());
+        doThrow(new KafkaException("kafka")).when(producer).sendRequest(any(), any(), any());
 
         try {
             processor.process(context, HelloTask.getDefaultInstance().toByteArray());


### PR DESCRIPTION
Motivation:

To resolve https://github.com/line/decaton/issues/159

Modifications:

- Add a new API to `DecatonClient` and `DecatonTaskProducer`

Result:

- Closes #159
- Users can produce a partition-specified task without redundant code and Inefficient deserialization