### PR TITLE
Make Decaton can consume any topic with deserializer

### DIFF
--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -351,8 +351,6 @@ By leveraging Decaton's deferred completion and async-client of your middleware 
 
 Now you know the basics and ready to start implementing Decaton apps!
 
-If you're attempting to consume existing topic which contains records in schema other than Decaton's task protocol, or maybe you want to use task schema that can be understandable even for non-decaton consumers. In case visit link:./consuming-any-data.adoc[Consuming Arbitrary Topic] to see how.
-
 For those thinking to run Decaton on production, link:./monitoring.adoc[Monitoring] might helps to always ensure your Decaton processors doing good.
 
 If you're using link:https://spring.io/[Spring] for running your applications, you might wanna take a look at link:./spring-integration.adoc[Spring Integration].

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -8,7 +8,7 @@ Decaton Documents
 - link:./runtime.adoc[Subpartition Runtime]
 - link:./spring-integration.adoc[Spring Integration]
 - link:./tracing.adoc[Tracing]
-- link:./consuming-any-data.adoc[Use Decaton for consuming topics of non-Decaton tasks]
+- link:./task-extractor.adoc[Implement custom task extractor]
 - link:./dynamic-property-configuration.adoc[Dynamic property configuration for the processor]
 - link:./monitoring.adoc[Monitoring Decaton]
 - Features

--- a/docs/task-extractor.adoc
+++ b/docs/task-extractor.adoc
@@ -1,16 +1,33 @@
-Consuming Arbitrary Topic
-=========================
+TaskExtractor
+=============
 :base_version: 9.0.0
 :modules: common,protocol,processor
 
