### PR TITLE
Add delivery latency and scheduled delay metrics

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -147,17 +147,11 @@ public class Metrics {
     public class TaskMetrics extends AbstractMetrics {
         public final Timer tasksDeliveryLatency =
                 meter(() -> Timer.builder("tasks.delivery.latency")
-                        .description("The latency between the time the task is produced and the time the task is consumed. "
-                                + "This metric depends on the task's `timestampMillis` field, and "
-                                + "it might not represent the actual end-to-end latency depending on how `timestampMillis` is constructed for the task.")
-                        .tags(availableTags.partitionScope())
-                        .register(registry));
-        public final Timer tasksDeliveryLatency =
-                meter(() -> Timer.builder("tasks.delivery.latency")
-                                 .description("The latency between the time the task is produced and the time the task is consumed")
+                                 .description("The latency between the time the task is produced and the time the task is consumed. "
+                                         + "This metric depends on the task's `timestampMillis` field, and it might not represent "
+                                         + "the actual end-to-end latency depending on how `timestampMillis` is constructed for the task.")
                                  .tags(availableTags.partitionScope())
                                  .register(registry));
-
         public final Timer tasksScheduledDelay =
                 meter(() -> Timer.builder("tasks.scheduled.delay")
                                  .description("The delay between the scheduled time and the time the task is consumed")

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -147,6 +147,13 @@ public class Metrics {
     public class TaskMetrics extends AbstractMetrics {
         public final Timer tasksDeliveryLatency =
                 meter(() -> Timer.builder("tasks.delivery.latency")
+                        .description("The latency between the time the task is produced and the time the task is consumed. "
+                                + "This metric depends on the task's `timestampMillis` field, and "
+                                + "it might not represent the actual end-to-end latency depending on how `timestampMillis` is constructed for the task.")
+                        .tags(availableTags.partitionScope())
+                        .register(registry));
+        public final Timer tasksDeliveryLatency =
+                meter(() -> Timer.builder("tasks.delivery.latency")
                                  .description("The latency between the time the task is produced and the time the task is consumed")
                                  .tags(availableTags.partitionScope())
                                  .register(registry));

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -145,6 +145,12 @@ public class Metrics {
     }
 
     public class TaskMetrics extends AbstractMetrics {
+        public final Timer tasksDeliveryLatency =
+                meter(() -> Timer.builder("tasks.delivery.latency")
+                                 .description("The latency between the Decaton client producing a task and its processor starting consumption")
+                                 .tags(availableTags.partitionScope())
+                                 .register(registry));
+
         public final Counter tasksProcessed =
                 meter(() -> Counter.builder("tasks.processed")
                                    .description("The number of tasks processed")

--- a/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/metrics/Metrics.java
@@ -147,7 +147,13 @@ public class Metrics {
     public class TaskMetrics extends AbstractMetrics {
         public final Timer tasksDeliveryLatency =
                 meter(() -> Timer.builder("tasks.delivery.latency")
-                                 .description("The latency between the Decaton client producing a task and its processor starting consumption")
+                                 .description("The latency between the time the task is produced and the time the task is consumed")
+                                 .tags(availableTags.partitionScope())
+                                 .register(registry));
+
+        public final Timer tasksScheduledDelay =
+                meter(() -> Timer.builder("tasks.scheduled.delay")
+                                 .description("The delay between the scheduled time and the time the task is consumed")
                                  .tags(availableTags.partitionScope())
                                  .register(registry));
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -131,6 +131,12 @@ public class ProcessPipeline<T> implements AutoCloseable {
                     TimeUnit.MILLISECONDS
             );
         }
+        if (task.metadata().scheduledTimeMillis() > 0) {
+            taskMetrics.tasksScheduledDelay.record(
+                    System.currentTimeMillis() - task.metadata().scheduledTimeMillis(),
+                    TimeUnit.MILLISECONDS
+            );
+        }
 
         Timer timer = Utils.timer();
         Completion processResult;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -140,6 +140,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
         ProcessingContext<T> context =
                 new ProcessingContextImpl<>(scope.subscriptionId(), request, task, processors, retryProcessor,
                                             scope.props());
+
         Timer timer = Utils.timer();
         Completion processResult;
         try (LoggingContext ignored = context.loggingContext()) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.Completion;
@@ -123,6 +124,13 @@ public class ProcessPipeline<T> implements AutoCloseable {
         ProcessingContext<T> context =
                 new ProcessingContextImpl<>(scope.subscriptionId(), request, task, processors, retryProcessor,
                                             scope.props());
+
+        if (task.metadata().timestampMillis() > 0) {
+            taskMetrics.tasksDeliveryLatency.record(
+                    System.currentTimeMillis() - task.metadata().timestampMillis(),
+                    TimeUnit.MILLISECONDS
+            );
+        }
 
         Timer timer = Utils.timer();
         Completion processResult;


### PR DESCRIPTION
The Decaton client adds timestamps to tasks when they are produced, as well as the scheduled execution time. As mentioned in #208, this allows us to output metrics on the time taken from producing to consuming a task. This can be beneficial for monitoring Decaton processors that require low latency, and for creating alerts.

Additionally, metrics on the delay from the scheduled time are particularly useful in determining whether schedules are being executed in retry topic as expected. If there is a significant delay, Decaton users may realize they need increase throughput somehow.

Resolve #208 