### PR TITLE
PerKeyQuota usage is double counted fixes #265

### DIFF
--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -19,6 +19,7 @@ package com.linecorp.decaton.processor.runtime.internal;
 import java.util.Collection;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -92,6 +93,14 @@ public class PartitionContext implements AutoCloseable {
     PartitionContext(PartitionScope scope,
                      Processors<?> processors,
                      SubPartitions subPartitions) {
+        this(scope, processors, subPartitions, System::currentTimeMillis);
+    }
+
+    // visible for testing
+    PartitionContext(PartitionScope scope,
+                     Processors<?> processors,
+                     SubPartitions subPartitions,
+                     LongSupplier timestampSupplier) {
         this.scope = scope;
         this.processors = processors;
         this.subPartitions = subPartitions;
@@ -107,7 +116,7 @@ public class PartitionContext implements AutoCloseable {
                 metricsCtor.new CommitControlMetrics());
         commitControl = new OutOfOrderCommitControl(scope.topicPartition(), capacity, offsetStateReaper);
         if (scope.perKeyQuotaConfig().isPresent() && scope.originTopic().equals(scope.topicPartition().topic())) {
-            perKeyQuotaManager = PerKeyQuotaManager.create(scope);
+            perKeyQuotaManager = PerKeyQuotaManager.create(scope, timestampSupplier);
         } else {
             perKeyQuotaManager = null;
         }
@@ -188,7 +197,7 @@ public class PartitionContext implements AutoCloseable {
         if (!quotaApplier.apply(record, offsetState, maybeRecordQuotaUsage(record.key()))) {
             TaskRequest request = new TaskRequest(
                     record.timestamp(), scope.topicPartition(), record.offset(), offsetState, record.key(),
-                    record.headers(), traceHandle, record.value(), maybeRecordQuotaUsage(record.key()));
+                    record.headers(), traceHandle, record.value());
             subPartitions.addTask(request);
         }
 

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PartitionContext.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.decaton.processor.runtime.internal;
 
+import java.time.Clock;
 import java.util.Collection;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
-import java.util.function.LongSupplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -93,14 +93,14 @@ public class PartitionContext implements AutoCloseable {
     PartitionContext(PartitionScope scope,
                      Processors<?> processors,
                      SubPartitions subPartitions) {
-        this(scope, processors, subPartitions, System::currentTimeMillis);
+        this(scope, processors, subPartitions, Clock.systemDefaultZone());
     }
 
     // visible for testing
     PartitionContext(PartitionScope scope,
                      Processors<?> processors,
                      SubPartitions subPartitions,
-                     LongSupplier timestampSupplier) {
+                     Clock clock) {
         this.scope = scope;
         this.processors = processors;
         this.subPartitions = subPartitions;
@@ -116,7 +116,7 @@ public class PartitionContext implements AutoCloseable {
                 metricsCtor.new CommitControlMetrics());
         commitControl = new OutOfOrderCommitControl(scope.topicPartition(), capacity, offsetStateReaper);
         if (scope.perKeyQuotaConfig().isPresent() && scope.originTopic().equals(scope.topicPartition().topic())) {
-            perKeyQuotaManager = PerKeyQuotaManager.create(scope, timestampSupplier);
+            perKeyQuotaManager = PerKeyQuotaManager.create(scope, clock);
         } else {
             perKeyQuotaManager = null;
         }

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PerKeyQuotaManager.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/PerKeyQuotaManager.java
@@ -91,7 +91,7 @@ public class PerKeyQuotaManager {
         PerKeyQuotaManager.delta = delta;
     }
 
-    public static PerKeyQuotaManager create(PartitionScope scope) {
+    public static PerKeyQuotaManager create(PartitionScope scope, LongSupplier timestampSupplier) {
         long seed = System.currentTimeMillis();
         log.info("Creating key counters with seed {} for partition {}", seed, scope.topicPartition());
 
@@ -103,7 +103,7 @@ public class PerKeyQuotaManager {
         WindowedKeyStat windowedStat = new WindowedKeyStat(
                 scope.perKeyQuotaConfig().get().window(),
                 counterSupplier);
-        return new PerKeyQuotaManager(scope, System::currentTimeMillis, windowedStat);
+        return new PerKeyQuotaManager(scope, timestampSupplier, windowedStat);
     }
 
     /**

--- a/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
+++ b/processor/src/main/java/com/linecorp/decaton/processor/runtime/internal/TaskRequest.java
@@ -19,7 +19,6 @@ package com.linecorp.decaton.processor.runtime.internal;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 
-import com.linecorp.decaton.processor.runtime.internal.PerKeyQuotaManager.QuotaUsage;
 import com.linecorp.decaton.processor.tracing.TracingProvider.RecordTraceHandle;
 
 import lombok.AllArgsConstructor;
@@ -44,8 +43,6 @@ public class TaskRequest {
     private final RecordTraceHandle trace;
     @ToString.Exclude
     private byte[] rawRequestBytes;
-    @ToString.Exclude
-    private final QuotaUsage quotaUsage;
 
     public String id() {
         // TaskRequest object is held alive through associated ProcessingContext's lifetime, hence holding

--- a/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/processors/CompactionProcessorTest.java
@@ -100,7 +100,7 @@ public class CompactionProcessorTest {
                 taskData,
                 taskData.toByteArray());
         TaskRequest request = new TaskRequest(
-                1723687072569L, new TopicPartition("topic", 1), 1, null, name.getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, null, null);
+                1723687072569L, new TopicPartition("topic", 1), 1, null, name.getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, null);
 
         ProcessingContext<HelloTask> context =
                 spy(new ProcessingContextImpl<>("subscription", request, task,

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessPipelineTest.java
@@ -96,7 +96,7 @@ public class ProcessPipelineTest {
 
     private static TaskRequest taskRequest() {
         return new TaskRequest(
-                1723687072569L, new TopicPartition("topic", 1), 1, new OffsetState(1234), "TEST".getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, TASK.toByteArray(), null);
+                1723687072569L, new TopicPartition("topic", 1), 1, new OffsetState(1234), "TEST".getBytes(StandardCharsets.UTF_8), null, NoopTrace.INSTANCE, TASK.toByteArray());
     }
 
     @Mock

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessingContextImplTest.java
@@ -123,7 +123,7 @@ public class ProcessingContextImplTest {
                                                             DecatonProcessor<HelloTask>... processors) {
         TaskRequest request = new TaskRequest(
                 NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8),
-                null, traceHandle, TASK.toByteArray(), null);
+                null, traceHandle, TASK.toByteArray());
         DecatonTask<HelloTask> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK, TASK.toByteArray());
         return new ProcessingContextImpl<>("subscription", request, task, Arrays.asList(processors),
@@ -368,7 +368,7 @@ public class ProcessingContextImplTest {
         CountDownLatch retryLatch = new CountDownLatch(1);
         DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
-                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
+                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray());
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK.toByteArray(), TASK.toByteArray());
 
@@ -399,7 +399,7 @@ public class ProcessingContextImplTest {
         CountDownLatch retryLatch = new CountDownLatch(1);
         DecatonProcessor<byte[]> retryProcessor = spy(new AsyncCompleteProcessor(retryLatch));
         TaskRequest request = new TaskRequest(
-                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray(), null);
+                NOW, new TopicPartition("topic", 1), 1, null, "TEST".getBytes(StandardCharsets.UTF_8), null, null, TASK.toByteArray());
         DecatonTask<byte[]> task = new DecatonTask<>(
                 TaskMetadata.builder().build(), TASK.toByteArray(), TASK.toByteArray());
 

--- a/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
+++ b/processor/src/test/java/com/linecorp/decaton/processor/runtime/internal/ProcessorUnitTest.java
@@ -67,7 +67,7 @@ public class ProcessorUnitTest {
 
         unit = spy(new ProcessorUnit(scope, pipeline, Executors.newSingleThreadExecutor()));
 
-        taskRequest = new TaskRequest(1723687072569L, topicPartition, 1, new OffsetState(1234), null, null, null, HelloTask.getDefaultInstance().toByteArray(), null);
+        taskRequest = new TaskRequest(1723687072569L, topicPartition, 1, new OffsetState(1234), null, null, null, HelloTask.getDefaultInstance().toByteArray());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Currently, Quota usage is counted twice mistakenly in PartitionContext, which causes keys to reach the quota at the half of quota value and shaped
- Added the test to ensure the double count is fixed.
- Also tested PerKeyQuota feature locally with this code (https://gist.github.com/ocadaruma/4503de325490c2591c0003bcb25540fc#file-realperkeyquotatest-java)
  * <img width="1489" height="711" alt="image" src="https://github.com/user-attachments/assets/253179fa-f7e9-4148-b146-8a387a996376" />
  * Confirmed worked as expected with quota = 500msg/sec. (400msg/sec -> not shaped, 600msg/sec -> shaped)