### PR TITLE
Handle RebalanceInProgressException on sync commit fixes #201

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.TimeoutException;
 
 import com.linecorp.decaton.processor.metrics.Metrics;
@@ -80,7 +81,7 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
             waitForRemainingTasksCompletion(rebalanceTimeoutMillis.value());
             try {
                 commitManager.commitSync();
-            } catch (CommitFailedException | TimeoutException e) {
+            } catch (CommitFailedException | TimeoutException | RebalanceInProgressException e) {
                 log.warn("Offset commit failed at group rebalance", e);
             }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java
@@ -83,6 +83,12 @@ public class ProcessorSubscription extends Thread implements AsyncShutdownable {
                 commitManager.commitSync();
             } catch (CommitFailedException | TimeoutException | RebalanceInProgressException e) {
                 log.warn("Offset commit failed at group rebalance", e);
+            } catch (RuntimeException e) {
+                // Even when offset commit failed due to unknown reason,
+                // we just log error here and don't kill the subscription because
+                // we suppose the only problem to do so is more task-duplications after the rebalance,
+                // which is not considered as fatal in at-least-once processing Decaton guarantees.
+                log.error("Offset commit failed at group rebalance by unexpected reason", e);
             }
 
             contexts.markRevoking(revokingPartitions);

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -53,6 +53,7 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -64,6 +65,7 @@ import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.DeferredCompletion;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.SubscriptionStateListener.State;
+import com.linecorp.decaton.processor.runtime.internal.AbstractDecatonProperties.Builder;
 import com.linecorp.decaton.processor.runtime.internal.ConsumerSupplier;
 import com.linecorp.decaton.processor.runtime.internal.SubscriptionScope;
 import com.linecorp.decaton.processor.tracing.internal.NoopTracingProvider;
@@ -99,12 +101,24 @@ public class ProcessorSubscriptionTest {
     }
 
     private static SubscriptionScope scope(String topic, long waitForProcessingOnClose) {
+        return scope(topic, waitForProcessingOnClose, null);
+    }
+
+    private static SubscriptionScope scope(String topic,
+                                           long waitForProcessingOnClose,
+                                           PropertySupplier additionalProps) {
+        Builder<ProcessorProperties> propertiesBuilder = ProcessorProperties
+                .builder()
+                .set(Property.ofStatic(
+                        ProcessorProperties.CONFIG_SHUTDOWN_TIMEOUT_MS,
+                        waitForProcessingOnClose));
+        if (additionalProps != null) {
+            propertiesBuilder.setBySupplier(additionalProps);
+        }
         return new SubscriptionScope(
                 "subscription",
                 topic,
-                Optional.empty(),
-                ProcessorProperties.builder().set(Property.ofStatic(
-                        ProcessorProperties.CONFIG_SHUTDOWN_TIMEOUT_MS, waitForProcessingOnClose)).build(),
+                Optional.empty(), propertiesBuilder.build(),
                 NoopTracingProvider.INSTANCE,
                 ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS,
                 DefaultSubPartitioner::new);
@@ -289,5 +303,69 @@ public class ProcessorSubscriptionTest {
         // The main point is that the below close returns within timeout.
         subscription.close();
         verify(consumer).close();
+    }
+
+    @Test(timeout = 10000L)
+    public void testCommitFailureOnPartitionRevocation() throws Exception {
+        TopicPartition tp = new TopicPartition("topic", 0);
+
+        CountDownLatch subscribed = new CountDownLatch(1);
+        CountDownLatch taskCompleted = new CountDownLatch(1);
+        CountDownLatch pollAfterRebalance = new CountDownLatch(1);
+        DecatonMockConsumer consumer = new DecatonMockConsumer() {
+            @Override
+            public synchronized void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+                super.subscribe(topics, listener);
+                subscribed.countDown();
+            }
+
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                throw new RebalanceInProgressException();
+            }
+        };
+        consumer.updateEndOffsets(singletonMap(tp, 10L));
+        // disable periodic async commit and wait remaining task completion forever for stable test
+        SubscriptionScope scope = scope(tp.topic(), 0L,
+                                        StaticPropertySupplier.of(
+                                                Property.ofStatic(ProcessorProperties.CONFIG_COMMIT_INTERVAL_MS, Long.MAX_VALUE),
+                                                Property.ofStatic(ProcessorProperties.CONFIG_GROUP_REBALANCE_TIMEOUT_MS, Long.MAX_VALUE)
+                                        ));
+        final ProcessorSubscription subscription = new ProcessorSubscription(
+                scope,
+                () -> consumer,
+                ProcessorsBuilder.consuming(scope.topic(),
+                                            (byte[] bytes) -> new DecatonTask<>(
+                                                    TaskMetadata.builder().build(), "dummy", bytes))
+                                 .thenProcess((ctx, task) -> {
+                                     ctx.deferCompletion().complete();
+                                     taskCompleted.countDown();
+                                 })
+                                 .build(null),
+                scope.props(),
+                null);
+        subscription.start();
+        subscribed.await();
+
+        consumer.rebalance(singleton(tp));
+        consumer.addRecord(new ConsumerRecord<>(tp.topic(), tp.partition(), 10, new byte[0], NO_DATA));
+
+        // records will be returned by this poll
+        consumer.schedulePollTask(() -> consumer.rebalanceListener.onPartitionsAssigned(singleton(tp)));
+        consumer.schedulePollTask(() -> {
+            try {
+                // after a task is completed (i.e. it will be committed after updating watermark),
+                // invoke the rebalance listener to cause commitSync
+                taskCompleted.await();
+                consumer.rebalanceListener.onPartitionsRevoked(consumer.assignment());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // If the subscription isn't killed, this poll should be called
+        consumer.schedulePollTask(pollAfterRebalance::countDown);
+
+        pollAfterRebalance.await();
+        subscription.close();
     }
 }

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -348,10 +348,13 @@ public class ProcessorSubscriptionTest {
         subscribed.await();
 
         consumer.rebalance(singleton(tp));
-        consumer.addRecord(new ConsumerRecord<>(tp.topic(), tp.partition(), 10, new byte[0], NO_DATA));
 
+        consumer.schedulePollTask(() -> {
+            consumer.rebalanceListener.onPartitionsAssigned(singleton(tp));
+            consumer.addRecord(new ConsumerRecord<>(tp.topic(), tp.partition(), 10, new byte[0], NO_DATA));
+        });
         // records will be returned by this poll
-        consumer.schedulePollTask(() -> consumer.rebalanceListener.onPartitionsAssigned(singleton(tp)));
+        consumer.scheduleNopPollTask();
         consumer.schedulePollTask(() -> {
             try {
                 // after a task is completed (i.e. it will be committed after updating watermark),


### PR DESCRIPTION
- As described in the issue, RebalanceInProgressException also could be thrown on commitSync, which should not be treated as fatal