### PR TITLE
Fix shadow build failure

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -76,7 +76,7 @@ public class CustomRunner implements Runner {
 
 #### Build a shadowJar of the custom runner:
 
-Build one using https://github.com/johnrengelman/shadow
+Build one using https://github.com/GradleUp/shadow
 
 ### Run benchmark:
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ import java.net.http.HttpResponse
 
 plugins {
     id "me.champeau.jmh" version "0.6.6" apply false
-    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.gradleup.shadow' version '8.3.6' apply false
     id 'io.freefair.lombok' version '8.2.2' apply false
 }
 
@@ -50,7 +50,7 @@ subprojects {
     // it does not work well by failing to generate an jmh JAR to be executed.
     // https://github.com/melix/jmh-gradle-plugin/blob/c17c89c8fed6d655678aac16ecd5b683ea7fc8b5/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy#L77
     apply plugin: 'me.champeau.jmh'
-    apply plugin: 'com.github.johnrengelman.shadow'
+    apply plugin: 'com.gradleup.shadow'
     apply plugin: 'io.freefair.lombok'
 
     group = "com.linecorp.decaton"

--- a/docs/example/build.gradle
+++ b/docs/example/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'com.google.protobuf' version '0.8.18'
-    id 'com.github.johnrengelman.shadow' version '7.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 ext {

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -11,7 +11,7 @@ In this guide we'll use Protocol Buffers since it's our usual choice.
 While Decaton provides support for Protocol Buffers, you can choose arbitrary serialization format as you want. All you need is to implement link:../common/src/main/java/com/linecorp/decaton/common/Serializer.java[Serializer] and link:../common/src/main/java/com/linecorp/decaton/common/Deserializer.java[Deserializer] and supply it to where Decaton API requires.
 
 To make use of Protocol Buffers, you need to configure your build to compile Java classes from protobuf IDLs during build.
-We also apply link:https://github.com/johnrengelman/shadow[gradle plugin for making shadow jar] for ease of executing, but it's completely optional in real projects.
+We also apply link:https://github.com/GradleUp/shadow[gradle plugin for making shadow jar] for ease of executing, but it's completely optional in real projects.
 
 [source,groovy]
 .build.gradle
@@ -19,7 +19,7 @@ We also apply link:https://github.com/johnrengelman/shadow[gradle plugin for mak
 plugins {
     id 'idea'
     id 'com.google.protobuf' version '0.8.18'
-    id 'com.github.johnrengelman.shadow' version '7.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 dependencies {


### PR DESCRIPTION
Currently, `./gradlew :benchmark:shadowJar` fails with below error:
```
* What went wrong:
Execution failed for task ':benchmark:shadowJar'.
> Unsupported class file major version 65
```

Suspecting this https://github.com/GradleUp/shadow/issues/894.
Not 100% sure why and when this error started happen though, let's just upgrade.

Confirmed locally the issue is fixed.