### PR TITLE
Ensure decaton works with older jdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         java: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup java for compile
+    - name: Setup java
       uses: actions/setup-java@v4
       with:
         distribution: temurin
@@ -26,7 +26,9 @@ jobs:
     - name: Execute test
       uses: eskatos/gradle-command-action@v1
       with:
+        # Java is installed on JAVA_HOME_{java major version}_X64
+        # refs: https://github.com/actions/setup-java/tree/v4.1.0?tab=readme-ov-file#install-multiple-jdks
         arguments: |
           -Ptest.java.major.version=${{ matrix.java }}
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_x64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_X64
           build jmhJar integrationTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,14 @@ jobs:
     - name: Setup java for compile
       uses: actions/setup-java@v1
       with:
-        java-version: 21
-    - name: Compile
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build jmhJar -x test
-    - name: Setup java for test
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
+        java-version: |
+          ${{ matrix.java }}
+          21
+
     - name: Execute test
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test integrationTest
+        arguments: |
+          -Ptest.java.major.version=${{ matrix.java }}
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_x64
+          build jmhJar integrationTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [21]
+        java: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup java
+    - name: Setup java for compile
+      uses: actions/setup-java@v1
+      with:
+        java-version: 21
+    - name: Compile
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build jmhJar -x test
+    - name: Setup java for test
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
     - name: Execute test
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build jmhJar integrationTest
+        arguments: test integrationTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Setup java for compile
       uses: actions/setup-java@v4
       with:
+        distribution: temurin
         java-version: |
           ${{ matrix.java }}
           21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup java for compile
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: |
           ${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,13 @@ subprojects {
             showStackTraces true
             showStandardStreams false
         }
+        def testJavaVersion = findProperty("test.java.major.version")
+        if (testJavaVersion != null) {
+            // https://docs.gradle.org/8.5/userguide/toolchains.html#toolchains_for_tasks
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(testJavaVersion)
+            }
+        }
     }
 
     afterEvaluate {

--- a/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
+++ b/client/src/test/java/com/linecorp/decaton/client/DecatonClientTest.java
@@ -39,8 +39,7 @@ import com.linecorp.decaton.protocol.Sample.HelloTask;
 
 @ExtendWith(MockitoExtension.class)
 public class DecatonClientTest {
-    @Spy
-    private final DecatonClient<HelloTask> decaton = new DecatonClient<HelloTask>() {
+    private static class NoopClient implements DecatonClient<HelloTask> {
         @Override
         public CompletableFuture<PutTaskResult> put(String key, HelloTask task) {
             return null;
@@ -73,7 +72,10 @@ public class DecatonClientTest {
         public void close() throws Exception {
             // noop
         }
-    };
+    }
+
+    @Spy
+    private final DecatonClient<HelloTask> decaton = new NoopClient();
 
     @Test
     public void testPutAsyncHelperOnSuccess() throws Exception {

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 
     itImplementation project(":protobuf")
     itImplementation project(":testing")
-    itImplementation project(":benchmark")
     itImplementation "io.micrometer:micrometer-registry-prometheus:$micrometerVersion"
     itImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/processor/src/it/java/com/linecorp/decaton/processor/VThreadCoreFunctionalityTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/VThreadCoreFunctionalityTest.java
@@ -22,6 +22,8 @@ import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.decaton.processor.runtime.ProcessorProperties;
@@ -33,6 +35,7 @@ import com.linecorp.decaton.testing.KafkaClusterExtension;
 import com.linecorp.decaton.testing.RandomExtension;
 import com.linecorp.decaton.testing.processor.ProcessorTestSuite;
 
+@EnabledForJreRange(min = JRE.JAVA_21)
 public class VThreadCoreFunctionalityTest {
     @RegisterExtension
     public static KafkaClusterExtension rule = new KafkaClusterExtension();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
@@ -372,7 +372,7 @@ public class ProcessingContextImplTest {
     @Timeout(5)
     public void testRetry() throws InterruptedException {
         CountDownLatch retryLatch = new CountDownLatch(1);
-        DecatonProcessor<byte[]> retryProcessor = new AsyncCompleteProcessor(retryLatch);
+        DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
                 new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, REQUEST.toByteArray(), null);
         DecatonTask<byte[]> task = new DecatonTask<>(
@@ -403,7 +403,7 @@ public class ProcessingContextImplTest {
     @Timeout(5)
     public void testRetryAtCompletionTimeout() throws InterruptedException {
         CountDownLatch retryLatch = new CountDownLatch(1);
-        DecatonProcessor<byte[]> retryProcessor = new AsyncCompleteProcessor(retryLatch);
+        DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
                 new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, REQUEST.toByteArray(), null);
         DecatonTask<byte[]> task = new DecatonTask<>(

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
     // We keep using 1.3.x for a while until we drop Java 8 support.
-    testRuntimeOnly "ch.qos.logback:logback-classic:1.3.14"
+    runtimeOnly "ch.qos.logback:logback-classic:1.3.14"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -39,5 +39,6 @@ dependencies {
     implementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     implementation "org.hamcrest:hamcrest:$hamcrestVersion"
 
-    testRuntimeOnly "ch.qos.logback:logback-classic:1.4.11"
+    // We keep using 1.3.x for a while until we drop Java 8 support.
+    testRuntimeOnly "ch.qos.logback:logback-classic:1.3.14"
 }


### PR DESCRIPTION
- Now Decaton compiles only on jdk >= 21 (by https://github.com/line/decaton/pull/224) but since there are many users who still use jdk 8,11,17, we still should run tests on these versions