### PR TITLE
Run unintentionally ignored tests

### DIFF
--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     testImplementation "com.linecorp.centraldogma:centraldogma-testing-junit:$centralDogmaVersion"
     // Necessary to mock final class CentralDogmaRepository for simulating concurrent updates
     testImplementation "org.mockito:mockito-inline:4.11.0"
+    testRuntimeOnly "ch.qos.logback:logback-classic:1.4.11"
 }

--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -14,5 +14,8 @@ dependencies {
     api "com.linecorp.centraldogma:centraldogma-client:$centralDogmaVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 
-    testImplementation "com.linecorp.centraldogma:centraldogma-testing-junit4:$centralDogmaVersion"
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+    testImplementation "com.linecorp.centraldogma:centraldogma-testing-junit:$centralDogmaVersion"
+    // Necessary to mock final class CentralDogmaRepository for simulating concurrent updates
+    testImplementation "org.mockito:mockito-inline:4.11.0"
 }

--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
@@ -57,7 +57,7 @@ import com.linecorp.decaton.processor.runtime.Property;
 
 public class CentralDogmaPropertySupplierIntegrationTest {
     @RegisterExtension
-    static final CentralDogmaExtension extension = new CentralDogmaExtension() {
+    final CentralDogmaExtension extension = new CentralDogmaExtension() {
         @Override
         protected boolean runForEachTest() {
             return true;

--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
@@ -189,17 +189,17 @@ public class CentralDogmaPropertySupplierIntegrationTest {
     @Test
     @Timeout(15)
     public void testCDRegisterTimeout() {
+        CentralDogma client = extension.client();
+        client.createProject(PROJECT_NAME).join();
+        CentralDogmaRepository centralDogmaRepository = spy(client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join());
+
+        doReturn(CompletableFuture.completedFuture(new Revision(1)))
+                .when(centralDogmaRepository)
+                .normalize(any());
+
+        CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
+
         assertThrows(RuntimeException.class, () -> {
-            CentralDogma client = extension.client();
-            client.createProject(PROJECT_NAME).join();
-            CentralDogmaRepository centralDogmaRepository = spy(client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join());
-
-            doReturn(CompletableFuture.completedFuture(new Revision(1)))
-                    .when(centralDogmaRepository)
-                    .normalize(any());
-
-            CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
-
             CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
         });
     }

--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierIntegrationTest.java
@@ -17,10 +17,11 @@
 package com.linecorp.decaton.centraldogma;
 
 import static com.linecorp.decaton.processor.runtime.ProcessorProperties.CONFIG_PARTITION_CONCURRENCY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -34,8 +35,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -49,14 +51,18 @@ import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 import com.linecorp.decaton.processor.runtime.ProcessorProperties;
 import com.linecorp.decaton.processor.runtime.Property;
 
 public class CentralDogmaPropertySupplierIntegrationTest {
+    @RegisterExtension
+    static final CentralDogmaExtension extension = new CentralDogmaExtension() {
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
 
-    @Rule
-    public CentralDogmaRule centralDogmaRule = new CentralDogmaRule() {
         @Override
         protected void configureHttpClient(WebClientBuilder builder) {
             builder.decorator(RetryingClient.builder(RetryRule.onUnprocessed())
@@ -74,9 +80,10 @@ public class CentralDogmaPropertySupplierIntegrationTest {
                 ProcessorProperties.defaultProperties());
     }
 
-    @Test(timeout = 50000)
+    @Test
+    @Timeout(50)
     public void testCDIntegration() throws InterruptedException {
-        CentralDogma client = centralDogmaRule.client();
+        CentralDogma client = extension.client();
 
         final String ORIGINAL =
                 "{\n"
@@ -134,7 +141,7 @@ public class CentralDogmaPropertySupplierIntegrationTest {
 
     @Test
     public void testFileExist() {
-        CentralDogma client = centralDogmaRule.client();
+        CentralDogma client = extension.client();
         client.createProject(PROJECT_NAME).join();
         CentralDogmaRepository centralDogmaRepository = client.createRepository(PROJECT_NAME, REPOSITORY_NAME)
                                                               .join();
@@ -149,16 +156,17 @@ public class CentralDogmaPropertySupplierIntegrationTest {
 
     @Test
     public void testFileNonExistent() {
-        CentralDogma client = centralDogmaRule.client();
+        CentralDogma client = extension.client();
         client.createProject(PROJECT_NAME).join();
         CentralDogmaRepository centralDogmaRepository = client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
         assertFalse(CentralDogmaPropertySupplier
                             .fileExists(centralDogmaRepository, FILENAME, Revision.HEAD));
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10)
     public void testCDRegisterSuccess() {
-        CentralDogma client = centralDogmaRule.client();
+        CentralDogma client = extension.client();
         client.createProject(PROJECT_NAME).join();
         CentralDogmaRepository centralDogmaRepository = client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
 
@@ -169,33 +177,40 @@ public class CentralDogmaPropertySupplierIntegrationTest {
                      prop.content().asText());
     }
 
-    @Test(timeout = 10000, expected = RuntimeException.class)
+    @Test
+    @Timeout(10)
     public void testCDRegisterNonExistentProject() {
-        CentralDogmaPropertySupplier.register(centralDogmaRule.client(),
-                                              "non-existent-project", REPOSITORY_NAME, FILENAME);
+        assertThrows(RuntimeException.class, () -> {
+            CentralDogmaPropertySupplier.register(extension.client(),
+                                                  "non-existent-project", REPOSITORY_NAME, FILENAME);
+        });
     }
 
-    @Test(timeout = 15000, expected = RuntimeException.class)
+    @Test
+    @Timeout(15)
     public void testCDRegisterTimeout() {
-        CentralDogma client = centralDogmaRule.client();
-        client.createProject(PROJECT_NAME).join();
-        CentralDogmaRepository centralDogmaRepository = spy(client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join());
+        assertThrows(RuntimeException.class, () -> {
+            CentralDogma client = extension.client();
+            client.createProject(PROJECT_NAME).join();
+            CentralDogmaRepository centralDogmaRepository = spy(client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join());
 
-        doReturn(CompletableFuture.completedFuture(new Revision(1)))
-                .when(centralDogmaRepository)
-                .normalize(any());
+            doReturn(CompletableFuture.completedFuture(new Revision(1)))
+                    .when(centralDogmaRepository)
+                    .normalize(any());
 
-        CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
+            CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
 
-        CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
+            CentralDogmaPropertySupplier.register(centralDogmaRepository, FILENAME);
+        });
     }
 
-    @Test(timeout = 15000)
+    @Test
+    @Timeout(15)
     public void testCDRegisterConflict() throws Exception {
         CountDownLatch userAIsRunning = new CountDownLatch(1);
         CountDownLatch userBIsRunning = new CountDownLatch(1);
 
-        CentralDogma client = centralDogmaRule.client();
+        CentralDogma client = extension.client();
         client.createProject(PROJECT_NAME).join();
         CentralDogmaRepository userB = client.createRepository(PROJECT_NAME, REPOSITORY_NAME).join();
         CentralDogmaRepository userA = spy(client.forRepo(PROJECT_NAME, REPOSITORY_NAME));

--- a/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierTest.java
+++ b/centraldogma/src/test/java/com/linecorp/decaton/centraldogma/CentralDogmaPropertySupplierTest.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.decaton.centraldogma;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,12 +36,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -65,10 +65,9 @@ import com.linecorp.decaton.processor.runtime.PropertyDefinition;
 import com.linecorp.decaton.processor.runtime.PropertySupplier;
 import com.linecorp.decaton.processor.runtime.StaticPropertySupplier;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class CentralDogmaPropertySupplierTest {
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String FILENAME = "/subscription.json";
@@ -92,7 +91,7 @@ public class CentralDogmaPropertySupplierTest {
 
     private CentralDogmaPropertySupplier supplier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(centralDogmaRepository.watcher(Query.ofJsonPath(FILENAME))).thenReturn(watcherRequest);
         when(watcherRequest.start()).thenReturn(rootWatcher);

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+plugins {
+    // To allow auto downloading toolchain when necessary
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = "decaton"
 include ":protocol"
 include ":client"

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -35,10 +35,14 @@ task integrationTestSpringBoot3(type: Test) {
     classpath = sourceSets.integrationTestSpringBoot3.runtimeClasspath
 }
 
+check.dependsOn(integrationTestSpringBoot2, integrationTestSpringBoot3)
+
 tasks.named('compileIntegrationTestSpringBoot3Java') {
     javaCompiler = javaToolchains.compilerFor {
         languageVersion = JavaLanguageVersion.of(17)
     }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -34,8 +34,7 @@ task integrationTestSpringBoot3(type: Test) {
     testClassesDirs = sourceSets.integrationTestSpringBoot3.output.classesDirs
     classpath = sourceSets.integrationTestSpringBoot3.runtimeClasspath
 
-    // Decaton is tested with Java 8, 11.
-    // boot3 test doesn't work with these versions because boot3 requires Java 17.
+    // boot3 test doesn't work with old Java versions because boot3 requires Java 17.
     enabled = javaLauncher.get().metadata.languageVersion.asInt() >= 17
 }
 

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -33,14 +33,17 @@ task integrationTestSpringBoot2(type: Test) {
 task integrationTestSpringBoot3(type: Test) {
     testClassesDirs = sourceSets.integrationTestSpringBoot3.output.classesDirs
     classpath = sourceSets.integrationTestSpringBoot3.runtimeClasspath
+
+    // Decaton is tested with Java 8, 11.
+    // boot3 test doesn't work with these versions because boot3 requires Java 17.
+    enabled = javaLauncher.get().metadata.languageVersion.asInt() >= 17
 }
 
 check.dependsOn(integrationTestSpringBoot2, integrationTestSpringBoot3)
 
 tasks.named('compileIntegrationTestSpringBoot3Java') {
-    javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
+    // These settings are necessary to resolve boot3 dependencies correctly
+    // (rather than just setting javaCompiler option to 17 like we previously did).
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }

--- a/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/AutoConfigureDecatonConfigurationTest.java
+++ b/spring/src/integrationTestSpringBoot3/java/com/linecorp/decatonl/spring/test/AutoConfigureDecatonConfigurationTest.java
@@ -18,19 +18,17 @@ package com.linecorp.decatonl.spring.test;
 
 import com.linecorp.decaton.spring.beans.DecatonConfiguration;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = NONE)
 public class AutoConfigureDecatonConfigurationTest {
 


### PR DESCRIPTION
- Found that `centraldogma`'s tests still depend on junit4, while Decaton's global test runner is already migrated to junit5 in #214 
  * Due to this, `centraldogma`'s tests were not executed at all unintentionally
- Also, `spring`'s integration tests were not executed because it isn't included in `check` task