-This document guides you how to consume and process topics containing records not produced by DecatonClient using Decaton processors.
+[NOTE]
+====
+From Decaton 9.0.0, you can just use link:../processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java[ProcessorsBuilder#consuming(String topic, Deserializer<T> deserializer)] to consume arbitrary topics,
+without worrying if the topic is produced by DecatonClient or not.
 
-By default, Decaton assumes messages are produced `DecatonClient`, where task metadata are stored as link:../protocol/src/main/proto/decaton.proto[TaskMetadataProto] in record headers.
-But Decaton has the capability to consume arbitrary topics other than topics produced by `DecatonClient`.
+You may need to read through this guide *ONLY* in specific situations described just below.
+====
 
-This means you can use Decaton as a drop-in replacement for a vanilla KafkaConsumer to leverage powerful features like deferred completion, delayed processing and so on.
+Decaton provides two ways to consume topics in link:../processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java[ProcessorsBuilder]:
 
-Through this guide, we assume the topic is JSON-serialized and use link:https://github.com/FasterXML/jackson-databind[jackson-databind] for deserialization, but it's trivial to consume arbitrary formats other than JSON.
+* `ProcessorsBuilder#consuming(String topic, Deserializer<T> deserializer)`
+* `ProcessorsBuilder#consuming(String topic, TaskExtractor<T> deserializer)`
+
+As you may have learned through link:./getting-started.adoc[Getting Started], former is the most common and convenient way to consume topics, where you can just pass a value deserializer.
+
+However, sometimes you may need to apply custom logic to extract a task from raw consumed messages:
+
+* You need to extract custom task metadata on consumption. (e.g. Set `scheduledTimeMillis` for delayed processing)
+* You need to access additional information (e.g. record headers) for deserialization
+
+This is where latter way with `TaskExtractor` comes in.
+
+This guide will show you how to implement `TaskExtractor` and use it.
+
+Through this guide, we assume the topic is JSON-serialized and use link:https://github.com/FasterXML/jackson-databind[jackson-databind] for deserialization.
 
 == TaskExtractor
 
@@ -29,6 +46,7 @@ public class JSONUserEventExtractor implements TaskExtractor<UserEvent> {
             TaskMetadata metadata = TaskMetadata.builder()
                                                 // Filling timestampMillis is not mandatory, but it would be useful
                                                 // when you monitor delivery latency between event production time and event processing time.
+                                                // Also, this will be used for scheduling tasks when scheduledTimeMillis is set.
                                                 .timestampMillis(event.getEventTimestampMillis())
                                                 // This field is not mandatory too, but you can track which application produced the task by filling this.
                                                 .sourceApplicationId("event-tracker")
@@ -66,7 +84,7 @@ public class UserEventProcessor implements DecatonProcessor<UserEvent> {
 }
 ----
 
-As you can see, once you implement TaskExtractor, the implementation of the DecatonProcessor can be done as when you consume a regular Decaton topic.
+As you can see, there's no difference the implementation of the DecatonProcessor from the case where you use `Deserializer`.
 
 Lastly, you need to instantiate link:../processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorSubscription.java[ProcessorSubscription] as follows.
 
@@ -84,11 +102,9 @@ ProcessorsBuilder.consuming(
 ...
 ----
 
-You have to pass TaskExtractor which you implemented above instead of link:../common/src/main/java/com/linecorp/decaton/common/Deserializer.java[Deseiralizer].
-
 == Run Example
 
-Now we are ready to process a JSON topic.
+Now we are ready to process a JSON topic with custom task extraction logic.
 
 Before trying out, let's download and extract the kafka binary from https://kafka.apache.org/downloads to use `kafka-console-producer.sh`.
 

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -259,7 +259,7 @@ public class RetryQueueingTest {
     @Timeout(60)
     public void testRetryQueueingMigrateToHeader() throws Exception {
         DynamicProperty<Boolean> metadataAsHeader =
-                new DynamicProperty<>(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT);
+                new DynamicProperty<>(ProcessorProperties.CONFIG_RETRY_TASK_IN_LEGACY_FORMAT);
         metadataAsHeader.set(true);
 
         AtomicInteger processCount = new AtomicInteger(0);
@@ -269,7 +269,7 @@ public class RetryQueueingTest {
                 .numTasks(100)
                 .propertySupplier(StaticPropertySupplier.of(
                         metadataAsHeader,
-                        Property.ofStatic(ProcessorProperties.CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING, true)))
+                        Property.ofStatic(ProcessorProperties.CONFIG_LEGACY_PARSE_FALLBACK_ENABLED, true)))
                 .produceTasksWithHeaderMetadata(false)
                 .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
                     if (ctx.metadata().retryCount() == 0) {

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -258,9 +258,9 @@ public class RetryQueueingTest {
     @Test
     @Timeout(60)
     public void testRetryQueueingMigrateToHeader() throws Exception {
-        DynamicProperty<Boolean> metadataAsHeader =
+        DynamicProperty<Boolean> retryTaskInLegacyFormat =
                 new DynamicProperty<>(ProcessorProperties.CONFIG_RETRY_TASK_IN_LEGACY_FORMAT);
-        metadataAsHeader.set(true);
+        retryTaskInLegacyFormat.set(true);
 
         AtomicInteger processCount = new AtomicInteger(0);
         CountDownLatch migrationLatch = new CountDownLatch(1);
@@ -268,7 +268,7 @@ public class RetryQueueingTest {
                 .builder(rule)
                 .numTasks(100)
                 .propertySupplier(StaticPropertySupplier.of(
-                        metadataAsHeader,
+                        retryTaskInLegacyFormat,
                         Property.ofStatic(ProcessorProperties.CONFIG_LEGACY_PARSE_FALLBACK_ENABLED, true)))
                 .produceTasksWithHeaderMetadata(false)
                 .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
@@ -278,7 +278,7 @@ public class RetryQueueingTest {
                         if (cnt < 50) {
                             ctx.retry();
                         } else if (cnt == 50) {
-                            metadataAsHeader.set(true);
+                            retryTaskInLegacyFormat.set(true);
                             migrationLatch.countDown();
                             ctx.retry();
                         } else {

--- a/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
+++ b/processor/src/it/java/com/linecorp/decaton/processor/RetryQueueingTest.java
@@ -259,15 +259,17 @@ public class RetryQueueingTest {
     @Timeout(60)
     public void testRetryQueueingMigrateToHeader() throws Exception {
         DynamicProperty<Boolean> metadataAsHeader =
-                new DynamicProperty<>(ProcessorProperties.CONFIG_TASK_METADATA_AS_HEADER);
-        metadataAsHeader.set(false);
+                new DynamicProperty<>(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT);
+        metadataAsHeader.set(true);
 
         AtomicInteger processCount = new AtomicInteger(0);
         CountDownLatch migrationLatch = new CountDownLatch(1);
         ProcessorTestSuite
                 .builder(rule)
                 .numTasks(100)
-                .propertySupplier(StaticPropertySupplier.of(metadataAsHeader))
+                .propertySupplier(StaticPropertySupplier.of(
+                        metadataAsHeader,
+                        Property.ofStatic(ProcessorProperties.CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING, true)))
                 .produceTasksWithHeaderMetadata(false)
                 .configureProcessorsBuilder(builder -> builder.thenProcess((ctx, task) -> {
                     if (ctx.metadata().retryCount() == 0) {

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumedRecord.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumedRecord.java
@@ -30,6 +30,11 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 public class ConsumedRecord {
     /**
+     * The timestamp of the record
+     */
+    long recordTimestamp;
+
+    /**
      * Headers of the record
      */
     Headers headers;

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumedRecord.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ConsumedRecord.java
@@ -32,7 +32,7 @@ public class ConsumedRecord {
     /**
      * The timestamp of the record
      */
-    long recordTimestamp;
+    long recordTimestampMillis;
 
     /**
      * Headers of the record

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.slf4j.MDC;
 
+import com.linecorp.decaton.common.Deserializer;
 import com.linecorp.decaton.processor.Completion;
 import com.linecorp.decaton.processor.DecatonProcessor;
 import com.linecorp.decaton.processor.ProcessingContext;
@@ -226,17 +227,31 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                                       Long.MAX_VALUE, v -> v instanceof Long && (Long) v >= 0);
 
     /**
-     * Controls whether to produce retry tasks with task metadata as headers, instead of as deprecated
-     * {@link DecatonTaskRequest} format.
+     * Controls whether to produce retry tasks in deprecated {@link DecatonTaskRequest} format.
      * <p>
-     * <b>CAUTION!!! YOU MAY NEED TO SET THIS TO FALSE WHEN YOU UPGRADE FROM 8.0.1 OR EARLIER</b>
+     * <b>CAUTION!!! YOU MAY NEED TO SET THIS TO TRUE WHEN YOU UPGRADE FROM 8.0.1 OR EARLIER</b>
      * <p>
      * Please read <a href="https://github.com/line/decaton/releases/tag/v9.0.0">Decaton 9.0.0 Release Note</a> carefully.
      * <p>
      * Reloadable: yes
      */
-    public static final PropertyDefinition<Boolean> CONFIG_TASK_METADATA_AS_HEADER =
-            PropertyDefinition.define("decaton.task.metadata.as.header", Boolean.class, true,
+    public static final PropertyDefinition<Boolean> CONFIG_RETRY_TASK_AS_LEGACY_FORMAT =
+            PropertyDefinition.define("decaton.retry.task.as.legacy.format", Boolean.class, false,
+                                      v -> v instanceof Boolean);
+
+    /**
+     * Controls whether to parse records as {@link DecatonTaskRequest} format when task metadata header is missing
+     * when {@link Deserializer} is used, instead of parsing task directly with the deserializer and
+     * fill reasonably-default task metadata.
+     * <p>
+     * <b>CAUTION!!! YOU MAY NEED TO SET THIS TO TRUE WHEN YOU UPGRADE FROM 8.0.1 OR EARLIER</b>
+     * <p>
+     * Please read <a href="https://github.com/line/decaton/releases/tag/v9.0.0">Decaton 9.0.0 Release Note</a> carefully.
+     * <p>
+     * Reloadable: yes
+     */
+    public static final PropertyDefinition<Boolean> CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING =
+            PropertyDefinition.define("decaton.parse.as.legacy.format.when.header.missing", Boolean.class, false,
                                       v -> v instanceof Boolean);
 
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
@@ -253,7 +268,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS,
                     CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS,
                     CONFIG_PER_KEY_QUOTA_PROCESSING_RATE,
-                    CONFIG_TASK_METADATA_AS_HEADER));
+                    CONFIG_RETRY_TASK_AS_LEGACY_FORMAT,
+                    CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorProperties.java
@@ -235,8 +235,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
      * <p>
      * Reloadable: yes
      */
-    public static final PropertyDefinition<Boolean> CONFIG_RETRY_TASK_AS_LEGACY_FORMAT =
-            PropertyDefinition.define("decaton.retry.task.as.legacy.format", Boolean.class, false,
+    public static final PropertyDefinition<Boolean> CONFIG_RETRY_TASK_IN_LEGACY_FORMAT =
+            PropertyDefinition.define("decaton.retry.task.in.legacy.format", Boolean.class, false,
                                       v -> v instanceof Boolean);
 
     /**
@@ -250,8 +250,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
      * <p>
      * Reloadable: yes
      */
-    public static final PropertyDefinition<Boolean> CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING =
-            PropertyDefinition.define("decaton.parse.as.legacy.format.when.header.missing", Boolean.class, false,
+    public static final PropertyDefinition<Boolean> CONFIG_LEGACY_PARSE_FALLBACK_ENABLED =
+            PropertyDefinition.define("decaton.legacy.parse.fallback.enabled", Boolean.class, false,
                                       v -> v instanceof Boolean);
 
     public static final List<PropertyDefinition<?>> PROPERTY_DEFINITIONS =
@@ -268,8 +268,8 @@ public class ProcessorProperties extends AbstractDecatonProperties {
                     CONFIG_DEFERRED_COMPLETE_TIMEOUT_MS,
                     CONFIG_PROCESSOR_THREADS_TERMINATION_TIMEOUT_MS,
                     CONFIG_PER_KEY_QUOTA_PROCESSING_RATE,
-                    CONFIG_RETRY_TASK_AS_LEGACY_FORMAT,
-                    CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING));
+                    CONFIG_RETRY_TASK_IN_LEGACY_FORMAT,
+                    CONFIG_LEGACY_PARSE_FALLBACK_ENABLED));
 
     /**
      * Find and return a {@link PropertyDefinition} from its name.

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java
@@ -141,7 +141,7 @@ public class ProcessorsBuilder<T> {
             DecatonTask<byte[]> outerTask = outerExtractor.extract(record);
             ConsumedRecord inner = ConsumedRecord
                     .builder()
-                    .recordTimestamp(record.recordTimestamp())
+                    .recordTimestampMillis(record.recordTimestampMillis())
                     .headers(record.headers())
                     .key(record.key())
                     .value(outerTask.taskDataBytes())

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/ProcessorsBuilder.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import com.linecorp.decaton.common.Deserializer;
 import com.linecorp.decaton.processor.DecatonProcessor;
+import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.internal.DecatonProcessorSupplierImpl;
 import com.linecorp.decaton.processor.runtime.internal.DefaultTaskExtractor;
 import com.linecorp.decaton.processor.runtime.internal.Processors;
@@ -53,7 +54,13 @@ public class ProcessorsBuilder<T> {
 
     /**
      * Create new {@link ProcessorsBuilder} that consumes message from topic expecting tasks of type
-     * which can be parsed by valueParser.
+     * which can be parsed by deserializer.
+     * <p>
+     * From Decaton 9.0.0, you can use this overload to consume tasks from arbitrary topics not only
+     * topics that are produced by DecatonClient.
+     * <p>
+     * If you want to extract custom {@link TaskMetadata} (e.g. for delayed processing), you can use
+     * {@link #consuming(String, TaskExtractor)} instead.
      * @param topic the name of topic to consume.
      * @param deserializer the deserializer to instantiate task of type {@link T} from serialized bytes.
      * @param <T> the type of instantiated tasks.
@@ -134,6 +141,7 @@ public class ProcessorsBuilder<T> {
             DecatonTask<byte[]> outerTask = outerExtractor.extract(record);
             ConsumedRecord inner = ConsumedRecord
                     .builder()
+                    .recordTimestamp(record.recordTimestamp())
                     .headers(record.headers())
                     .key(record.key())
                     .value(outerTask.taskDataBytes())

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/SubscriptionBuilder.java
@@ -263,7 +263,7 @@ public class SubscriptionBuilder {
         return new ProcessorSubscription(scope,
                                          consumerSupplier.get(),
                                          quotaApplier(scope),
-                                         processorsBuilder.build(maybeRetryProcessorSupplier(scope)),
+                                         processorsBuilder.build(maybeRetryProcessorSupplier(scope), props),
                                          props,
                                          stateListener);
     }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -45,14 +45,14 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
     private final Duration backoff;
     private final RetryMetrics metrics;
     private final String retryTopic;
-    private final Property<Boolean> retryTaskAsLegacyFormatProperty;
+    private final Property<Boolean> retryTaskInLegacyFormatProperty;
 
     public DecatonTaskRetryQueueingProcessor(SubscriptionScope scope, DecatonTaskProducer producer) {
         RetryConfig retryConfig = scope.retryConfig().get(); // This won't be instantiated unless it present
         this.producer = producer;
         backoff = retryConfig.backoff();
         retryTopic = scope.retryTopic().get(); // This won't be instantiated unless it present
-        retryTaskAsLegacyFormatProperty = scope.props().get(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT);
+        retryTaskInLegacyFormatProperty = scope.props().get(ProcessorProperties.CONFIG_RETRY_TASK_IN_LEGACY_FORMAT);
 
         metrics = Metrics.withTags("subscription", scope.subscriptionId()).new RetryMetrics();
     }
@@ -70,7 +70,7 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                                  .build();
 
         final ProducerRecord<byte[], byte[]> record;
-        if (retryTaskAsLegacyFormatProperty.value()) {
+        if (retryTaskInLegacyFormatProperty.value()) {
             DecatonTaskRequest request =
                     DecatonTaskRequest.newBuilder()
                                       .setMetadata(taskMetadata)

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -45,14 +45,14 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
     private final Duration backoff;
     private final RetryMetrics metrics;
     private final String retryTopic;
-    private final Property<Boolean> metadataAsHeaderProperty;
+    private final Property<Boolean> retryTaskAsLegacyFormatProperty;
 
     public DecatonTaskRetryQueueingProcessor(SubscriptionScope scope, DecatonTaskProducer producer) {
         RetryConfig retryConfig = scope.retryConfig().get(); // This won't be instantiated unless it present
         this.producer = producer;
         backoff = retryConfig.backoff();
         retryTopic = scope.retryTopic().get(); // This won't be instantiated unless it present
-        metadataAsHeaderProperty = scope.props().get(ProcessorProperties.CONFIG_TASK_METADATA_AS_HEADER);
+        retryTaskAsLegacyFormatProperty = scope.props().get(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT);
 
         metrics = Metrics.withTags("subscription", scope.subscriptionId()).new RetryMetrics();
     }
@@ -70,15 +70,7 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                                  .build();
 
         final ProducerRecord<byte[], byte[]> record;
-        if (metadataAsHeaderProperty.value()) {
-            record = new ProducerRecord<>(
-                    retryTopic,
-                    null,
-                    context.key(),
-                    serializedTask,
-                    context.headers());
-            TaskMetadataUtil.writeAsHeader(taskMetadata, record.headers());
-        } else {
+        if (retryTaskAsLegacyFormatProperty.value()) {
             DecatonTaskRequest request =
                     DecatonTaskRequest.newBuilder()
                                       .setMetadata(taskMetadata)
@@ -90,6 +82,14 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                     context.key(),
                     request.toByteArray(),
                     context.headers());
+        } else {
+            record = new ProducerRecord<>(
+                    retryTopic,
+                    null,
+                    context.key(),
+                    serializedTask,
+                    context.headers());
+            TaskMetadataUtil.writeAsHeader(taskMetadata, record.headers());
         }
         metrics.retryTaskRetries.record(nextRetryCount);
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractor.java
@@ -71,7 +71,7 @@ public class DefaultTaskExtractor<T> implements TaskExtractor<T> {
                 T task = taskDeserializer.deserialize(record.value());
                 return new DecatonTask<>(
                         TaskMetadata.builder()
-                                    .timestampMillis(record.recordTimestamp())
+                                    .timestampMillis(record.recordTimestampMillis())
                                     .build(),
                         task,
                         record.value());

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -174,7 +174,7 @@ public class PartitionContext implements AutoCloseable {
                           QuotaApplier quotaApplier) {
         if (!quotaApplier.apply(record, offsetState, maybeRecordQuotaUsage(record.key()))) {
             TaskRequest request = new TaskRequest(
-                    scope.topicPartition(), record.offset(), offsetState, record.key(),
+                    record.timestamp(), scope.topicPartition(), record.offset(), offsetState, record.key(),
                     record.headers(), traceHandle, record.value(), maybeRecordQuotaUsage(record.key()));
             subPartitions.addTask(request);
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -124,11 +124,6 @@ public class ProcessPipeline<T> implements AutoCloseable {
 
     // visible for testing
     DecatonTask<T> extract(TaskRequest request) {
-        // This is a workaround to pass the config to TaskExtractor
-        // since it doesn't have a reference to ProcessorProperties.
-        DefaultTaskExtractor.setParseAsLegacyWhenHeaderMissing(
-                scope.props().get(ProcessorProperties.CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING).value());
-
         final DecatonTask<T> extracted;
         extracted = taskExtractor.extract(
                 ConsumedRecord.builder()

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -132,7 +132,7 @@ public class ProcessPipeline<T> implements AutoCloseable {
         final DecatonTask<T> extracted;
         extracted = taskExtractor.extract(
                 ConsumedRecord.builder()
-                              .recordTimestamp(request.recordTimestamp())
+                              .recordTimestampMillis(request.recordTimestamp())
                               .headers(request.headers())
                               .key(request.key())
                               .value(request.rawRequestBytes())

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipeline.java
@@ -124,9 +124,15 @@ public class ProcessPipeline<T> implements AutoCloseable {
 
     // visible for testing
     DecatonTask<T> extract(TaskRequest request) {
+        // This is a workaround to pass the config to TaskExtractor
+        // since it doesn't have a reference to ProcessorProperties.
+        DefaultTaskExtractor.setParseAsLegacyWhenHeaderMissing(
+                scope.props().get(ProcessorProperties.CONFIG_PARSE_AS_LEGACY_FORMAT_WHEN_HEADER_MISSING).value());
+
         final DecatonTask<T> extracted;
         extracted = taskExtractor.extract(
                 ConsumedRecord.builder()
+                              .recordTimestamp(request.recordTimestamp())
                               .headers(request.headers())
                               .key(request.key())
                               .value(request.rawRequestBytes())

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
@@ -32,6 +32,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @AllArgsConstructor
 public class TaskRequest {
+    private final long recordTimestamp;
     private final TopicPartition topicPartition;
     private final long recordOffset;
     private final OffsetState offsetState;

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
@@ -100,7 +100,7 @@ public class CompactionProcessorTest {
                 taskData,
                 taskData.toByteArray());
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, name.getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, null, null);
+                1723687072569L, new TopicPartition("topic", 1), 1, null, name.getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, null, null);
 
         ProcessingContext<HelloTask> context =
                 spy(new ProcessingContextImpl<>("subscription", request, task,

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/ProcessorSubscriptionTest.java
@@ -149,7 +149,7 @@ public class ProcessorSubscriptionTest {
                 scope,
                 consumer,
                 NoopQuotaApplier.INSTANCE,
-                builder.build(null),
+                builder.build(null, scope.props()),
                 scope.props(),
                 listener);
     }
@@ -280,7 +280,7 @@ public class ProcessorSubscriptionTest {
                                             (ConsumedRecord record) -> new DecatonTask<>(
                                                     TaskMetadata.builder().build(), "dummy", record.value()))
                                  .thenProcess(processor)
-                                 .build(null),
+                                 .build(null, scope.props()),
                 scope.props(),
                 newState -> {
                     if (newState == State.RUNNING) {
@@ -357,7 +357,7 @@ public class ProcessorSubscriptionTest {
                                      ctx.deferCompletion().complete();
                                      taskCompleted.countDown();
                                  })
-                                 .build(null),
+                                 .build(null, scope.props()),
                 scope.props(),
                 null);
         subscription.start();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
@@ -171,8 +171,8 @@ public class DecatonTaskRetryQueueingProcessorTest {
                 SubPartitionRuntime.THREAD_POOL,
                 Optional.of(RetryConfig.builder().backoff(RETRY_BACKOFF).build()), Optional.empty(),
                 ProcessorProperties.builder()
-                                   .set(Property.ofStatic(ProcessorProperties.CONFIG_TASK_METADATA_AS_HEADER,
-                                                          false))
+                                   .set(Property.ofStatic(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT,
+                                                          true))
                                    .build(), NoopTracingProvider.INSTANCE,
                 ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS,
                 DefaultSubPartitioner::new);

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessorTest.java
@@ -171,7 +171,7 @@ public class DecatonTaskRetryQueueingProcessorTest {
                 SubPartitionRuntime.THREAD_POOL,
                 Optional.of(RetryConfig.builder().backoff(RETRY_BACKOFF).build()), Optional.empty(),
                 ProcessorProperties.builder()
-                                   .set(Property.ofStatic(ProcessorProperties.CONFIG_RETRY_TASK_AS_LEGACY_FORMAT,
+                                   .set(Property.ofStatic(ProcessorProperties.CONFIG_RETRY_TASK_IN_LEGACY_FORMAT,
                                                           true))
                                    .build(), NoopTracingProvider.INSTANCE,
                 ConsumerSupplier.DEFAULT_MAX_POLL_RECORDS,

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractorTest.java
@@ -46,7 +46,7 @@ public class DefaultTaskExtractorTest {
 
         ConsumedRecord record = ConsumedRecord
                 .builder()
-                .recordTimestamp(1561709151628L)
+                .recordTimestampMillis(1561709151628L)
                 .headers(new RecordHeaders())
                 .value(LEGACY_REQUEST.toByteArray())
                 .build();
@@ -67,7 +67,7 @@ public class DefaultTaskExtractorTest {
 
         ConsumedRecord record = ConsumedRecord
                 .builder()
-                .recordTimestamp(1561709151628L)
+                .recordTimestampMillis(1561709151628L)
                 .headers(new RecordHeaders())
                 .value(TASK.toByteArray())
                 .build();

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/DefaultTaskExtractorTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.decaton.processor.TaskMetadata;
 import com.linecorp.decaton.processor.runtime.ConsumedRecord;
 import com.linecorp.decaton.processor.runtime.DecatonTask;
+import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.Property;
 import com.linecorp.decaton.protobuf.ProtocolBuffersDeserializer;
 import com.linecorp.decaton.protocol.internal.DecatonInternal.DecatonTaskRequest;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
@@ -40,9 +42,9 @@ public class DefaultTaskExtractorTest {
                               .build();
     @Test
     public void testExtract() {
-        DefaultTaskExtractor.setParseAsLegacyWhenHeaderMissing(true);
         DefaultTaskExtractor<HelloTask> extractor = new DefaultTaskExtractor<>(
-                new ProtocolBuffersDeserializer<>(HelloTask.parser()));
+                new ProtocolBuffersDeserializer<>(HelloTask.parser()),
+                Property.ofStatic(ProcessorProperties.CONFIG_LEGACY_PARSE_FALLBACK_ENABLED, true));
 
         ConsumedRecord record = ConsumedRecord
                 .builder()
@@ -61,9 +63,9 @@ public class DefaultTaskExtractorTest {
 
     @Test
     public void testExtractBypassLegacyFormatWhenHeaderMissing() {
-        DefaultTaskExtractor.setParseAsLegacyWhenHeaderMissing(false);
         DefaultTaskExtractor<HelloTask> extractor = new DefaultTaskExtractor<>(
-                new ProtocolBuffersDeserializer<>(HelloTask.parser()));
+                new ProtocolBuffersDeserializer<>(HelloTask.parser()),
+                Property.ofStatic(ProcessorProperties.CONFIG_LEGACY_PARSE_FALLBACK_ENABLED, false));
 
         ConsumedRecord record = ConsumedRecord
                 .builder()

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
@@ -96,7 +96,7 @@ public class ProcessPipelineTest {
 
     private static TaskRequest taskRequest() {
         return new TaskRequest(
-                new TopicPartition("topic", 1), 1, new OffsetState(1234), "TEST".getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, TASK.toByteArray(), null);
+                1723687072569L, new TopicPartition("topic", 1), 1, new OffsetState(1234), "TEST".getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, TASK.toByteArray(), null);
     }
 
     @Mock

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
@@ -69,6 +69,8 @@ import lombok.RequiredArgsConstructor;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessingContextImplTest {
+    private static final long NOW = 1723687072569L;
+
     private static class NamedProcessor implements DecatonProcessor<HelloTask> {
         private final String name;
         private final DecatonProcessor<HelloTask> impl;
@@ -120,7 +122,7 @@ public class ProcessingContextImplTest {
     private static ProcessingContextImpl<HelloTask> context(RecordTraceHandle traceHandle,
                                                             DecatonProcessor<HelloTask>... processors) {
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8),
+                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8),
                 null, traceHandle, TASK.toByteArray(), null);
         DecatonTask<HelloTask> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK, TASK.toByteArray());
@@ -366,7 +368,7 @@ public class ProcessingContextImplTest {
         CountDownLatch retryLatch = new CountDownLatch(1);
         DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
+                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK.toByteArray(), TASK.toByteArray());
 
@@ -397,7 +399,7 @@ public class ProcessingContextImplTest {
         CountDownLatch retryLatch = new CountDownLatch(1);
         DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
-                new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
+                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK.toByteArray(), TASK.toByteArray());
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
@@ -67,7 +67,7 @@ public class ProcessorUnitTest {
 
         unit = spy(new ProcessorUnit(scope, pipeline, Executors.newSingleThreadExecutor()));
 
-        taskRequest = new TaskRequest(topicPartition, 1, new OffsetState(1234), null, null, null, HelloTask.getDefaultInstance().toByteArray(), null);
+        taskRequest = new TaskRequest(1723687072569L, topicPartition, 1, new OffsetState(1234), null, null, null, HelloTask.getDefaultInstance().toByteArray(), null);
     }
 
     @Test

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorsTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorsTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.linecorp.decaton.processor.runtime.DecatonProcessorSupplier;
 import com.linecorp.decaton.processor.runtime.DefaultSubPartitioner;
 import com.linecorp.decaton.processor.runtime.ProcessorProperties;
+import com.linecorp.decaton.processor.runtime.Property;
 import com.linecorp.decaton.processor.runtime.SubPartitionRuntime;
 import com.linecorp.decaton.processor.tracing.internal.NoopTracingProvider;
 import com.linecorp.decaton.protocol.Sample.HelloTask;
@@ -69,7 +70,8 @@ public class ProcessorsTest {
 
         Processors<HelloTask> processors = new Processors<>(
                 suppliers, null,
-                new DefaultTaskExtractor<>(bytes -> HelloTask.getDefaultInstance()),
+                new DefaultTaskExtractor<>(bytes -> HelloTask.getDefaultInstance(),
+                                           Property.ofStatic(ProcessorProperties.CONFIG_LEGACY_PARSE_FALLBACK_ENABLED)),
                 null);
 
         doThrow(new RuntimeException("exception")).when(suppliers.get(2)).getProcessor(any(), any(), anyInt());


### PR DESCRIPTION
## Motivation
- As of Decaton 8.0.1, the most common way to use Decaton was to use DecatonClient as the producer and DecatonProcessor as the consumer, with implementing value Serializer/Deserializer respectively.
- After #238, DecatonClient no longer wraps tasks with `DecatonTaskRequest` protobuf, which means records produced by DecatonClient and ones produced by non-DecatonClient producers (serialized by Kafka's serializer) have identical serialized bytes.
  * Then why not making `Deserializer` support consuming non-DecatonClient topics, without forcing users to implement `TaskExtractor` (which is bit bothersome than just a deserializer) ?

## Summary of changes
- Update documentations and examples
- `ProcessorsBuilder#consuming(String topic, Deserializer<T> deserializer)` now deserializes messages bytes directly even when task-metadata header is missing. **This is a breaking change**
  * Previous behavior when task-metadata header is missing was to unwrap as `DecatonTaskRequest` pb first, then deserialize serialized task in it. This was for `<= 8.0.0 to 9.0.0` migration where old DecatonClient might produce records during the upgrade.
      * Since "records are produced by old client / or records are produced by non-Decaton client" is not distinguishable from Decaton, we add new `decaton.parse.as.legacy.format.when.header.missing` property to control the behavior for graceful migration.
  * With regards to this, when task-metadata header is missing, we need to fill reasonable default of task metadata.
      * The only field must be filled might be `TaskMetadata#timestampMillis`.
          - e.g. to calculate delivery latency correctly
      * To fill `timestampMillis`, we add `ConsumedRecord#recordTimestampMillis`, which can be retrieved from record itself

## Expected upgrade procedure from <= 8.0.1 to 9.0.0
- Enable both `decaton.retry.task.as.legacy.format` and `decaton.parse.as.legacy.format.when.header.missing`
- Upgrade all processor instances
- Upgrade all decaton client
- Disable `decaton.retry.task.as.legacy.format`
- Disable `decaton.parse.as.legacy.format.when.header.missing`

I'll describe the detail in 9.0.0 release note