### PR TITLE
Introduce a timeout for destroying processors

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -29,7 +29,6 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.runtime.internal.AbstractDecatonProperties;
 import com.linecorp.decaton.processor.runtime.internal.OutOfOrderCommitControl;
-import com.linecorp.decaton.processor.runtime.internal.PartitionProcessor;
 import com.linecorp.decaton.processor.runtime.internal.RateLimiter;
 
 /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -29,6 +29,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.ProcessingContext;
 import com.linecorp.decaton.processor.runtime.internal.AbstractDecatonProperties;
 import com.linecorp.decaton.processor.runtime.internal.OutOfOrderCommitControl;
+import com.linecorp.decaton.processor.runtime.internal.PartitionProcessor;
 import com.linecorp.decaton.processor.runtime.internal.RateLimiter;
 
 /**
@@ -179,6 +180,19 @@ public class ProcessorProperties extends AbstractDecatonProperties {
             PropertyDefinition.define("decaton.deferred.complete.timeout.ms", Long.class, -1L,
                                       v -> v instanceof Long);
 
+    /**
+     * Timeout for destroying processors.
+     * When {@link PartitionProcessor#close()} is called, all processors will be destroyed.
+     * At this time, Decaton waits synchronously for the running tasks to finish until this timeout.
+     * If it is not a problem not to wait for task completion, it is recommended to set this timeout,
+     * since this task termination doesn't affect offsets.
+     *
+     * Reloadable: yes
+     */
+    public static final PropertyDefinition<Long> CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS =
+            PropertyDefinition.define("decaton.destroy.processor.timeout.ms", Long.class, 1000L,
+                                      v -> v instanceof Long && (Long) v >= 0);
+
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
             Collections.unmodifiableList(Arrays.asList(
                     CONFIG_IGNORE_KEYS,
@@ -190,7 +204,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_SHUTDOWN_TIMEOUT_MS,
                     CONFIG_LOGGING_MDC_ENABLED,
                     CONFIG_BIND_CLIENT_METRICS,
-                    CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS));
+                    CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS,
+                    CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -182,15 +182,18 @@ public class ProcessorProperties extends AbstractDecatonProperties {
 
     /**
      * Timeout for destroying processors.
-     * When {@link PartitionProcessor#close()} is called, all processors will be destroyed.
+     * When a partition is revoked for rebalance or a subscription is about to be shutdown,
+     * all processors will be destroyed.
      * At this time, Decaton waits synchronously for the running tasks to finish until this timeout.
-     * If it is not a problem not to wait for task completion, it is recommended to set this timeout,
-     * since this task termination doesn't affect offsets.
+     *
+     * Even if timeout occurs, Decaton will continue other clean-up tasks.
+     * Therefore, you can set this timeout only if unexpected behavior is acceptable in the middle of the last
+     * {@link DecatonProcessor#process(ProcessingContext, Object)} which timed out.
      *
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS =
-            PropertyDefinition.define("decaton.destroy.processor.timeout.ms", Long.class, 1000L,
+            PropertyDefinition.define("decaton.destroy.processor.timeout.ms", Long.class, Long.MAX_VALUE,
                                       v -> v instanceof Long && (Long) v >= 0);
 
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -181,7 +181,7 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Long);
 
     /**
-     * Timeout for destroying processors.
+     * Timeout for processor threads termination.
      * When a partition is revoked for rebalance or a subscription is about to be shutdown,
      * all processors will be destroyed.
      * At this time, Decaton waits synchronously for the running tasks to finish until this timeout.
@@ -192,9 +192,9 @@ public class ProcessorProperties extends AbstractDecatonProperties {
      *
      * Reloadable: yes
      */
-    public static final PropertyDefinition<Long> CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS =
-            PropertyDefinition.define("decaton.destroy.processor.timeout.ms", Long.class, Long.MAX_VALUE,
-                                      v -> v instanceof Long && (Long) v >= 0);
+    public static final PropertyDefinition<Long> CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS =
+            PropertyDefinition.define("decaton.processor.threads.termination.timeout.ms", Long.class,
+                                      Long.MAX_VALUE, v -> v instanceof Long && (Long) v >= 0);
 
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
             Collections.unmodifiableList(Arrays.asList(
@@ -208,7 +208,7 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_LOGGING_MDC_ENABLED,
                     CONFIG_BIND_CLIENT_METRICS,
                     CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS,
-                    CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS));
+                    CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
@@ -179,7 +179,7 @@ public class PartitionProcessor implements AsyncShutdownable {
         try {
             awaitShutdown(Duration.ofMillis(destroyingTimeoutMillis.value()));
         } catch (TimeoutException e) {
-            // impossible
+            logger.warn("awaitShutdown failed due to timeout in {} ms", destroyingTimeoutMillis.value(), e);
         }
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
+import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS;
 import static java.util.stream.Collectors.toList;
 
 import java.time.Duration;
@@ -24,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
 import org.apache.kafka.common.TopicPartition;
@@ -34,6 +37,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.runtime.AsyncShutdownable;
 import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.metrics.Metrics;
+import com.linecorp.decaton.processor.runtime.Property;
 import com.linecorp.decaton.processor.runtime.internal.Utils.Task;
 
 /**
@@ -59,6 +63,8 @@ public class PartitionProcessor implements AsyncShutdownable {
     private final RateLimiter rateLimiter;
 
     private final CompletionStage<Void> shutdownFuture;
+
+    private final Property<Long> destroyingTimeoutMillis;
 
     private Task destroyThreadProcessorTask(int i) {
         return () -> processors.destroyThreadScope(scope.subscriptionId(), scope.topicPartition(), i);
@@ -104,6 +110,7 @@ public class PartitionProcessor implements AsyncShutdownable {
         units = new ArrayList<>(concurrency);
         subPartitioner = new SubPartitioner(concurrency);
         rateLimiter = new DynamicRateLimiter(scope.props().get(ProcessorProperties.CONFIG_PROCESSING_RATE));
+        destroyingTimeoutMillis = scope.props().get(CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS);
 
         try {
             for (int i = 0; i < concurrency; i++) {
@@ -165,5 +172,14 @@ public class PartitionProcessor implements AsyncShutdownable {
     @Override
     public CompletionStage<Void> shutdownFuture() {
         return shutdownFuture;
+    }
+
+    @Override
+    public void awaitShutdown() throws InterruptedException, ExecutionException {
+        try {
+            awaitShutdown(Duration.ofMillis(destroyingTimeoutMillis.value()));
+        } catch (TimeoutException e) {
+            // impossible
+        }
     }
 }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionProcessor.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
-import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_DESTROY_PROCESSOR_TIMEOUT_MS;
 import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS;
 import static java.util.stream.Collectors.toList;
 


### PR DESCRIPTION
Motivation:

Described in https://github.com/line/decaton/issues/119

Modifications:

- Add timeout for destroying processors
- Set timeout to `PartitionProcessor#awaitShutdown`

Result:

- Closes #119
- `PartitionProcessor#awaitShutdown` waits up to 1000 ms by default
- Users can easily set this timeout

