### PR TITLE
Add a metric for v9 upgrade

### DIFF
--- a/client/src/main/java/com/linecorp/decaton/client/internal/TaskMetadataUtil.java
+++ b/client/src/main/java/com/linecorp/decaton/client/internal/TaskMetadataUtil.java
@@ -55,4 +55,8 @@ public class TaskMetadataUtil {
             throw new UncheckedIOException(e);
         }
     }
+
+    public static boolean hasMetadataHeader(Headers headers) {
+        return headers.lastHeader(METADATA_HEADER_KEY) != null;
+    }
 }


### PR DESCRIPTION
## Motivation
- In [Decaton v9 upgrade procedure], before disabling `decaton.legacy.parse.fallback.enabled` at the last step in B,C,D, we have to ensure all tasks are produced in new format
- Ensuring all producers are producing with Decaton client v9 with new format might be hard in practice, which may result in serious issue like task drop by deserialization (or more worse, corrupted task might be caused) if failed
- We should provide a metric to ensure if users can disable `decaton.legacy.parse.fallback.enabled` or not

## NOTE
- Several issues found on v9 upgrade procedure by user report, and v9.0.0's release note is becoming complex.
  * I'll prepare a dedicate document in `docs` later in separate PR
- To create per-topic label, we dynamically create Counter without defining in `Metrics`. I expect this doesn't cause performance issue because micrometer has cache-mechanism. But I'll check performance dashboard after PR gets merged and find another way if there's performance drop