### PR TITLE
Use SubscriptionBuilder.properties() to set property supplier

### DIFF
--- a/docs/dynamic-property-configuration.adoc
+++ b/docs/dynamic-property-configuration.adoc
@@ -47,7 +47,7 @@ ProcessorSubscription testProcessor =
                            .consumerConfig(consumerConfig)
                            .buildAndStart();
 ----
-<1> When you instantiate the `ProcessorSubscription`, use `SubscriptionBuilder.properties()` to set your property supplier.
+<1> When you instantiate the `ProcessorSubscription`, use `SubscriptionBuilder#properties` to set your property supplier.
 
 The following is the full example that demonstrates how to use `CentralDogmaPropertySupplier`:
 [source,java]


### PR DESCRIPTION
When user instantiates `ProcessorSubscription` using `SubscriptionBuilder`, it seems appropriate to use `SubscriptionBuilder.properties()` to set property supplier, rather than using `props.setBySupplier()` directly.