### PR TITLE
Fix task parse failure during migration to v9 fixes #250

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/internal/TaskMetadataUtil.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/TaskMetadataUtil.java
@@ -26,7 +26,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.linecorp.decaton.protocol.Decaton.TaskMetadataProto;
 
 public class TaskMetadataUtil {
-    private static final String METADATA_HEADER_KEY = "dt_meta";
+    public static final String METADATA_HEADER_KEY = "dt_meta";
 
     /**
      * Write metadata to {@link Headers}

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/DecatonTaskRetryQueueingProcessor.java
@@ -82,6 +82,13 @@ public class DecatonTaskRetryQueueingProcessor implements DecatonProcessor<byte[
                     context.key(),
                     request.toByteArray(),
                     context.headers());
+            // When decaton.legacy.parse.fallback.enabled is true during v9 upgrade process,
+            // it determines whether to parse tasks in legacy format or not based on the existence of metadata header.
+            // If header existence and the format is inconsistent, it will throw an exception on task parsing.
+            //
+            // At this point, DecatonClient may be already upgraded to v9 (i.e. produce tasks in new format with added metadata header).
+            // Hence, to ensure this retry tasks can be parsed correctly, we have to remove it when producing a task in legacy format.
+            record.headers().remove(TaskMetadataUtil.METADATA_HEADER_KEY);
         } else {
             record = new ProducerRecord<>(
                     retryTopic,


### PR DESCRIPTION
## Summary
- As described in #250, current upgrade procedure for CaseD doesn't work because retry tasks might be serialized as old format when `retry.task.in.legacy.format` is true while preserving `dt_meta` if original task is produced by new decaton client
  * Existing integration test didn't catch this because the procedure written in release-note and the procedure in integration test wasn't equal... This was the mistake I overlooked.
      - Unliked CaseD, current integration test disables `retry.task.in.legacy.format` before upgrading decaton client, which works correctly
- To fix this, we should ensure `dt_meta exists iff the task is in new format` is always true, by removing `dt_meta` when producing retry task in old format

## Appendix
- I formally verified the correctness: https://github.com/line/decaton/issues/250#issuecomment-2883796173

## TODO
- Update upgrade guide in RELEASE NOTE with:
  * WARN CaseD doesn't work in Decaton <= v9.1.0 so must go with v9.1.1