### PR TITLE
Run shadowJar task before assemble

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,7 @@ subprojects {
             }
         }
     }
+    assemble.dependsOn(shadowJar)
 
     tasks.withType(PublishToMavenRepository) {
         onlyIf {


### PR DESCRIPTION
`./gradlew build --dry-run` without this patch doesn't show shadowJar task.

Let's run this on every PR and master push to catch issues early, rather than troubleshooting them during the publish phase.

This is related to https://github.com/line/decaton/pull/272