### PR TITLE
Make `max.pending.records` property reloadable

### DIFF
--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierTest.java
@@ -167,7 +167,7 @@ public class CentralDogmaPropertySupplierTest {
 
         CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
         verify(centralDogmaRepository).commit(
-                any(String.class),
+                anyString(),
                 eq(Change.ofJsonUpsert(FILENAME, defaultPropertiesAsJsonNode()))
         );
     }
@@ -212,13 +212,13 @@ public class CentralDogmaPropertySupplierTest {
         when(filesRequest.list(Revision.HEAD)).thenReturn(CompletableFuture.completedFuture(Collections.emptyMap()));
 
         final CommitRequest commitRequest = mock(CommitRequest.class);
-        when(centralDogmaRepository.commit(any(String.class), eq(Change.ofJsonUpsert(FILENAME, jsonNodeProperties)))).thenReturn(commitRequest);
+        when(centralDogmaRepository.commit(anyString(), eq(Change.ofJsonUpsert(FILENAME, jsonNodeProperties)))).thenReturn(commitRequest);
         when(commitRequest.push(Revision.HEAD)).thenReturn(CompletableFuture.completedFuture(new PushResult(Revision.HEAD, whenCentralDogmaPushed)));
 
         CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME, supplier);
 
         verify(centralDogmaRepository).commit(
-                any(String.class),
+                anyString(),
                 eq(Change.ofJsonUpsert(FILENAME, jsonNodeProperties))
         );
     }

--- a/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
@@ -76,6 +76,11 @@ public class PropertyReloadRequestTest {
         DynamicProperty<Integer> concurrencyProp =
                 new DynamicProperty<>(ProcessorProperties.CONFIG_PARTITION_CONCURRENCY);
         concurrencyProp.set(1);
+
+        DynamicProperty<Integer> recordsProp =
+                new DynamicProperty<>(ProcessorProperties.CONFIG_MAX_PENDING_RECORDS);
+        recordsProp.set(10);
+
         try (ProcessorSubscription subscription = TestUtils.subscription(
                 rule.bootstrapServers(),
                 builder -> builder.processorsBuilder(ProcessorsBuilder
@@ -83,7 +88,8 @@ public class PropertyReloadRequestTest {
                                                                         new ProtocolBuffersDeserializer<>(
                                                                                 HelloTask.parser()))
                                                              .thenProcess(processor))
-                                  .addProperties(StaticPropertySupplier.of(concurrencyProp)));
+                                  .addProperties(StaticPropertySupplier.of(concurrencyProp),
+                                                 StaticPropertySupplier.of(recordsProp)));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 
             int count = 0;
@@ -92,12 +98,19 @@ public class PropertyReloadRequestTest {
                 if (count == 1000) {
                     TimeUnit.SECONDS.sleep(1);
                     concurrencyProp.set(3);
+                } else if (count == 3000) {
+                    TimeUnit.SECONDS.sleep(1);
+                    recordsProp.set(20);
                 } else if (count == 5000) {
                     TimeUnit.SECONDS.sleep(1);
                     concurrencyProp.set(1);
+                    recordsProp.set(5);
                 } else if (count == 7500) {
                     TimeUnit.SECONDS.sleep(1);
                     concurrencyProp.set(5);
+                } else if (count == 9000) {
+                    TimeUnit.SECONDS.sleep(1);
+                    recordsProp.set(15);
                 }
                 client.put(key, HelloTask.getDefaultInstance());
             }

--- a/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/PropertyReloadRequestTest.java
@@ -88,8 +88,7 @@ public class PropertyReloadRequestTest {
                                                                         new ProtocolBuffersDeserializer<>(
                                                                                 HelloTask.parser()))
                                                              .thenProcess(processor))
