### PR TITLE
Bring back java 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 20]
+        java: [8, 11, 17, 20]
     steps:
     - uses: actions/checkout@v2
     - name: Setup java

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ subprojects {
     group = "com.linecorp.decaton"
     version = "${version}" + (snapshot.toBoolean() ? "-SNAPSHOT" : "")
 
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
         mavenCentral()
@@ -74,8 +74,8 @@ subprojects {
 
         // Likely be used for most modules
         testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-        testImplementation "org.mockito:mockito-core:5.5.0"
-        testImplementation "org.mockito:mockito-junit-jupiter:5.5.0"
+        testImplementation "org.mockito:mockito-core:4.11.0"
+        testImplementation "org.mockito:mockito-junit-jupiter:4.11.0"
         itImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     }
 


### PR DESCRIPTION
Reverting java 8 support drop by https://github.com/line/decaton/pull/214/commits/ca52c6b1d6e68d3fdd1781a742a57ad64546b7ac as we found there's people still want java8 support.