### PR TITLE
Support spring boot 3 on decaton-spring

### DIFF
--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -1,6 +1,53 @@
+ext {
+    boot2Version = "2.7.11"
+    boot3Version = "3.1.2"
+}
+
 dependencies {
     api project(":processor")
 
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "org.springframework.boot:spring-boot-starter:2.7.11"
+    api "org.springframework.boot:spring-boot-starter:$boot2Version"
+}
+
+// The following integrationTest profiles can be removed when support for boot2 is no longer needed.
+sourceSets.create('integrationTestSpringBoot2') {
+    compileClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.main.output
+    compileClasspath += sourceSets.testFixtures.output
+    runtimeClasspath += sourceSets.testFixtures.output
+}
+
+sourceSets.create('integrationTestSpringBoot3') {
+    compileClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.main.output
+    compileClasspath += sourceSets.testFixtures.output
+    runtimeClasspath += sourceSets.testFixtures.output
+}
+
+task integrationTestSpringBoot2(type: Test) {
+    testClassesDirs = sourceSets.integrationTestSpringBoot2.output.classesDirs
+    classpath = sourceSets.integrationTestSpringBoot2.runtimeClasspath
+}
+
+task integrationTestSpringBoot3(type: Test) {
+    testClassesDirs = sourceSets.integrationTestSpringBoot3.output.classesDirs
+    classpath = sourceSets.integrationTestSpringBoot3.runtimeClasspath
+}
+
+tasks.named('compileIntegrationTestSpringBoot3Java') {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencies {
+    integrationTestSpringBoot2Implementation project(":processor")
+    integrationTestSpringBoot2Implementation "org.springframework.boot:spring-boot-starter:$boot2Version"
+    integrationTestSpringBoot2Implementation "org.springframework.boot:spring-boot-starter-test:$boot2Version"
+    integrationTestSpringBoot2Implementation "junit:junit:$junitVersion"
+    integrationTestSpringBoot3Implementation project(":processor")
+    integrationTestSpringBoot3Implementation "org.springframework.boot:spring-boot-starter:$boot3Version"
+    integrationTestSpringBoot3Implementation "org.springframework.boot:spring-boot-starter-test:$boot3Version"
+    integrationTestSpringBoot3Implementation "junit:junit:$junitVersion"
 }

--- a/spring/src/integrationTestSpringBoot2/java/com/linecorp/decaton/spring/test/AutoConfigureDecatonConfigurationTest.java
+++ b/spring/src/integrationTestSpringBoot2/java/com/linecorp/decaton/spring/test/AutoConfigureDecatonConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.spring.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.linecorp.decaton.spring.beans.DecatonConfiguration;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = NONE)
+public class AutoConfigureDecatonConfigurationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void test_getBean() {
+        assertThat(applicationContext.getBean(
+                DecatonConfiguration.DecatonBeanFactoryPostProcessor.class)).isNotNull();
+    }
+}

--- a/spring/src/integrationTestSpringBoot2/java/com/linecorp/decaton/spring/test/TestSpringBootApplication.java
+++ b/spring/src/integrationTestSpringBoot2/java/com/linecorp/decaton/spring/test/TestSpringBootApplication.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decaton.spring.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestSpringBootApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TestSpringBootApplication.class, args);
+    }
+}

--- a/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/AutoConfigureDecatonConfigurationTest.java
+++ b/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/AutoConfigureDecatonConfigurationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decatonl.spring.test;
+
+import com.linecorp.decaton.spring.beans.DecatonConfiguration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = NONE)
+public class AutoConfigureDecatonConfigurationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void test_getBean() {
+        assertThat(applicationContext.getBean(
+                DecatonConfiguration.DecatonBeanFactoryPostProcessor.class)).isNotNull();
+    }
+}

--- a/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/TestSpringBootApplication.java
+++ b/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/TestSpringBootApplication.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.decatonl.spring.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestSpringBootApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TestSpringBootApplication.class, args);
+    }
+}

--- a/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.linecorp.decaton.spring.beans.DecatonConfiguration


### PR DESCRIPTION
# motivation

There has been a change in the auto-configuration file in Spring Boot 3.
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files

In the `decaton-spring` module, it is necessary to support both boot 2 and boot 3 until migrating to boot 3.

# modification 

- In addition to the `spring.factories` used in boot 2, a new configuration file `spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` was added for boot 3 in `META-INF`.
- Integration tests have been created to verify that auto-configuration works in both boot 2 and boot 3.
  - If these tests are excessive, I'll remove them.