### PR TITLE
Add metrics to check DeferredCompletion leak

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -206,6 +206,9 @@ public class Metrics {
 
     public class PartitionStateMetrics extends AbstractMetrics {
         public final Gauge tasksPending;
+        public final Gauge partitionPaused;
+        public final Gauge lastCommittedOffset;
+        public final Gauge latestConsumedOffset;
 
         public final Timer queueStarvedTime =
                 meter(() -> Timer.builder("partition.queue.starved.time")
@@ -220,9 +223,11 @@ public class Metrics {
                                  .tags(availableTags.partitionScope())
                                  .register(registry));
 
-        public final Gauge partitionPaused;
 
-        public PartitionStateMetrics(Supplier<Number> pendingTasksFn, Supplier<Number> partitionPausedFn) {
+        public PartitionStateMetrics(Supplier<Number> pendingTasksFn,
+                                     Supplier<Number> partitionPausedFn,
+                                     Supplier<Number> lastCommittedOffsetFn,
+                                     Supplier<Number> latestConsumedOffsetFn) {
             tasksPending = meter(() -> Gauge.builder("tasks.pending", pendingTasksFn)
                                             .description("The number of pending tasks")
                                             .tags(availableTags.partitionScope())
@@ -231,6 +236,14 @@ public class Metrics {
                                                .description("Whether the partition is paused. 1 if paused, 0 otherwise")
                                                .tags(availableTags.partitionScope())
                                                .register(registry));
+            lastCommittedOffset = meter(() -> Gauge.builder("offset.last.committed", lastCommittedOffsetFn)
+                                                   .description("The last committed offset")
+                                                   .tags(availableTags.partitionScope())
+                                                   .register(registry()));
+            latestConsumedOffset = meter(() -> Gauge.builder("offset.latest.consumed", latestConsumedOffsetFn)
+                                                    .description("The latest consumed offset")
+                                                    .tags(availableTags.partitionScope())
+                                                    .register(registry()));
         }
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -55,6 +55,7 @@ public class PartitionContext implements AutoCloseable {
     @Getter
     @Setter
     private boolean revoking;
+    private long latestConsumedOffset;
 
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
@@ -72,7 +73,8 @@ public class PartitionContext implements AutoCloseable {
         commitControl = new OutOfOrderCommitControl(scope.topicPartition(), capacity, offsetStateReaper);
 
         metrics = metricsCtor.new PartitionStateMetrics(
-                commitControl::pendingOffsetsCount, () -> paused() ? 1 : 0);
+                commitControl::pendingOffsetsCount, () -> paused() ? 1 : 0,
+                () -> lastCommittedOffset, () -> latestConsumedOffset);
         lastCommittedOffset = -1;
         pausedTimeNanos = -1;
         lastQueueStarvedTime = -1;
@@ -134,6 +136,7 @@ public class PartitionContext implements AutoCloseable {
     }
 
     public OffsetState registerOffset(long offset) {
+        latestConsumedOffset = Math.max(latestConsumedOffset, offset);
         return commitControl.reportFetchedOffset(offset);
     }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -43,7 +43,7 @@ public class PartitionContext implements AutoCloseable {
     private final PartitionStateMetrics metrics;
 
     // The offset committed successfully at last commit
-    private long lastCommittedOffset;
+    private volatile long lastCommittedOffset;
     private volatile long pausedTimeNanos;
     private long lastQueueStarvedTime;
     /**
@@ -55,7 +55,7 @@ public class PartitionContext implements AutoCloseable {
     @Getter
     @Setter
     private boolean revoking;
-    private long latestConsumedOffset;
+    private volatile long latestConsumedOffset;
 
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
@@ -136,7 +136,7 @@ public class PartitionContext implements AutoCloseable {
     }
 
     public OffsetState registerOffset(long offset) {
-        latestConsumedOffset = Math.max(latestConsumedOffset, offset);
+        latestConsumedOffset = offset;
         return commitControl.reportFetchedOffset(offset);
     }
 


### PR DESCRIPTION
Motivation:

We can detect `DeferredCompletion ` leak by monitoring `latest consumed offset - last committed offset < max.pending.record`.
Therefore, we need to add these metrics.

Modifications:

- Add the following metrics
  - `decaton.offset.last.committed` 
  - `decaton.offset.latest.consumed`

Result:

- Closes #39
- Users can monitor `DeferredCompletion` leak