### PR TITLE
Use version catelogs in Gradle

### DIFF
--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,25 +1,22 @@
 ext {
     publishOnlyLocal = true
     shadeAllDependencies = true
-
-    picoVersion = "4.2.0"
-    jacksonVersion = "2.13.4"
 }
 
 dependencies {
     implementation project(":processor")
     implementation project(":testing")
 
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
+    implementation libs.slf4jApi
+    implementation libs.kafkaClients
 
-    annotationProcessor "info.picocli:picocli-codegen:$picoVersion"
-    implementation "info.picocli:picocli:$picoVersion"
-    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    annotationProcessor libs.picocliCodegen
+    implementation libs.picocli
+    implementation libs.jacksonLegacyCore
+    implementation libs.jacksonLegacyDatabind
+    implementation libs.jacksonLegacyDataformatYaml
     // To serialize java.time.Duration
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jacksonLegacyDatatypeJsr310
 
-    runtimeOnly "ch.qos.logback:logback-classic:1.4.11"
+    runtimeOnly libs.logbackClassic
 }

--- a/brave/build.gradle
+++ b/brave/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     api project(":processor")
 
-    api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "io.zipkin.brave:brave-instrumentation-kafka-clients:5.18.1"
+    api libs.kafkaClients
+    api libs.braveInstrumentationKafka
 
     itImplementation project(":testing")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -64,17 +64,6 @@ subprojects {
     }
 
     ext {
-        // Freezing this to 1.X until https://github.com/spring-projects/spring-boot/issues/12649 is resolved
-        slf4jVersion = "1.7.36"
-        protobufVersion = "3.22.3"
-        kafkaVersion = "3.9.2"
-        micrometerVersion = "1.12.4"
-        micrometerTracingVersion = "1.2.4"
-        lombokVersion = "1.18.30"
-        junitVersion = "5.10.0"
-        hamcrestVersion = "2.2"
-        javaDocExtractorVersion = "0.15.0"
-
         isReleaseVersion = !version.endsWith('-SNAPSHOT')
 
         shadeAllDependencies = false // Whether this project should results uber jar or not
@@ -85,7 +74,7 @@ subprojects {
 
     // need override because gradle-lombok plugin brings outdated lombok version
     lombok {
-        version = "$lombokVersion"
+        version = libs.versions.lombok.get()
     }
 
     gradle.projectsEvaluated {
@@ -101,14 +90,14 @@ subprojects {
     }
 
     dependencies {
-        compileOnly "org.projectlombok:lombok:$lombokVersion"
-        annotationProcessor "org.projectlombok:lombok:$lombokVersion"
+        compileOnly libs.lombok
+        annotationProcessor libs.lombok
 
         // Likely be used for most modules
-        testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-        testImplementation "org.mockito:mockito-core:4.11.0"
-        testImplementation "org.mockito:mockito-junit-jupiter:4.11.0"
-        itImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+        testImplementation libs.junitJupiter
+        testImplementation libs.mockitoCore
+        testImplementation libs.mockitoJunitJupiter
+        itImplementation libs.junitJupiter
     }
 
     sourceSets.create('it') {

--- a/centraldogma/build.gradle
+++ b/centraldogma/build.gradle
@@ -2,13 +2,6 @@ repositories {
     mavenCentral()
 }
 
-ext {
-    centralDogmaVersion = "0.64.3"
-    jacksonVersion = "2.17.0"
-    jsonSchemaGeneratorVersion = "4.38.0"
-    jsonSchemaSlf4jVersion = "2.0.12"
-}
-
 sourceSets {
     jsonschema {
         java.srcDir 'src/jsonschema/java'
@@ -25,25 +18,25 @@ configurations {
 dependencies {
     api project(":processor")
 
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    api "com.linecorp.centraldogma:centraldogma-client:$centralDogmaVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    implementation libs.slf4jApi
+    api libs.centraldogmaClient
+    implementation libs.jacksonCurrentDatabind
+    implementation libs.jacksonCurrentDataformatYaml
 
-    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-    testImplementation "com.linecorp.centraldogma:centraldogma-testing-junit:$centralDogmaVersion"
+    testImplementation libs.hamcrest
+    testImplementation libs.centraldogmaTestingJunit
     // Necessary to mock final class CentralDogmaRepository for simulating concurrent updates
-    testImplementation "org.mockito:mockito-inline:4.11.0"
-    testRuntimeOnly "ch.qos.logback:logback-classic:1.4.11"
-    testImplementation "com.networknt:json-schema-validator:1.5.8"
+    testImplementation libs.mockitoInline
+    testRuntimeOnly libs.logbackClassic
+    testImplementation libs.jsonSchemaValidator
 
     // For generating JSON Schemas for Decaton ProcessorProperties
     jsonschemaImplementation project(":processor")
-    jsonschemaImplementation "org.slf4j:slf4j-api:$jsonSchemaSlf4jVersion"
-    jsonschemaImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    jsonschemaImplementation "com.github.victools:jsonschema-generator:$jsonSchemaGeneratorVersion"
-    jsonschemaImplementation "com.github.therapi:therapi-runtime-javadoc:$javaDocExtractorVersion"
-    jsonschemaRuntimeOnly "org.slf4j:slf4j-simple:$jsonSchemaSlf4jVersion"
+    jsonschemaImplementation libs.slf4jApiJsonschema
+    jsonschemaImplementation libs.jacksonCurrentDatabind
+    jsonschemaImplementation libs.jsonSchemaGenerator
+    jsonschemaImplementation libs.therapiRuntimeJavadoc
+    jsonschemaRuntimeOnly libs.slf4jSimple
 }
 
 def schemaOutDir = file("$projectDir/src/jsonschema/dist")

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -2,8 +2,8 @@ dependencies {
     api project(":protocol")
     api project(":common")
 
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    api "org.apache.kafka:kafka-clients:$kafkaVersion"
+    implementation libs.slf4jApi
+    api libs.kafkaClients
 
     testImplementation project(":protobuf")
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -3,7 +3,7 @@ ext {
 }
 
 dependencies {
-    implementation "org.asciidoctor:asciidoctorj:2.1.0"
+    implementation libs.asciidoctorj
 }
 
 task(validateDocs, dependsOn: 'classes', type: JavaExec) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,80 @@
+[versions]
+slf4j = "1.7.36"
+protobuf = "3.22.3"
+kafka = "3.9.2"
+micrometer = "1.12.4"
+micrometerTracing = "1.2.4"
+lombok = "1.18.30"
+junit = "5.10.0"
+hamcrest = "2.2"
+therapi = "0.15.0"
+mockito = "4.11.0"
+zipkinBrave = "5.18.1"
+zeroAllocationHashing = "0.16"
+picocli = "4.2.0"
+jacksonLegacy = "2.13.4"
+jacksonCurrent = "2.17.0"
+logbackClassic = "1.4.11"
+logbackClassicLegacy = "1.3.14"
+centraldogma = "0.64.3"
+jsonSchemaGenerator = "4.38.0"
+jsonSchemaSlf4j = "2.0.12"
+jsonSchemaValidator = "1.5.8"
+zookeeper = "3.5.6"
+otelKafka = "1.33.1-alpha"
+springBoot2 = "2.7.18"
+springBoot3 = "3.1.10"
+asciidoctorj = "2.1.0"
+
+[libraries]
+slf4jApi = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4jApiJsonschema = { module = "org.slf4j:slf4j-api", version.ref = "jsonSchemaSlf4j" }
+slf4jSimple = { module = "org.slf4j:slf4j-simple", version.ref = "jsonSchemaSlf4j" }
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
+junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
+mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockitoJunitJupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+mockitoInline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
+
+kafkaClients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
+kafkaScala = { module = "org.apache.kafka:kafka_2.12", version.ref = "kafka" }
+kafkaServer = { module = "org.apache.kafka:kafka-server", version.ref = "kafka" }
+protobufJava = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+protobufProtoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
+
+micrometerCore = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
+micrometerRegistryPrometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+micrometerTracing = { module = "io.micrometer:micrometer-tracing", version.ref = "micrometerTracing" }
+micrometerTracingBridgeBrave = { module = "io.micrometer:micrometer-tracing-bridge-brave", version.ref = "micrometerTracing" }
+micrometerTracingBridgeOtel = { module = "io.micrometer:micrometer-tracing-bridge-otel", version.ref = "micrometerTracing" }
+opentelemetryKafkaClients = { module = "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6", version.ref = "otelKafka" }
+
+braveInstrumentationKafka = { module = "io.zipkin.brave:brave-instrumentation-kafka-clients", version.ref = "zipkinBrave" }
+zeroAllocationHashing = { module = "net.openhft:zero-allocation-hashing", version.ref = "zeroAllocationHashing" }
+
+therapiRuntimeJavadoc = { module = "com.github.therapi:therapi-runtime-javadoc", version.ref = "therapi" }
+therapiRuntimeJavadocScribe = { module = "com.github.therapi:therapi-runtime-javadoc-scribe", version.ref = "therapi" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
+picocliCodegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
+
+jacksonLegacyCore = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jacksonLegacy" }
+jacksonLegacyDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonLegacy" }
+jacksonLegacyDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jacksonLegacy" }
+jacksonLegacyDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jacksonLegacy" }
+jacksonCurrentDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonCurrent" }
+jacksonCurrentDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jacksonCurrent" }
+
+centraldogmaClient = { module = "com.linecorp.centraldogma:centraldogma-client", version.ref = "centraldogma" }
+centraldogmaTestingJunit = { module = "com.linecorp.centraldogma:centraldogma-testing-junit", version.ref = "centraldogma" }
+jsonSchemaGenerator = { module = "com.github.victools:jsonschema-generator", version.ref = "jsonSchemaGenerator" }
+jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
+
+zookeeper = { module = "org.apache.zookeeper:zookeeper", version.ref = "zookeeper" }
+logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackClassic" }
+logbackClassicLegacy = { module = "ch.qos.logback:logback-classic", version.ref = "logbackClassicLegacy" }
+springBoot2Starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springBoot2" }
+springBoot2StarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBoot2" }
+springBoot3Starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springBoot3" }
+springBoot3StarterTest = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBoot3" }
+asciidoctorj = { module = "org.asciidoctor:asciidoctorj", version.ref = "asciidoctorj" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,11 @@
 [versions]
+# Freezing this to 1.x until https://github.com/spring-projects/spring-boot/issues/12649 is resolved.
 slf4j = "1.7.36"
 protobuf = "3.22.3"
 kafka = "3.9.2"
 micrometer = "1.12.4"
 micrometerTracing = "1.2.4"
+# Keep this explicit because the Freefair Lombok plugin may bring an outdated Lombok version.
 lombok = "1.18.30"
 junit = "5.10.0"
 hamcrest = "2.2"
@@ -15,6 +17,7 @@ picocli = "4.2.0"
 jacksonLegacy = "2.13.4"
 jacksonCurrent = "2.17.0"
 logbackClassic = "1.4.11"
+# We keep using 1.3.x for a while until we drop Java 8 support.
 logbackClassicLegacy = "1.3.14"
 centraldogma = "0.64.3"
 jsonSchemaGenerator = "4.38.0"
@@ -22,6 +25,7 @@ jsonSchemaSlf4j = "2.0.12"
 jsonSchemaValidator = "1.5.8"
 zookeeper = "3.5.6"
 otelKafka = "1.33.1-alpha"
+# Remove this when support for Spring Boot 2 is no longer needed.
 springBoot2 = "2.7.18"
 springBoot3 = "3.1.10"
 asciidoctorj = "2.1.0"

--- a/micrometer-tracing/build.gradle
+++ b/micrometer-tracing/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
     api project(":processor")
 
-    api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "io.micrometer:micrometer-tracing:$micrometerTracingVersion"
+    api libs.kafkaClients
+    api libs.micrometerTracing
 
     itImplementation project(":testing")
-    itImplementation "io.micrometer:micrometer-tracing-bridge-brave:$micrometerTracingVersion"
-    itImplementation "io.micrometer:micrometer-tracing-bridge-otel:$micrometerTracingVersion"
-    itImplementation "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:1.33.1-alpha"
+    itImplementation libs.micrometerTracingBridgeBrave
+    itImplementation libs.micrometerTracingBridgeOtel
+    itImplementation libs.opentelemetryKafkaClients
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -3,27 +3,27 @@ dependencies {
     api project(":client")
     api project(":protocol")
 
-    api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "io.micrometer:micrometer-core:$micrometerVersion"
+    api libs.kafkaClients
+    api libs.micrometerCore
 
-    implementation "net.openhft:zero-allocation-hashing:0.16"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation libs.zeroAllocationHashing
+    implementation libs.slf4jApi
 
-    annotationProcessor "com.github.therapi:therapi-runtime-javadoc-scribe:$javaDocExtractorVersion"
-    compileOnly "com.github.therapi:therapi-runtime-javadoc:$javaDocExtractorVersion"
+    annotationProcessor libs.therapiRuntimeJavadocScribe
+    compileOnly libs.therapiRuntimeJavadoc
 
     testImplementation project(":protobuf")
 
-    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
-    testFixturesImplementation "org.slf4j:slf4j-api:$slf4jVersion"
-    testFixturesImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-    testFixturesImplementation "org.apache.kafka:kafka-clients:$kafkaVersion"
-    testFixturesCompileOnly "org.projectlombok:lombok:$lombokVersion"
+    testImplementation libs.hamcrest
+    testFixturesImplementation libs.slf4jApi
+    testFixturesImplementation libs.junitJupiter
+    testFixturesImplementation libs.kafkaClients
+    testFixturesCompileOnly libs.lombok
 
     itImplementation project(":protobuf")
     itImplementation project(":testing")
-    itImplementation "io.micrometer:micrometer-registry-prometheus:$micrometerVersion"
-    itImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+    itImplementation libs.micrometerRegistryPrometheus
+    itImplementation libs.hamcrest
 }
 
 jmh {

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -5,5 +5,5 @@ ext {
 dependencies {
     api project(":common")
 
-    api "com.google.protobuf:protobuf-java:$protobufVersion"
+    api libs.protobufJava
 }

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -3,12 +3,11 @@ plugins {
 }
 
 dependencies {
-    shade "com.google.protobuf:protobuf-java:$protobufVersion"
+    shade libs.protobufJava
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$protobufVersion"
+        artifact = libs.protobufProtoc.get()
     }
 }
-

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -1,13 +1,8 @@
-ext {
-    boot2Version = "2.7.18"
-    boot3Version = "3.1.10"
-}
-
 dependencies {
     api project(":processor")
 
-    api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "org.springframework.boot:spring-boot-starter:$boot2Version"
+    api libs.kafkaClients
+    api libs.springBoot2Starter
 }
 
 // The following integrationTest profiles can be removed when support for boot2 is no longer needed.
@@ -49,11 +44,11 @@ tasks.named('compileIntegrationTestSpringBoot3Java') {
 
 dependencies {
     integrationTestSpringBoot2Implementation project(":processor")
-    integrationTestSpringBoot2Implementation "org.springframework.boot:spring-boot-starter:$boot2Version"
-    integrationTestSpringBoot2Implementation "org.springframework.boot:spring-boot-starter-test:$boot2Version"
-    integrationTestSpringBoot2Implementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+    integrationTestSpringBoot2Implementation libs.springBoot2Starter
+    integrationTestSpringBoot2Implementation libs.springBoot2StarterTest
+    integrationTestSpringBoot2Implementation libs.junitJupiter
     integrationTestSpringBoot3Implementation project(":processor")
-    integrationTestSpringBoot3Implementation "org.springframework.boot:spring-boot-starter:$boot3Version"
-    integrationTestSpringBoot3Implementation "org.springframework.boot:spring-boot-starter-test:$boot3Version"
-    integrationTestSpringBoot3Implementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+    integrationTestSpringBoot3Implementation libs.springBoot3Starter
+    integrationTestSpringBoot3Implementation libs.springBoot3StarterTest
+    integrationTestSpringBoot3Implementation libs.junitJupiter
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -16,30 +16,29 @@
 
 ext {
     noPublish = true
-    jacksonVersion = "2.13.4"
 }
 
 dependencies {
     implementation testFixtures(project(':processor'))
     implementation project(':protobuf')
 
-    implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
-    implementation "org.apache.kafka:kafka_2.12:$kafkaVersion"
-    implementation "org.apache.kafka:kafka-server:$kafkaVersion"
-    implementation "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-    implementation "org.apache.kafka:kafka_2.12:$kafkaVersion:test"
+    implementation libs.kafkaClients
+    implementation libs.kafkaScala
+    implementation libs.kafkaServer
+    implementation("${libs.kafkaClients.get()}:test")
+    implementation("${libs.kafkaScala.get()}:test")
 
-    implementation "com.google.protobuf:protobuf-java:$protobufVersion"
-    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.protobufJava
+    implementation libs.jacksonLegacyCore
+    implementation libs.jacksonLegacyDatabind
 
-    implementation('org.apache.zookeeper:zookeeper:3.5.6') {
+    implementation(libs.zookeeper) {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'log4j', module: 'log4j'
     }
-    implementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-    implementation "org.hamcrest:hamcrest:$hamcrestVersion"
+    implementation libs.junitJupiter
+    implementation libs.hamcrest
 
     // We keep using 1.3.x for a while until we drop Java 8 support.
-    runtimeOnly "ch.qos.logback:logback-classic:1.3.14"
+    runtimeOnly libs.logbackClassicLegacy
 }


### PR DESCRIPTION
Version catalogs is a modern way to declare versions. https://docs.gradle.org/current/userguide/version_catalogs.html

This change migrates the current version declarations to version catalogs. The scope of this change is only aliases, so it does not affect publishing or dependency resolution.

Version catalog can also manage plugin versions, but I did not introduce that yet because the current `build.gradle` style cannot use it. After we finish cleaning up the Gradle setup, we may be able to introduce it.

I confirmed that this does not change version resolution or the published JARs as follows:

1. Locally publish from the master branch and get the POM for the corresponding JAR.
2. Do the same from this PR.
3. Compare them and confirm they are identical.
