### PR TITLE
Narrow down the scope of waiting for pending tasks to per partition

### DIFF
--- a/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.processor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.decaton.client.DecatonClient;
+import com.linecorp.decaton.processor.internal.HashableByteArray;
+import com.linecorp.decaton.processor.runtime.DynamicProperty;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.ProcessorSubscription;
+import com.linecorp.decaton.processor.runtime.ProcessorsBuilder;
+import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
+import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
+import com.linecorp.decaton.protocol.Sample.HelloTask;
+import com.linecorp.decaton.testing.KafkaClusterRule;
+import com.linecorp.decaton.testing.TestUtils;
+
+public class PropertyReloadRequestTest {
+
+    @ClassRule
+    public static KafkaClusterRule rule = new KafkaClusterRule();
+
+    private String topicName;
+
+    @Before
+    public void setUp() {
+        topicName = rule.admin().createRandomTopic(3, 3);
+    }
+
+    @After
+    public void tearDown() {
+        rule.admin().deleteTopics(true, topicName);
+    }
+
+    @Test(timeout = 30000)
+    public void testPropertyDynamicSwitch() throws Exception {
+        Set<String> keys = new HashSet<>();
+
+        for (int i = 0; i < 10000; i++) {
+            keys.add("key" + i);
+        }
+        Set<HashableByteArray> processedKeys = Collections.synchronizedSet(new HashSet<>());
+        CountDownLatch processLatch = new CountDownLatch(keys.size());
+
+        DecatonProcessor<HelloTask> processor = (context, task) -> {
+            processedKeys.add(new HashableByteArray(context.key()));
+            processLatch.countDown();
+        };
+
+        DynamicProperty<Integer> concurrencyProp =
+                new DynamicProperty<>(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY);
+        concurrencyProp.set(1);
+        try (ProcessorSubscription subscription = TestUtils.subscription(
+                rule.bootstrapServers(),
+                builder -> builder.processorsBuilder(ProcessorsBuilder
+                                                             .consuming(topicName,
+                                                                        new ProtocolBuffersDeserializer<>(
+                                                                                HelloTask.parser()))
+                                                             .thenProcess(processor))
+                                  .addProperties(StaticPropertySupplier.of(concurrencyProp)));
+             DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
+
+            int count = 0;
+            for (String key : keys) {
+                count++;
+                if (count == 1000) {
+                    TimeUnit.SECONDS.sleep(1);
+                    concurrencyProp.set(3);
+                } else if (count == 5000) {
+                    TimeUnit.SECONDS.sleep(1);
+                    concurrencyProp.set(1);
+                } else if (count == 7500) {
+                    TimeUnit.SECONDS.sleep(1);
+                    concurrencyProp.set(5);
+                }
+                client.put(key, HelloTask.getDefaultInstance());
+            }
+            processLatch.await();
+        }
+
+        assertEquals(10000, processedKeys.size());
+    }
+}

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -74,7 +74,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                            && (long) v <= RateLimiter.MAX_RATE);
     /**
      * Concurrency used to process tasks coming from single partition.
-     * Reloading this property will pause all assigned partitions until current pending tasks have done.
+     * Reloading this property will be performed for each assigned partition as soon as
+     * the current pending tasks of the assigned partition have done.
      *
      * Reloadable: yes
      */

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -56,6 +56,14 @@ public class PartitionContext implements AutoCloseable {
     @Setter
     private boolean revoking;
 
+    /**
+     * Indicates that if true, reloading is requested and not completed.
+     * This is used to perform reloading processing for each partition.
+     */
+    @Getter
+    @Setter
+    private boolean reloadState;
+
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
         this.processors = processors;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -62,7 +62,7 @@ public class PartitionContext implements AutoCloseable {
      */
     @Getter
     @Setter
-    private boolean reloadState;
+    private volatile boolean reloadRequested;
 
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -56,6 +56,9 @@ public class PartitionContext implements AutoCloseable {
     @Setter
     private boolean revoking;
 
+    @Getter
+    private boolean reloading;
+
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
         this.processors = processors;
@@ -155,6 +158,13 @@ public class PartitionContext implements AutoCloseable {
         long pausedNanos = System.nanoTime() - pausedTimeNanos;
         pausedTimeNanos = -1;
         metrics.partitionPausedTime.record(pausedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void reloading(boolean reloading) {
+        this.reloading = reloading;
+        if (reloading) {
+            pause();
+        }
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -56,9 +56,6 @@ public class PartitionContext implements AutoCloseable {
     @Setter
     private boolean revoking;
 
-    @Getter
-    private boolean reloading;
-
     public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
         this.scope = scope;
         this.processors = processors;
@@ -158,13 +155,6 @@ public class PartitionContext implements AutoCloseable {
         long pausedNanos = System.nanoTime() - pausedTimeNanos;
         pausedTimeNanos = -1;
         metrics.partitionPausedTime.record(pausedNanos, TimeUnit.NANOSECONDS);
-    }
-
-    public void reloading(boolean reloading) {
-        this.reloading = reloading;
-        if (reloading) {
-            pause();
-        }
     }
 
     @Override

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
@@ -22,17 +22,12 @@ import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -289,7 +284,7 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
                     .filter(entry -> entry.getValue().reloadRequested()
                                      && entry.getValue().pendingTasksCount() == 0)
                     .map(Entry::getKey)
-                    .collect(Collectors.toList());
+                    .collect(toList());
             if (reloadableTopicPartitions.isEmpty()) {
                 return;
             }
@@ -307,13 +302,13 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
     }
 
     private void reloadContexts(Collection<TopicPartition> topicPartitions) {
-        logger.info("Start dropping partition context({})", topicPartitions);
+        logger.info("Start dropping partition contexts({})", topicPartitions);
         removePartition(topicPartitions);
         logger.info("Finished dropping partition contexts. Start recreating partition contexts");
         Map<TopicPartition, AssignmentConfig> configs = topicPartitions.stream().collect(
                 toMap(Function.identity(), tp -> new AssignmentConfig(true)));
         addPartitions(configs);
-        logger.info("Completed reloading property");
+        logger.info("Completed reloading partition contexts({})", topicPartitions);
     }
 
     private void destroyProcessors(Collection<TopicPartition> partitions) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContexts.java
@@ -81,10 +81,9 @@ public class PartitionContexts implements OffsetsStore, AssignmentStore, Partiti
 
             lock.lock();
             try {
-                if (!reloadRequested.getAndSet(true)) {
-                    reloadStates.replaceAll((t, v) -> true);
-                    logger.info("Requested reload partition.concurrency oldValue={}, newValue={}", oldVal, newVal);
-                }
+                reloadRequested.set(true);
+                reloadStates.replaceAll((t, v) -> true);
+                logger.info("Requested reload partition.concurrency oldValue={}, newValue={}", oldVal, newVal);
             } finally {
                 lock.unlock();
             }

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/PartitionContextsTest.java
@@ -162,27 +162,27 @@ public class PartitionContextsTest {
 
         doReturn(0).when(cts.get(0)).pendingTasksCount();
         doReturn(0).when(cts.get(1)).pendingTasksCount();
-        doReturn(false).when(cts.get(0)).reloadState();
-        doReturn(false).when(cts.get(1)).reloadState();
+        doReturn(false).when(cts.get(0)).reloadRequested();
+        doReturn(false).when(cts.get(1)).reloadRequested();
 
         Collection<TopicPartition> needPause = contexts.partitionsNeedsPause();
         assertTrue(needPause.isEmpty());
 
         // Pause all partitions by reloading
         partitionConcurrencyProperty.set(42);
-        doReturn(true).when(cts.get(0)).reloadState();
-        doReturn(true).when(cts.get(1)).reloadState();
+        doReturn(true).when(cts.get(0)).reloadRequested();
+        doReturn(true).when(cts.get(1)).reloadRequested();
         needPause = contexts.partitionsNeedsPause();
         assertEquals(2, needPause.size());
 
         // Resume 1 partition by finishing reloading
-        doReturn(false).when(cts.get(0)).reloadState();
+        doReturn(false).when(cts.get(0)).reloadRequested();
         needPause = contexts.partitionsNeedsPause();
         assertEquals(1, needPause.size());
         assertEquals(cts.get(1).topicPartition(), needPause.iterator().next());
 
         // Resume all partitions by finishing reloading
-        doReturn(false).when(cts.get(1)).reloadState();
+        doReturn(false).when(cts.get(1)).reloadRequested();
         needPause = contexts.partitionsNeedsPause();
         assertTrue(needPause.isEmpty());
 
@@ -307,14 +307,14 @@ public class PartitionContextsTest {
 
         partitionConcurrencyProperty.set(42);
         for (PartitionContext context: allContexts) {
-            doReturn(true).when(context).reloadState();
+            doReturn(true).when(context).reloadRequested();
         }
         contexts.maybeHandlePropertyReload();
 
         // property reload is requested, but there are pending tasks
         verify(contexts, times(reloadableContexts.size())).instantiateContext(any());
         for (PartitionContext context: reloadableContexts) {
-            doReturn(false).when(context).reloadState();
+            doReturn(false).when(context).reloadRequested();
         }
 
         for (PartitionContext context: pendingContexts) {


### PR DESCRIPTION
Motivation:

Described in https://github.com/line/decaton/issues/172

Modifications:

- Reload context per partition when reloading is requested

Result:

- Closes #172 
- Reduces time to resume processing when dynamic property reloaded 