### PR TITLE
Prevent non-RuntimeException causes completion-leak fixes #211

### DIFF
--- a/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
+++ b/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
@@ -123,14 +123,14 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
         child.watch(node -> {
             try {
                 setValue(prop, node);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 logger.warn("Failed to set value updated from CentralDogma for {}", definition.name(), e);
             }
         });
         try {
             JsonNode node = child.initialValueFuture().join().value(); //doesn't fail since it's a child watcher
             setValue(prop, node);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             logger.warn("Failed to set initial value from CentralDogma for {}", definition.name(), e);
         }
 

--- a/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
+++ b/centraldogma/src/main/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplier.java
@@ -124,6 +124,8 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
             try {
                 setValue(prop, node);
             } catch (Exception e) {
+                // Catching Exception instead of RuntimeException, since
+                // Kotlin-implemented DynamicProperty would throw checked exceptions
                 logger.warn("Failed to set value updated from CentralDogma for {}", definition.name(), e);
             }
         });
@@ -131,6 +133,8 @@ public class CentralDogmaPropertySupplier implements PropertySupplier, AutoClose
             JsonNode node = child.initialValueFuture().join().value(); //doesn't fail since it's a child watcher
             setValue(prop, node);
         } catch (Exception e) {
+            // Catching Exception instead of RuntimeException, since
+            // Kotlin-implemented DynamicProperty would throw checked exceptions
             logger.warn("Failed to set initial value from CentralDogma for {}", definition.name(), e);
         }
 

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -120,6 +120,9 @@ public interface DecatonClient<T> extends AutoCloseable {
             try {
                 errorCallback.accept(e);
             } catch (Exception ignored) {
+                // Catching Exception instead of RuntimeException, since
+                // Kotlin-implemented callback would throw checked exceptions
+
                 // noop
             }
             return null;

--- a/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
+++ b/client/src/main/java/com/linecorp/decaton/client/DecatonClient.java
@@ -119,7 +119,7 @@ public interface DecatonClient<T> extends AutoCloseable {
         result.exceptionally(e -> {
             try {
                 errorCallback.accept(e);
-            } catch (RuntimeException ignored) {
+            } catch (Exception ignored) {
                 // noop
             }
             return null;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
@@ -79,6 +79,8 @@ public class CompletionImpl implements Completion {
         try {
             return cb.apply(this) == TimeoutChoice.GIVE_UP;
         } catch (Exception e) {
+            // Catching Exception instead of RuntimeException, since
+            // Kotlin-implemented callback would throw checked exceptions
             log.warn("Completion timeout callback threw an exception", e);
             return false;
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/CompletionImpl.java
@@ -78,7 +78,7 @@ public class CompletionImpl implements Completion {
         }
         try {
             return cb.apply(this) == TimeoutChoice.GIVE_UP;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             log.warn("Completion timeout callback threw an exception", e);
             return false;
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -80,6 +80,9 @@ public class ProcessPipeline<T> implements AutoCloseable {
         try {
             extracted = extract(request);
         } catch (Exception e) {
+            // Catching Exception instead of RuntimeException, since
+            // Kotlin-implemented extractor would throw checked exceptions
+
             // Complete the offset to forward offsets
             offsetState.completion().complete();
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -79,7 +79,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
         final DecatonTask<T> extracted;
         try {
             extracted = extract(request);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             // Complete the offset to forward offsets
             offsetState.completion().complete();
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/Processors.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/Processors.java
@@ -79,14 +79,14 @@ public class Processors<T> {
                              .collect(Collectors.toList());
             logger.info("Creating partition processor core: {}", scope);
             return new ProcessPipeline<>(scope, processors, retryProcessor, taskExtractor, scheduler, metrics);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             // If exception occurred in the middle of instantiating processors, we have to make sure
             // all the previously created processors are destroyed before bubbling up the exception.
             try {
                 destroyThreadScope(scope.subscriptionId(),
                                    scope.topicPartition(),
                                    scope.threadId());
-            } catch (RuntimeException e1) {
+            } catch (Exception e1) {
                 logger.warn("processor supplier threw exception while leaving thread scope", e1);
             }
             throw e;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/Processors.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/Processors.java
@@ -80,6 +80,9 @@ public class Processors<T> {
             logger.info("Creating partition processor core: {}", scope);
             return new ProcessPipeline<>(scope, processors, retryProcessor, taskExtractor, scheduler, metrics);
         } catch (Exception e) {
+            // Catching Exception instead of RuntimeException, since
+            // Kotlin-implemented processor-supplier would throw checked exceptions
+
             // If exception occurred in the middle of instantiating processors, we have to make sure
             // all the previously created processors are destroyed before bubbling up the exception.
             try {
@@ -87,6 +90,9 @@ public class Processors<T> {
                                    scope.topicPartition(),
                                    scope.threadId());
             } catch (Exception e1) {
+                // Catching Exception instead of RuntimeException, since
+                // Kotlin-implemented processor-supplier would throw checked exceptions
+
                 logger.warn("processor supplier threw exception while leaving thread scope", e1);
             }
             throw e;

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
@@ -187,6 +187,21 @@ public class ProcessPipelineTest {
     }
 
     @Test
+    public void testExtract_ThrowsNonRuntimeException() throws InterruptedException {
+        // thenThrow cannot be used with checked exception
+        when(extractorMock.extract(any())).thenAnswer(inv -> {
+            throw new Exception();
+        });
+
+        TaskRequest request = taskRequest();
+        // Checking exception doesn't bubble up
+        pipeline.scheduleThenProcess(request);
+        verify(schedulerMock, never()).schedule(any());
+        verify(processorMock, never()).process(any(), any());
+        assertTrue(request.offsetState().completion().isComplete());
+    }
+
+    @Test
     public void testScheduleThenProcess_ExtractThrows() throws InterruptedException {
         when(extractorMock.extract(any())).thenThrow(new RuntimeException());
 


### PR DESCRIPTION
- The problem and the cause is described in #211
- Summary of the fixes:
  * Considering any user-supplied logic could throw non-RuntimeExceptions when it's implemented by non-Java JVM languages, I changed to catch `Exception` instead of `RuntimeException` where Decaton executes user-supplied logic