### PR TITLE
Fix invalid json of benchmark output

### DIFF
--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -18,6 +18,7 @@ package com.linecorp.decaton.benchmark;
 
 import static java.util.Collections.emptyList;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -95,6 +96,9 @@ public final class Main implements Callable<Integer> {
             defaultValue = "text")
     private String resultFormat;
 
+    @Option(names = "--file", description = "Result file to write output to. If not specified, output to stdout")
+    private Path resultFile;
+
     @Option(names = "--file-name-only",
             description = "Trim file paths in result from its path to filename only")
     private boolean fileNameOnly;
@@ -167,7 +171,13 @@ public final class Main implements Callable<Integer> {
         @SuppressWarnings("OptionalGetWithoutIsPresent")
         BenchmarkResult sum = results.stream().reduce(BenchmarkResult::plus).get();
         BenchmarkResult result = sum.div(results.size());
-        resultFormat.print(config, System.out, result);
+        if (resultFile != null) {
+            try (FileOutputStream fos = new FileOutputStream(resultFile.toFile())) {
+                resultFormat.print(config, fos, result);
+            }
+        } else {
+            resultFormat.print(config, System.out, result);
+        }
         return 0;
     }
 

--- a/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
+++ b/benchmark/src/main/java/com/linecorp/decaton/benchmark/Main.java
@@ -96,8 +96,8 @@ public final class Main implements Callable<Integer> {
             defaultValue = "text")
     private String resultFormat;
 
-    @Option(names = "--file", description = "Result file to write output to. If not specified, output to stdout")
-    private Path resultFile;
+    @Option(names = "--output", description = "Result file to write output to. If not specified, output to stdout")
+    private Path resultOutput;
 
     @Option(names = "--file-name-only",
             description = "Trim file paths in result from its path to filename only")
@@ -171,8 +171,8 @@ public final class Main implements Callable<Integer> {
         @SuppressWarnings("OptionalGetWithoutIsPresent")
         BenchmarkResult sum = results.stream().reduce(BenchmarkResult::plus).get();
         BenchmarkResult result = sum.div(results.size());
-        if (resultFile != null) {
-            try (FileOutputStream fos = new FileOutputStream(resultFile.toFile())) {
+        if (resultOutput != null) {
+            try (FileOutputStream fos = new FileOutputStream(resultOutput.toFile())) {
                 resultFormat.print(config, fos, result);
             }
         } else {

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -27,8 +27,8 @@ function run_with_opts() {
         --file-name-only \
         --warmup 10000000 \
         --param=decaton.max.pending.records=10000 \
-        "$@" \
-        >$tmp
+        --file=$tmp \
+        "$@"
     mv $tmp $out_dir/$name-benchmark.json
 }
 

--- a/cb/run-bm.sh
+++ b/cb/run-bm.sh
@@ -27,7 +27,7 @@ function run_with_opts() {
         --file-name-only \
         --warmup 10000000 \
         --param=decaton.max.pending.records=10000 \
-        --file=$tmp \
+        --output=$tmp \
         "$@"
     mv $tmp $out_dir/$name-benchmark.json
 }


### PR DESCRIPTION
- Now performance dashboard doesn't work because latest run produces invalid JSON output
    * https://line.github.io/decaton/commit-data/a3f14197b71c65a7aa8d83b78d5c9756dbf9ca89/tasks_100k_latency_10ms_concurrency_20-benchmark.json
- This is because current version of async-profiler output `Profiling started` on stdout and there seems to be no way to disable this
- To address this, I added `--file` option to the benchmark module to prevent async-profiler output and benchmark output are mixed