### PR TITLE
Fix `decaton.processor.processed.time` to measure task processing time

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ThreadPoolSubPartitions.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/ThreadPoolSubPartitions.java
@@ -89,12 +89,14 @@ public class ThreadPoolSubPartitions extends AbstractSubPartitions {
                                       Utils.namedThreadFactory("PartitionProcessorThread-" + scope)) {
             @Override
             public void execute(Runnable command) {
-                Timer timer = Utils.timer();
-                try {
-                    super.execute(command);
-                } finally {
-                    metrics.processorProcessedTime.record(timer.duration());
-                }
+                super.execute(() -> {
+                    Timer timer = Utils.timer();
+                    try {
+                        command.run();
+                    } finally {
+                        metrics.processorProcessedTime.record(timer.duration());
+                    }
+                });
             }
         };
     }


### PR DESCRIPTION
Fix #252. I apologize if my correction is incorrect.

## Summary
- As-Is: `decaton.processor.processed.time` measured the time taken to execute [`ThreadPoolExecutor#execute`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html#execute(java.lang.Runnable)) itself.
- To-Be: This timer measures the time taken to execute `command` (= `processTask(request)`).