-                                  .addProperties(StaticPropertySupplier.of(concurrencyProp),
-                                                 StaticPropertySupplier.of(recordsProp)));
+                                  .addProperties(StaticPropertySupplier.of(concurrencyProp, recordsProp)));
              DecatonClient<HelloTask> client = TestUtils.client(topicName, rule.bootstrapServers())) {
 
             int count = 0;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -33,20 +33,22 @@ import com.linecorp.decaton.processor.runtime.internal.RateLimiter;
 
 /**
  * Collection of properties that can be configured to adjust {@link DecatonProcessor}'s behavior.
- *
- * Description of each attributes:
- * - Reloadable : Whether update on the property can be applied to running instance without restarting it.
- *                Note that for properties enabled for this attribute, updating its value may take certain
- *                latency.
+ * <p>
+ * Description of each attribute:
+ * <ul>
+ * <li>Reloadable: Whether update on the property can be applied to running instance without restarting it.
+ *                 Note that for properties enabled for this attribute, updating its value may take certain
+ *                 latency.</li>
+ * </ul>
  */
 public class ProcessorProperties extends AbstractDecatonProperties {
     /**
      * List of keys of task to skip processing.
-     *
+     * <p>
      * Note that this property accepts only String keys, while Decaton consumer supports consuming
      * keys of arbitrary type. This means that records with non-String keys may just pass through
      * this filter.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<List<String>> CONFIG_IGNORE_KEYS =
@@ -54,16 +56,18 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       PropertyDefinition.checkListElement(String.class));
     /**
      * Maximum rate of processing tasks per-partition in second.
-     *
-     * If the value N is
-     *   - (0, 1,000,000]: Do the best to process tasks as much as N per second.
-     *       N may not be kept well if a task takes over a second to process or N is greater than
-     *       actual throughput per second.
-     *   -  0: Stop all processing but the task currently being processed isn`t interrupted
-     *   - -1: Unlimited
-     *
+     * <p>
+     * If the value N is:
+     * <ul>
+     * <li>(0, 1,000,000]: Do the best to process tasks as much as N per second.
+     *     N may not be kept well if a task takes over a second to process or N is greater than
+     *     actual throughput per second.</li>
+     * <li>0: Stop all processing but the task currently being processed isn`t interrupted</li>
+     * <li>-1: Unlimited</li>
+     * </ul>
+     * <p>
      * See also {@link RateLimiter}.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_PROCESSING_RATE =
@@ -74,9 +78,10 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                            && (long) v <= RateLimiter.MAX_RATE);
     /**
      * Concurrency used to process tasks coming from single partition.
+     * <p>
      * Reloading this property will be performed for each assigned partition as soon as
      * the current pending tasks of the assigned partition have done.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Integer> CONFIG_PARTITION_CONCURRENCY =
@@ -84,17 +89,21 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Integer && (Integer) v > 0);
     /**
      * Number of records to pause source partition if pending count exceeds this number.
-     *
-     * Reloadable: no
+     * <p>
+     * Reloading this property will be performed for each assigned partition as soon as
+     * the current pending tasks of the assigned partition have done.
+     * <p>
+     * Reloadable: yes
      */
     public static final PropertyDefinition<Integer> CONFIG_MAX_PENDING_RECORDS =
             PropertyDefinition.define("decaton.max.pending.records", Integer.class, 10_000,
                                       v -> v instanceof Integer && (Integer) v > 0);
     /**
      * Interval in milliseconds to put in between offset commits.
-     * Too frequent offset commit would cause high load on brokers while it doesn't essentially prevents
+     * <p>
+     * Too frequent offset commit would cause high load on brokers while it doesn't essentially prevent
      * duplicate processing.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_COMMIT_INTERVAL_MS =
@@ -102,16 +111,19 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Long && (Long) v >= 0);
     /**
      * Timeout for consumer group rebalance.
+     * <p>
      * Decaton waits up to this time for tasks currently pending or in-progress to finish before allowing a
      * rebalance to proceed.
+     * <p>
      * Any tasks that do not complete within this timeout will not have their offsets committed before the
      * rebalance, meaning they may be processed multiple times (as they will be processed again after the
      * rebalance). If {@link #CONFIG_PARTITION_CONCURRENCY} is greater than 1, this situation might also cause
      * other records from the same partition to be processed multiple times (see
      * {@link OutOfOrderCommitControl}).
+     * <p>
      * Generally, this should be set such that {@link #CONFIG_MAX_PENDING_RECORDS} can be comfortably processed
      * within this timeout.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_GROUP_REBALANCE_TIMEOUT_MS =
@@ -124,9 +136,10 @@ public class ProcessorProperties extends AbstractDecatonProperties {
      * still be running even after {@link ProcessorSubscription#close()} returns, which might lead to errors
      * from e.g. shutting down dependencies of this {@link ProcessorSubscription} that are still in use from
      * async tasks.
+     * <p>
      * Generally, this should be set such that {@link #CONFIG_MAX_PENDING_RECORDS} can be comfortably processed
      * within this timeout.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_SHUTDOWN_TIMEOUT_MS =
@@ -134,11 +147,11 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Long && (Long) v >= 0);
 
     /**
-     * Control whether to enable or disable decaton specific information store in slf4j's {@link MDC}.
+     * Control whether to enable or disable decaton specific information store in SLF4J's {@link MDC}.
      * This option is enabled by default, but it is known to cause some object allocations which could become
      * a problem in massive scale traffic. This option intend to provide an option for users to disable MDC
      * properties where not necessary to reduce GC pressure.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Boolean> CONFIG_LOGGING_MDC_ENABLED =
@@ -146,9 +159,9 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Boolean);
     /**
      * Controls whether to enable or disable binding Micrometer's KafkaClientMetrics to decaton consumers.
-     * This is disabled for backwards compatiblity, but recommended if you rely on Micrometer
+     * This is disabled for backwards compatibility, but recommended if you rely on Micrometer
      * since JMX metrics are deprecated. The downside is a possible increase in metrics count.
-     *
+     * <p>
      * Reloadable: no
      */
     public static final PropertyDefinition<Boolean> CONFIG_BIND_CLIENT_METRICS =
@@ -156,24 +169,26 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       v -> v instanceof Boolean);
     /**
      * Control time to "timeout" a deferred completion.
+     * <p>
      * Decaton allows {@link DecatonProcessor}s to defer completion of a task by calling
      * {@link ProcessingContext#deferCompletion()}, which is useful for processors which integrates with
      * asynchronous processing frameworks that sends the processing context to somewhere else and get back
      * later.
+     * <p>
      * However, since leaking {@link Completion} returned by {@link ProcessingContext#deferCompletion()} means
      * to create a never-completed task, that causes consumption to suck completely after
      * {@link #CONFIG_MAX_PENDING_RECORDS} records stacked up, which is not desirable for some use cases.
-     *
+     * <p>
      * By setting this timeout, Decaton will try to "timeout" a deferred completion after the specified period.
      * By setting the timeout to sufficiently large value, which you can be sure that none of normal processing
      * to take, some potentially leaked completion will be forcefully completed and decaton can continue to
      * consume the following tasks.
-     *
-     * Be very careful when using this feature since forcefully completing a timed out completion might leads
-     * you some data loss if the corresponding processing hasn't yet complete.
-     *
+     * <p>
+     * Be very careful when using this feature since forcefully completing a timed out completion might lead
+     * to some data loss if the corresponding processing hasn't yet complete.
+     * <p>
      * This timeout can be disabled by setting -1, and it is the default.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS =
@@ -194,14 +209,15 @@ public class ProcessorProperties extends AbstractDecatonProperties {
 
     /**
      * Timeout for processor threads termination.
+     * <p>
      * When a partition is revoked for rebalance or a subscription is about to be shutdown,
      * all processors will be destroyed.
      * At this time, Decaton waits synchronously for the running tasks to finish until this timeout.
-     *
+     * <p>
      * Even if timeout occurs, Decaton will continue other clean-up tasks.
      * Therefore, you can set this timeout only if unexpected behavior is acceptable in the middle of the last
      * {@link DecatonProcessor#process(ProcessingContext, Object)} which timed out.
-     *
+     * <p>
      * Reloadable: yes
      */
     public static final PropertyDefinition<Long> CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS =

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -69,20 +69,20 @@ public class PartitionContext implements AutoCloseable {
     @Setter
     private volatile boolean reloadRequested;
 
-    public PartitionContext(PartitionScope scope, Processors<?> processors, int maxPendingRecords) {
-        this(scope, processors, new PartitionProcessor(scope, processors), maxPendingRecords);
+    public PartitionContext(PartitionScope scope, Processors<?> processors) {
+        this(scope, processors, new PartitionProcessor(scope, processors));
     }
 
     // visible for testing
     PartitionContext(PartitionScope scope,
                      Processors<?> processors,
-                     PartitionProcessor partitionProcessor,
-                     int maxPendingRecords) {
+                     PartitionProcessor partitionProcessor) {
         this.scope = scope;
         this.processors = processors;
         this.partitionProcessor = partitionProcessor;
 
-        int capacity = maxPendingRecords + scope.maxPollRecords();
+        int capacity = scope.props().get(ProcessorProperties.CONFIG_MAX_PENDING_RECORDS).value() +
+                       scope.maxPollRecords();
         TopicPartition tp = scope.topicPartition();
         Metrics metricsCtor = Metrics.withTags("subscription", scope.subscriptionId(),
                                                "topic", tp.topic(),
@@ -107,7 +107,7 @@ public class PartitionContext implements AutoCloseable {
 
     /**
      * Returns the largest offset waiting to be committed, if exists.
-     *
+     * <p>
      * It returns non-empty value with offset which is larger than the offset
      * reported last by {@link #updateCommittedOffset(long)}.
      *

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -21,6 +21,8 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -183,7 +185,7 @@ public class ProcessorSubscriptionTest {
         doAnswer(invocation -> {
             listener.set(invocation.getArgument(1));
             return null;
-        }).when(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        }).when(consumer).subscribe(anyCollection(), any(ConsumerRebalanceListener.class));
 
         BlockingQueue<Long> feedOffsets = new ArrayBlockingQueue<>(4);
         feedOffsets.add(100L);
@@ -203,8 +205,8 @@ public class ProcessorSubscriptionTest {
             committedOffsets.putAll(invocation.getArgument(0));
             return null;
         };
-        doAnswer(storeCommitOffsets).when(consumer).commitSync(any(Map.class));
-        doAnswer(storeCommitOffsets).when(consumer).commitAsync(any(Map.class), any());
+        doAnswer(storeCommitOffsets).when(consumer).commitSync(anyMap());
+        doAnswer(storeCommitOffsets).when(consumer).commitAsync(anyMap(), any());
 
         AtomicBoolean first = new AtomicBoolean();
         doAnswer(invocation -> {

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ConsumeManagerTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
@@ -29,7 +30,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -85,7 +85,7 @@ public class ConsumeManagerTest {
         doAnswer(invocation -> {
             rebalanceListener = invocation.getArgument(1);
             return null;
-        }).when(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        }).when(consumer).subscribe(anyCollection(), any(ConsumerRebalanceListener.class));
         consumeManager.init(singletonList(TOPIC));
     }
 


### PR DESCRIPTION
This PR updates `PartitionContexts` so the `max.pending.records` property can be reloaded at runtime, similar to the `partition.concurrency` property.

Modifications:
- Extract reload listener in `PartitionContexts` and register it for `CONFIG_MAX_PENDING_RECORDS`
- `PartitionContext` now reads the property value from `PartitionScope`
- Cleanup `ProcessorProperties` Javadoc formatting
- Cleanup some `unchecked` code in tests